### PR TITLE
[#1064] Restore Seed-Birthday Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed
 - Updated user interface of these screens:
-   - New Wallet Recovery Seed screen accessible from onboarding 
-   - Seed Recovery screen accessible from Settings
-   - Restore existing wallet accessible from onboarding
+   - New Wallet Recovery Seed screen (accessible from onboarding) 
+   - Seed Recovery screen (accessible from Settings)
+   - Restore Seed screen for an existing wallet (accessible from onboarding)
+   - Restore Seed Birthday Height screen for an existing wallet (accessible from onboarding)

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/TextField.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/TextField.kt
@@ -11,8 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
 @Suppress("LongParameterList")
 @Composable
@@ -20,6 +22,7 @@ fun FormTextField(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    textStyle: TextStyle = ZcashTheme.extendedTypography.textFieldValue,
     label: @Composable (() -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
@@ -38,6 +41,7 @@ fun FormTextField(
         value = value,
         onValueChange = onValueChange,
         label = label,
+        textStyle = textStyle,
         keyboardOptions = keyboardOptions,
         colors = colors,
         modifier = modifier.then(

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/TextField.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/TextField.kt
@@ -40,11 +40,13 @@ fun FormTextField(
         label = label,
         keyboardOptions = keyboardOptions,
         colors = colors,
-        modifier = if (withBorder) {
-            modifier.border(width = 1.dp, color = MaterialTheme.colorScheme.primary)
-        } else {
-            modifier
-        },
+        modifier = modifier.then(
+            if (withBorder) {
+                modifier.border(width = 1.dp, color = MaterialTheme.colorScheme.primary)
+            } else {
+                Modifier
+            }
+        ),
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
         keyboardActions = keyboardActions,

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/internal/Typography.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/internal/Typography.kt
@@ -124,6 +124,7 @@ data class ExtendedTypography(
     val securityWarningText: TextStyle,
     val textFieldHint: TextStyle,
     val textFieldValue: TextStyle,
+    val textFieldBirthday: TextStyle,
 )
 
 @Suppress("CompositionLocalAllowlist")
@@ -171,5 +172,6 @@ val LocalExtendedTypography = staticCompositionLocalOf {
         textFieldValue = PrimaryTypography.bodyLarge.copy(
             fontSize = 17.sp,
         ),
+        textFieldBirthday = SecondaryTypography.headlineMedium.copy(),
     )
 }

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreViewTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreViewTest.kt
@@ -185,12 +185,16 @@ class RestoreViewTest : UiTestPrerequisites() {
             initialWordsList = SeedPhraseFixture.new().split
         )
 
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_button_skip)).also {
+        composeTestRule.onNodeWithText(
+            text = getStringResource(R.string.restore_birthday_button_restore),
+            ignoreCase = true
+        ).also {
+            it.assertIsEnabled()
             it.performClick()
         }
 
         assertEquals(testSetup.getRestoreHeight(), null)
-        assertEquals(testSetup.getStage(), RestoreStage.Complete)
+        assertEquals(1, testSetup.getOnFinishedCount())
     }
 
     @Test
@@ -201,14 +205,7 @@ class RestoreViewTest : UiTestPrerequisites() {
             initialWordsList = SeedPhraseFixture.new().split
         )
 
-        composeTestRule.onNodeWithText(
-            text = getStringResource(R.string.restore_birthday_button_restore),
-            ignoreCase = true
-        ).also {
-            it.assertIsNotEnabled()
-        }
-
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_hint)).also {
+        composeTestRule.onNodeWithTag(RestoreTag.BIRTHDAY_TEXT_FIELD).also {
             it.performTextInput(ZcashNetwork.Mainnet.saplingActivationHeight.value.toString())
         }
 
@@ -221,34 +218,7 @@ class RestoreViewTest : UiTestPrerequisites() {
         }
 
         assertEquals(testSetup.getRestoreHeight(), ZcashNetwork.Mainnet.saplingActivationHeight)
-        assertEquals(testSetup.getStage(), RestoreStage.Complete)
-    }
-
-    @Test
-    @MediumTest
-    fun height_set_valid_but_skip() {
-        val testSetup = newTestSetup(
-            initialStage = RestoreStage.Birthday,
-            initialWordsList = SeedPhraseFixture.new().split
-        )
-
-        composeTestRule.onNodeWithText(
-            text = getStringResource(R.string.restore_birthday_button_restore),
-            ignoreCase = true
-        ).also {
-            it.assertIsNotEnabled()
-        }
-
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_hint)).also {
-            it.performTextInput(ZcashNetwork.Mainnet.saplingActivationHeight.value.toString())
-        }
-
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_button_skip)).also {
-            it.performClick()
-        }
-
-        assertNull(testSetup.getRestoreHeight())
-        assertEquals(testSetup.getStage(), RestoreStage.Complete)
+        assertEquals(1, testSetup.getOnFinishedCount())
     }
 
     @Test
@@ -263,10 +233,10 @@ class RestoreViewTest : UiTestPrerequisites() {
             text = getStringResource(R.string.restore_birthday_button_restore),
             ignoreCase = true
         ).also {
-            it.assertIsNotEnabled()
+            it.assertIsEnabled()
         }
 
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_hint)).also {
+        composeTestRule.onNodeWithTag(RestoreTag.BIRTHDAY_TEXT_FIELD).also {
             it.performTextInput((ZcashNetwork.Mainnet.saplingActivationHeight.value - 1L).toString())
         }
 
@@ -275,14 +245,11 @@ class RestoreViewTest : UiTestPrerequisites() {
             ignoreCase = true
         ).also {
             it.assertIsNotEnabled()
-        }
-
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_button_skip)).also {
             it.performClick()
         }
 
         assertNull(testSetup.getRestoreHeight())
-        assertEquals(testSetup.getStage(), RestoreStage.Complete)
+        assertEquals(0, testSetup.getOnFinishedCount())
     }
 
     @Test
@@ -293,14 +260,7 @@ class RestoreViewTest : UiTestPrerequisites() {
             initialWordsList = SeedPhraseFixture.new().split
         )
 
-        composeTestRule.onNodeWithText(
-            text = getStringResource(R.string.restore_birthday_button_restore),
-            ignoreCase = true
-        ).also {
-            it.assertIsNotEnabled()
-        }
-
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_hint)).also {
+        composeTestRule.onNodeWithTag(RestoreTag.BIRTHDAY_TEXT_FIELD).also {
             it.performTextInput("1.2")
         }
 
@@ -309,27 +269,27 @@ class RestoreViewTest : UiTestPrerequisites() {
             ignoreCase = true
         ).also {
             it.assertIsNotEnabled()
-        }
-
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_birthday_button_skip)).also {
             it.performClick()
         }
 
         assertNull(testSetup.getRestoreHeight())
-        assertEquals(testSetup.getStage(), RestoreStage.Complete)
+        assertEquals(0, testSetup.getOnFinishedCount())
     }
 
     @Test
     @MediumTest
     fun complete_click_take_to_wallet() {
         val testSetup = newTestSetup(
-            initialStage = RestoreStage.Complete,
+            initialStage = RestoreStage.Birthday,
             initialWordsList = SeedPhraseFixture.new().split
         )
 
         assertEquals(0, testSetup.getOnFinishedCount())
 
-        composeTestRule.onNodeWithText(getStringResource(R.string.restore_button_see_wallet), ignoreCase = true).also {
+        composeTestRule.onNodeWithText(
+            text = getStringResource(R.string.restore_birthday_button_restore),
+            ignoreCase = true
+        ).also {
             it.performClick()
         }
 
@@ -372,26 +332,6 @@ class RestoreViewTest : UiTestPrerequisites() {
         composeTestRule.mainClock.autoAdvance = false
 
         assertEquals(testSetup.getStage(), RestoreStage.Seed)
-        assertEquals(0, testSetup.getOnBackCount())
-    }
-
-    @Test
-    @MediumTest
-    fun back_from_complete() {
-        val testSetup = newTestSetup(
-            initialStage = RestoreStage.Complete,
-            initialWordsList = SeedPhraseFixture.new().split
-        )
-
-        assertEquals(0, testSetup.getOnBackCount())
-
-        composeTestRule.onNodeWithContentDescription(
-            getStringResource(R.string.restore_back_content_description)
-        ).also {
-            it.performClick()
-        }
-
-        assertEquals(testSetup.getStage(), RestoreStage.Birthday)
         assertEquals(0, testSetup.getOnBackCount())
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/model/RestoreStage.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/model/RestoreStage.kt
@@ -4,8 +4,7 @@ enum class RestoreStage {
     // Note: the ordinal order is used to manage progression through each stage
     // so be careful if reordering these
     Seed,
-    Birthday,
-    Complete;
+    Birthday;
 
     /**
      * @see getPrevious
@@ -15,15 +14,15 @@ enum class RestoreStage {
     /**
      * @see getNext
      */
-    fun hasNext() = ordinal < values().size - 1
+    fun hasNext() = ordinal < entries.size - 1
 
     /**
      * @return Previous item in ordinal order.  Returns the first item when it cannot go further back.
      */
-    fun getPrevious() = values()[maxOf(0, ordinal - 1)]
+    fun getPrevious() = entries[maxOf(0, ordinal - 1)]
 
     /**
      * @return Last item in ordinal order.  Returns the last item when it cannot go further forward.
      */
-    fun getNext() = values()[minOf(values().size - 1, ordinal + 1)]
+    fun getNext() = entries[minOf(entries.size - 1, ordinal + 1)]
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -71,11 +72,9 @@ import co.electriccoin.zcash.ui.design.component.Body
 import co.electriccoin.zcash.ui.design.component.ChipOnSurface
 import co.electriccoin.zcash.ui.design.component.FormTextField
 import co.electriccoin.zcash.ui.design.component.GradientSurface
-import co.electriccoin.zcash.ui.design.component.Header
 import co.electriccoin.zcash.ui.design.component.PrimaryButton
 import co.electriccoin.zcash.ui.design.component.Reference
 import co.electriccoin.zcash.ui.design.component.SmallTopAppBar
-import co.electriccoin.zcash.ui.design.component.TertiaryButton
 import co.electriccoin.zcash.ui.design.component.TopScreenLogoTitle
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.screen.restore.RestoreTag
@@ -88,9 +87,9 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentHashSetOf
 import kotlinx.coroutines.launch
 
-@Preview("Restore Wallet")
+@Preview("Restore Seed")
 @Composable
-private fun PreviewRestore() {
+private fun PreviewRestoreSeed() {
     ZcashTheme(forceDarkMode = false) {
         GradientSurface {
             RestoreWallet(
@@ -119,12 +118,31 @@ private fun PreviewRestore() {
     }
 }
 
-@Preview("Restore Complete")
+@Preview("Restore Seed Birthday")
 @Composable
-private fun PreviewRestoreComplete() {
+private fun PreviewRestoreBirthday() {
     ZcashTheme(forceDarkMode = false) {
-        RestoreComplete(
-            onComplete = {}
+        RestoreWallet(
+            ZcashNetwork.Mainnet,
+            restoreState = RestoreState(RestoreStage.Birthday),
+            completeWordList = persistentHashSetOf(
+                "abandon",
+                "ability",
+                "able",
+                "about",
+                "above",
+                "absent",
+                "absorb",
+                "abstract",
+                "rib",
+                "ribbon"
+            ),
+            userWordList = WordList(listOf("abandon", "absorb")),
+            restoreHeight = null,
+            setRestoreHeight = {},
+            onBack = {},
+            paste = { "" },
+            onFinished = {}
         )
     }
 }
@@ -135,7 +153,6 @@ private fun PreviewRestoreComplete() {
  * @param restoreHeight A null height indicates no user input.
  */
 @Suppress("LongParameterList", "LongMethod")
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun RestoreWallet(
     zcashNetwork: ZcashNetwork,
@@ -167,20 +184,28 @@ fun RestoreWallet(
     Scaffold(
         modifier = Modifier.navigationBarsPadding(),
         topBar = {
-            RestoreTopAppBar(
-                onBack = {
-                    if (currentStage.hasPrevious()) {
-                        restoreState.goPrevious()
-                    } else {
-                        onBack()
-                    }
-                },
-                isShowClear = currentStage == RestoreStage.Seed,
-                onClear = {
-                    userWordList.set(emptyList())
-                    text = ""
+            when (currentStage) {
+                RestoreStage.Seed -> {
+                    RestoreSeedTopAppBar(
+                        onBack = onBack,
+                        onClear = {
+                            userWordList.set(emptyList())
+                            text = ""
+                        }
+                    )
                 }
-            )
+                RestoreStage.Birthday -> {
+                    RestoreSeedBirthdayTopAppBar(
+                        onBack = {
+                            if (currentStage.hasPrevious()) {
+                                restoreState.goPrevious()
+                            } else {
+                                onBack()
+                            }
+                        }
+                    )
+                }
+            }
         },
         bottomBar = {
             when (currentStage) {
@@ -198,10 +223,7 @@ fun RestoreWallet(
                     )
                 }
                 RestoreStage.Birthday -> {
-                    // No content
-                }
-                RestoreStage.Complete -> {
-                    // No content
+                    // No content. The action button is part of scrollable content.
                 }
             }
         },
@@ -231,52 +253,18 @@ fun RestoreWallet(
                     )
                 }
                 RestoreStage.Birthday -> {
-                    RestoreBirthday(
+                    RestoreBirthdayMainContent(
                         zcashNetwork = zcashNetwork,
                         initialRestoreHeight = restoreHeight,
                         setRestoreHeight = setRestoreHeight,
-                        onNext = { restoreState.goNext() },
+                        onDone = onFinished,
                         modifier = commonModifier
                             .imePadding()
                             .navigationBarsPadding()
-                            .animateContentSize()
-                    )
-                }
-                RestoreStage.Complete -> {
-                    // In some cases we need to hide the software keyboard manually, as it stays shown after
-                    // input on prior screens
-                    LocalSoftwareKeyboardController.current?.hide()
-
-                    RestoreComplete(
-                        onComplete = onFinished,
-                        modifier = commonModifier
                     )
                 }
             }
         }
-    )
-}
-
-@Composable
-private fun RestoreTopAppBar(
-    onBack: () -> Unit,
-    onClear: () -> Unit,
-    isShowClear: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    SmallTopAppBar(
-        backText = stringResource(id = R.string.restore_back).uppercase(),
-        backContentDescriptionText = stringResource(R.string.restore_back_content_description),
-        onBack = onBack,
-        regularActions = if (isShowClear) { {
-            ClearSeedMenuItem(
-                onSeedClear = onClear
-            )
-        }
-        } else {
-            null
-        },
-        modifier = modifier,
     )
 }
 
@@ -292,6 +280,38 @@ private fun ClearSeedMenuItem(
         modifier = modifier.then(
             Modifier.padding(all = ZcashTheme.dimens.spacingDefault)
         )
+    )
+}
+
+@Composable
+private fun RestoreSeedTopAppBar(
+    onBack: () -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SmallTopAppBar(
+        backText = stringResource(id = R.string.restore_back).uppercase(),
+        backContentDescriptionText = stringResource(R.string.restore_back_content_description),
+        onBack = onBack,
+        regularActions = {
+            ClearSeedMenuItem(
+                onSeedClear = onClear
+            )
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun RestoreSeedBirthdayTopAppBar(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SmallTopAppBar(
+        backText = stringResource(id = R.string.restore_back).uppercase(),
+        backContentDescriptionText = stringResource(R.string.restore_back_content_description),
+        onBack = onBack,
+        modifier = modifier
     )
 }
 
@@ -388,7 +408,6 @@ private fun RestoreSeedMainContent(
     DisposableEffect(parseResult) {
         // Causes the TextFiled to refocus
         if (!isSeedValid) {
-            Twig.error { "NUT" }
             focusRequester.requestFocus()
         }
         // Causes scroll to the TextField after the first type action
@@ -638,13 +657,16 @@ private fun Warn(
 
 @Composable
 @Suppress("LongMethod")
-private fun RestoreBirthday(
+private fun RestoreBirthdayMainContent(
     zcashNetwork: ZcashNetwork,
     initialRestoreHeight: BlockHeight?,
     setRestoreHeight: (BlockHeight?) -> Unit,
-    onNext: () -> Unit,
+    onDone: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val scrollState = rememberScrollState()
+    val focusRequester = remember { FocusRequester() }
+
     val (height, setHeight) = rememberSaveable {
         mutableStateOf(initialRestoreHeight?.value?.toString() ?: "")
     }
@@ -652,15 +674,16 @@ private fun RestoreBirthday(
     Column(
         Modifier
             .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .then(modifier),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Header(stringResource(R.string.restore_birthday_header))
+        TopScreenLogoTitle(
+            title = stringResource(R.string.restore_birthday_header),
+            logoContentDescription = stringResource(R.string.zcash_logo_content_description),
+        )
 
-        Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
-
-        Body(stringResource(R.string.restore_birthday_body))
+        Body(stringResource(R.string.restore_birthday_sub_header))
 
         Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
 
@@ -670,11 +693,11 @@ private fun RestoreBirthday(
                 val filteredHeightString = heightString.filter { it.isDigit() }
                 setHeight(filteredHeightString)
             },
-            Modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .padding(ZcashTheme.dimens.spacingTiny)
+                .focusRequester(focusRequester)
                 .testTag(RestoreTag.BIRTHDAY_TEXT_FIELD),
-            label = { Text(stringResource(id = R.string.restore_birthday_hint)) },
             keyboardOptions = KeyboardOptions(
                 KeyboardCapitalization.None,
                 autoCorrect = false,
@@ -682,7 +705,7 @@ private fun RestoreBirthday(
                 keyboardType = KeyboardType.Number
             ),
             keyboardActions = KeyboardActions(onAny = {}),
-            shape = RectangleShape,
+            withBorder = false,
         )
 
         Spacer(
@@ -693,65 +716,33 @@ private fun RestoreBirthday(
 
         Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
 
-        val isBirthdayValid = height.toLongOrNull()?.let {
+        // Empty birthday value is a valid birthday height too, thus run validation only in case of non-empty heights.
+        val isBirthdayValid = height.isEmpty() || height.toLongOrNull()?.let {
             it >= zcashNetwork.saplingActivationHeight.value
         } ?: false
 
+        val isEmptyBirthday = height.isEmpty()
+
         PrimaryButton(
             onClick = {
-                setRestoreHeight(BlockHeight.new(zcashNetwork, height.toLong()))
-                onNext()
+                if (isEmptyBirthday) {
+                    setRestoreHeight(null)
+                } else if (isBirthdayValid) {
+                    setRestoreHeight(BlockHeight.new(zcashNetwork, height.toLong()))
+                } else {
+                    error("The restore button should not expect click events")
+                }
+                onDone()
             },
             text = stringResource(R.string.restore_birthday_button_restore),
-            enabled = isBirthdayValid,
-            outerPaddingValues = PaddingValues(top = ZcashTheme.dimens.spacingSmall)
+            enabled = isBirthdayValid
         )
 
-        TertiaryButton(
-            onClick = {
-                setRestoreHeight(null)
-                onNext()
-            },
-            text = stringResource(R.string.restore_birthday_button_skip),
-            outerPaddingValues = PaddingValues(top = ZcashTheme.dimens.spacingDefault)
-        )
-
-        Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
+        Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingHuge))
     }
-}
 
-@Composable
-private fun RestoreComplete(
-    onComplete: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        Modifier
-            .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
-            .then(modifier),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Header(stringResource(R.string.restore_complete_header))
-
-        Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
-
-        Body(stringResource(R.string.restore_complete_info))
-
-        Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
-
-        Spacer(
-            modifier = Modifier
-                .fillMaxHeight()
-                .weight(MINIMAL_WEIGHT)
-        )
-
-        PrimaryButton(
-            onClick = onComplete,
-            text = stringResource(R.string.restore_button_see_wallet),
-            outerPaddingValues = PaddingValues(top = ZcashTheme.dimens.spacingSmall)
-        )
-
-        Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
+    LaunchedEffect(Unit) {
+        // Causes the TextFiled to focus on the first screen visit
+        focusRequester.requestFocus()
     }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
@@ -337,8 +337,6 @@ private fun RestoreSeedMainContent(
     val focusRequester = remember { FocusRequester() }
     val textFieldScrollToHeight = rememberSaveable { mutableIntStateOf(0) }
 
-    Twig.error { "TEST: $parseResult, $text" }
-
     if (parseResult is ParseResult.Add) {
         setText("")
         userWordList.append(parseResult.words)
@@ -698,6 +696,7 @@ private fun RestoreBirthdayMainContent(
                 .padding(ZcashTheme.dimens.spacingTiny)
                 .focusRequester(focusRequester)
                 .testTag(RestoreTag.BIRTHDAY_TEXT_FIELD),
+            textStyle = ZcashTheme.extendedTypography.textFieldBirthday,
             keyboardOptions = KeyboardOptions(
                 KeyboardCapitalization.None,
                 autoCorrect = false,

--- a/ui-lib/src/main/res/ui/restore/values/strings.xml
+++ b/ui-lib/src/main/res/ui/restore/values/strings.xml
@@ -11,14 +11,8 @@
     <string name="restore_seed_warning_suggestions">This word is not in the seed phrase dictionary.  Please select the correct one from the suggestions.</string>
     <string name="restore_seed_warning_no_suggestions">This word is not in the seed phrase dictionary.</string>
 
-    <string name="restore_birthday_header">Do you know the wallet’s birthday?</string>
-    <string name="restore_birthday_body">This will allow a faster sync. If you don’t know the wallet’s birthday, don’t worry.</string>
-    <string name="restore_birthday_hint">Birthday height</string>
-    <string name="restore_birthday_button_restore">Restore with this birthday</string>
-    <string name="restore_birthday_button_skip">I don’t know the birthday</string>
-
-    <string name="restore_complete_header">Seed phrase imported!</string>
-    <string name="restore_complete_info">We will now scan the blockchain to find your transactions and balance.</string>
-    <string name="restore_button_see_wallet">Take me to my wallet</string>
+    <string name="restore_birthday_header">Wallet birthday height</string>
+    <string name="restore_birthday_sub_header">(optional)</string>
+    <string name="restore_birthday_button_restore">Restore</string>
 
 </resources>

--- a/ui-screenshot-test/src/main/java/co/electroniccoin/zcash/ui/screenshot/ScreenshotTest.kt
+++ b/ui-screenshot-test/src/main/java/co/electroniccoin/zcash/ui/screenshot/ScreenshotTest.kt
@@ -141,11 +141,6 @@ class ScreenshotTest : UiTestPrerequisites() {
         }
     }
 
-    // TODO [#859]: Screenshot tests fail on Firebase Test Lab
-    // TODO [#859]: https://github.com/Electric-Coin-Company/zashi-android/issues/859
-    // Some of the restore screenshots broke with the Compose 1.4 update and we don't yet know why.
-    private val isRestoreScreenshotsEnabled = false
-
     @Suppress("LongMethod", "FunctionNaming", "CyclomaticComplexMethod")
     private fun take_screenshots_for_restore_wallet(resContext: Context, tag: String) {
         // TODO [#286]: Screenshot tests fail on Firebase Test Lab
@@ -207,39 +202,31 @@ class ScreenshotTest : UiTestPrerequisites() {
                 SeedPhrase.SEED_PHRASE_SIZE
         }
 
-        if (isRestoreScreenshotsEnabled.not()) {
-            return
-        }
-
-        composeTestRule.onNodeWithText(resContext.getString(R.string.restore_seed_button_next)).also {
-            it.performScrollTo()
-
+        composeTestRule.onNodeWithText(
+            text = resContext.getString(R.string.restore_seed_button_next),
+            ignoreCase = true
+        ).also {
             // Even with waiting for the word list in the view model, there's some latency before the button is enabled
             composeTestRule.waitUntil(5.seconds.inWholeMilliseconds) {
                 runCatching { it.assertIsEnabled() }.isSuccess
             }
-
-            it.performClick()
-        }
-
-        composeTestRule.onNodeWithText(resContext.getString(R.string.restore_birthday_button_restore)).also {
-            composeTestRule.waitUntil(5.seconds.inWholeMilliseconds) {
-                kotlin.runCatching { it.assertExists() }.isSuccess
-            }
-        }
-
-        takeScreenshot(tag, "Import 3")
-
-        composeTestRule.onNodeWithText(resContext.getString(R.string.restore_birthday_button_skip)).also {
             it.performScrollTo()
             it.performClick()
         }
 
-        composeTestRule.onNodeWithText(resContext.getString(R.string.restore_complete_header)).also {
+        composeTestRule.onNodeWithText(resContext.getString(R.string.restore_birthday_header)).also {
             it.assertExists()
         }
 
-        takeScreenshot(tag, "Import 4")
+        takeScreenshot(tag, "Import 3")
+
+        composeTestRule.onNodeWithText(
+            text = resContext.getString(R.string.restore_birthday_button_restore),
+            ignoreCase = true
+        ).also {
+            it.performScrollTo()
+            it.performClick()
+        }
     }
 
     @Test


### PR DESCRIPTION
- Reworked Restore Seed-Birthday height screen
- Contains UI, screen logic and tests
- Changelog update
- Closes #1064

### Before:
<img src="https://github.com/Electric-Coin-Company/zashi-android/assets/9017390/a943362d-92a7-4afe-aaed-9fef1c47d96e" width="300" />

### After:
<img src="https://github.com/Electric-Coin-Company/zashi-android/assets/9017390/32aaf63d-494b-4198-8c94-93ff67e12f97" width="300" />

<img src="https://github.com/Electric-Coin-Company/zashi-android/assets/9017390/37c65b3c-426c-4c68-8931-4c26e246b453" width="300" />

<img src="https://github.com/Electric-Coin-Company/zashi-android/assets/9017390/36245a81-98b6-4d48-8716-586b45788b97" width="300" />

### After video:
https://github.com/Electric-Coin-Company/zashi-android/assets/9017390/28508c36-3f09-4023-a8bb-66e24f275e0a

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [x] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._