### PR TITLE
[#1201] Enhance SendStage.SendFailure with error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ directly impact users rather than highlighting other key architectural updates.*
 - The current balance UI on top of the Account screen has been reworked. It now displays the currently available 
   balance as well.
 - The same current balance UI was also incorporated into the Send Form screen. 
+- The Send Error screen now contains a simple text with the reason for failure. The Send screen UI refactoring is 
+  still in progress.
 
 ## [0.2.0 (530)] - 2024-01-16
 

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/SendViewTestSetup.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/SendViewTestSetup.kt
@@ -71,7 +71,7 @@ class SendViewTestSetup(
     @Suppress("TestFunctionName")
     fun DefaultContent() {
         val (sendStage, setSendStage) =
-            rememberSaveable { mutableStateOf(initialState) }
+            rememberSaveable(stateSaver = SendStage.Saver) { mutableStateOf(initialState) }
 
         lastSendStage = sendStage
 
@@ -81,7 +81,7 @@ class SendViewTestSetup(
                 SendStage.Form -> {}
                 SendStage.Confirmation -> setSendStage(SendStage.Form)
                 SendStage.Sending -> {}
-                SendStage.SendFailure -> setSendStage(SendStage.Form)
+                is SendStage.SendFailure -> setSendStage(SendStage.Form)
                 SendStage.SendSuccessful -> {}
             }
         }

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/view/SendViewAndroidTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/view/SendViewAndroidTest.kt
@@ -83,7 +83,7 @@ class SendViewAndroidTest : UiTestPrerequisites() {
     fun back_on_send_failure_with_system_navigation() {
         val testSetup =
             newTestSetup(
-                SendStage.SendFailure,
+                SendStage.SendFailure("Test error message"),
                 runBlocking { ZecSendFixture.new() }
             )
 

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/view/SendViewTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/view/SendViewTest.kt
@@ -378,7 +378,7 @@ class SendViewTest : UiTestPrerequisites() {
     fun back_on_send_failure() {
         val testSetup =
             newTestSetup(
-                SendStage.SendFailure,
+                SendStage.SendFailure("Test error message"),
                 runBlocking { ZecSendFixture.new() }
             )
 
@@ -396,7 +396,7 @@ class SendViewTest : UiTestPrerequisites() {
     fun close_on_send_failure() {
         val testSetup =
             newTestSetup(
-                SendStage.SendFailure,
+                SendStage.SendFailure("Test error message"),
                 runBlocking { ZecSendFixture.new() }
             )
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
@@ -80,7 +80,8 @@ internal fun WrapSend(
     // 1. Use a different UI flow entirely
     // 2. Show a pre-filled Send form
     // 3. Go directly to the Confirmation screen
-    val (sendStage, setSendStage) = rememberSaveable { mutableStateOf(SendStage.Form) }
+    val (sendStage, setSendStage) =
+        rememberSaveable(stateSaver = SendStage.Saver) { mutableStateOf(SendStage.Form) }
 
     val (zecSend, setZecSend) = rememberSaveable(stateSaver = ZecSend.Saver) { mutableStateOf(null) }
 
@@ -89,7 +90,7 @@ internal fun WrapSend(
             SendStage.Form -> goBack()
             SendStage.Confirmation -> setSendStage(SendStage.Form)
             SendStage.Sending -> { /* no action - wait until the sending is done */ }
-            SendStage.SendFailure -> setSendStage(SendStage.Form)
+            is SendStage.SendFailure -> setSendStage(SendStage.Form)
             SendStage.SendSuccessful -> {
                 setZecSend(null)
                 setSendStage(SendStage.Form)
@@ -127,7 +128,7 @@ internal fun WrapSend(
                         }
                         .onFailure {
                             Twig.debug { "Transaction submission failed with: $it." }
-                            setSendStage(SendStage.SendFailure)
+                            setSendStage(SendStage.SendFailure(it.localizedMessage ?: ""))
                         }
                 }
             },

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/model/SendStage.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/model/SendStage.kt
@@ -1,9 +1,64 @@
 package co.electriccoin.zcash.ui.screen.send.model
 
-enum class SendStage {
-    Form,
-    Confirmation,
-    Sending,
-    SendFailure,
-    SendSuccessful
+import androidx.compose.runtime.saveable.mapSaver
+
+sealed class SendStage {
+    data object Form : SendStage()
+
+    data object Confirmation : SendStage()
+
+    data object Sending : SendStage()
+
+    data class SendFailure(val error: String) : SendStage()
+
+    data object SendSuccessful : SendStage()
+
+    companion object {
+        private const val TYPE_FORM = "form" // $NON-NLS
+        private const val TYPE_CONFIRMATION = "confirmation" // $NON-NLS
+        private const val TYPE_SENDING = "sending" // $NON-NLS
+        private const val TYPE_FAILURE = "failure" // $NON-NLS
+        private const val TYPE_SUCCESSFUL = "successful" // $NON-NLS
+        private const val KEY_TYPE = "type" // $NON-NLS
+        private const val KEY_ERROR = "error" // $NON-NLS
+
+        internal val Saver
+            get() =
+                run {
+                    mapSaver<SendStage>(
+                        save = { it.toSaverMap() },
+                        restore = {
+                            if (it.isEmpty()) {
+                                null
+                            } else {
+                                val sendStageString = (it[KEY_TYPE] as String)
+                                when (sendStageString) {
+                                    TYPE_FORM -> Form
+                                    TYPE_CONFIRMATION -> Confirmation
+                                    TYPE_SENDING -> Sending
+                                    TYPE_FAILURE -> SendFailure((it[KEY_ERROR] as String))
+                                    TYPE_SUCCESSFUL -> SendSuccessful
+                                    else -> null
+                                }
+                            }
+                        }
+                    )
+                }
+
+        private fun SendStage.toSaverMap(): HashMap<String, String> {
+            val saverMap = HashMap<String, String>()
+            when (this) {
+                Form -> saverMap[KEY_TYPE] = TYPE_FORM
+                Confirmation -> saverMap[KEY_TYPE] = TYPE_CONFIRMATION
+                is SendFailure -> {
+                    saverMap[KEY_TYPE] = TYPE_FAILURE
+                    saverMap[KEY_ERROR] = this.error
+                }
+                SendSuccessful -> saverMap[KEY_TYPE] = TYPE_SUCCESSFUL
+                Sending -> saverMap[KEY_TYPE] = TYPE_SENDING
+            }
+
+            return saverMap
+        }
+    }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
@@ -130,7 +130,8 @@ private fun PreviewSendFailure() {
                         amount = ZatoshiFixture.new(),
                         memo = MemoFixture.new()
                     ),
-                onDone = {}
+                onDone = {},
+                reason = "Insufficient balance"
             )
         }
     }
@@ -262,7 +263,6 @@ private fun SendMainContent(
                 hasCameraFeature = hasCameraFeature,
                 modifier = modifier
             )
-            // TestSend(modifier)
         }
         (sendStage == SendStage.Confirmation) -> {
             SendConfirmation(
@@ -287,9 +287,10 @@ private fun SendMainContent(
                 modifier = modifier,
             )
         }
-        (sendStage == SendStage.SendFailure) -> {
+        (sendStage is SendStage.SendFailure) -> {
             SendFailure(
                 zecSend = zecSend,
+                reason = sendStage.error,
                 onDone = onBack,
                 modifier = modifier,
             )
@@ -681,7 +682,8 @@ private fun SendSuccessful(
 private fun SendFailure(
     zecSend: ZecSend,
     onDone: () -> Unit,
-    modifier: Modifier = Modifier
+    reason: String,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
@@ -706,6 +708,20 @@ private fun SendFailure(
                 zecSend.amount.toZecString(),
                 zecSend.destination.abbreviated(),
                 zecSend.memo.valueOrEmptyChar()
+            )
+        )
+
+        Spacer(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(dimens.spacingDefault)
+        )
+
+        Body(
+            stringResource(
+                R.string.send_failure_reason,
+                reason,
             )
         )
 

--- a/ui-lib/src/main/res/ui/send/values/strings.xml
+++ b/ui-lib/src/main/res/ui/send/values/strings.xml
@@ -18,7 +18,10 @@
     <string name="send_in_progress_wait">Please wait</string>
 
     <string name="send_failure_title">Sending failure</string>
-    <string name="send_failure_amount_address_memo" formatted="true">Sending failed for: <xliff:g id="amount" example="12.345">%1$s</xliff:g> ZEC to <xliff:g id="address" example="zs1g7cqw … mvyzgm">%2$s</xliff:g> with a memo: <xliff:g id="memo" example="for Veronika">%3$s</xliff:g></string>
+    <string name="send_failure_amount_address_memo" formatted="true">Sending failed for:\n<xliff:g id="amount"
+        example="12.345">%1$s</xliff:g> ZEC to <xliff:g id="address" example="zs1g7cqw … mvyzgm">%2$s</xliff:g> with a memo: <xliff:g id="memo" example="for Veronika">%3$s</xliff:g></string>
+    <string name="send_failure_reason" formatted="true">Sending failed with:\n<xliff:g
+        id="reason" example="Insufficient balance">%1$s</xliff:g></string>
     <string name="send_failure_button">Back</string>
 
     <string name="send_successful_title">Sending successful</string>


### PR DESCRIPTION
- Closes #1201
- The changes also contain custom saver for SendStage
- The error is printed on the SendFailure screen as a simple text for now
- Changelog updated

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._