### PR TITLE
[#1151] Background syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+### Added
+- A periodic background block synchronization has been added. When the device is connected to the internet using an 
+ unmetered connection and is plugged into the power, the background task will start to synchronize blocks randomly 
+  between 3 and 4 a.m.
+
 ## [0.2.0 (554)] - 2024-02-13
 
 ### Changed

--- a/app/proguard-project.txt
+++ b/app/proguard-project.txt
@@ -24,3 +24,4 @@
 # in the projects, so the classes aren't present.  These warnings are safe to suppress.
 -dontwarn kotlinx.serialization.KSerializer
 -dontwarn kotlinx.serialization.Serializable
+-dontwarn kotlinx.serialization.internal.AbstractPolymorphicSerializer

--- a/ui-lib/src/main/java/co/electriccoin/zcash/work/SyncWorker.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/work/SyncWorker.kt
@@ -84,6 +84,8 @@ class SyncWorker(context: Context, workerParameters: WorkerParameters) : Corouti
                     .setRequiresCharging(true)
                     .build()
 
+            // TODO [#1258]: Consider using flexInterval in BG sync trigger planning
+            // TODO [#1258]: https://github.com/Electric-Coin-Company/zashi-android/issues/1258
             return PeriodicWorkRequestBuilder<SyncWorker>(SYNC_PERIOD.toJavaDuration())
                 .setConstraints(constraints)
                 .setInitialDelay(targetTimeDiff.toJavaDuration())

--- a/ui-lib/src/main/java/co/electriccoin/zcash/work/SyncWorker.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/work/SyncWorker.kt
@@ -12,55 +12,115 @@ import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletCoordinator
 import cash.z.ecc.android.sdk.model.PercentDecimal
 import co.electriccoin.zcash.global.getInstance
+import co.electriccoin.zcash.spackle.Twig
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.takeWhile
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.until
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 import kotlin.time.toJavaDuration
+
+// TODO [#1249]: Add documentation and tests on background syncing
+// TODO [#1249]: https://github.com/Electric-Coin-Company/zashi-android/issues/1249
 
 @Keep
 class SyncWorker(context: Context, workerParameters: WorkerParameters) : CoroutineWorker(context, workerParameters) {
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun doWork(): Result {
-        // Enhancements to this implementation would be:
-        // - Quit early if the synchronizer is null after a timeout period
-        // - Return better status information
+        Twig.debug { "BG Sync: starting..." }
 
         WalletCoordinator.getInstance(applicationContext).synchronizer
             .flatMapLatest {
+                Twig.debug { "BG Sync: synchronizer: $it" }
+
                 it?.status?.combine(it.progress) { status, progress ->
-                    StatusAndProgress(status, progress)
+                    StatusAndProgress(status, progress).also {
+                        Twig.debug { "BG Sync: result: $it" }
+                    }
                 } ?: emptyFlow()
             }
             .takeWhile {
-                it.status != Synchronizer.Status.DISCONNECTED && it.progress.isLessThanHundredPercent()
+                it.status != Synchronizer.Status.DISCONNECTED &&
+                    it.status != Synchronizer.Status.SYNCED
             }
             .collect()
+
+        Twig.debug { "BG Sync: terminating..." }
 
         return Result.success()
     }
 
     companion object {
-        /*
-         * There may be better periods; we have not optimized for this yet.
-         */
-        private val DEFAULT_SYNC_PERIOD = 24.hours
+        private val SYNC_PERIOD = 24.hours
+        private val SYNC_DAY_SHIFT = 1.days // Move to tomorrow
+        private val SYNC_START_TIME_HOURS = 3.hours // Start around 3 a.m. at night
+        private val SYNC_START_TIME_MINUTES = 60.minutes // Randomize with minutes until 4 a.m.
 
         fun newWorkRequest(): PeriodicWorkRequest {
+            val targetTimeDiff = calculateTargetTimeDifference()
+
+            Twig.debug { "BG Sync: necessary trigger delay time: $targetTimeDiff" }
+
             val constraints =
                 Constraints.Builder()
                     .setRequiresStorageNotLow(true)
-                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiredNetworkType(NetworkType.UNMETERED)
+                    .setRequiresCharging(true)
                     .build()
 
-            return PeriodicWorkRequestBuilder<SyncWorker>(DEFAULT_SYNC_PERIOD.toJavaDuration())
+            return PeriodicWorkRequestBuilder<SyncWorker>(SYNC_PERIOD.toJavaDuration())
                 .setConstraints(constraints)
+                .setInitialDelay(targetTimeDiff.toJavaDuration())
                 .build()
+        }
+
+        private fun calculateTargetTimeDifference(): Duration {
+            val currentTimeZone: TimeZone = TimeZone.currentSystemDefault()
+
+            val now: Instant = Clock.System.now()
+
+            val targetTime =
+                now
+                    .plus(SYNC_DAY_SHIFT)
+                    .toLocalDateTime(currentTimeZone)
+                    .date
+                    .atTime(
+                        hour = SYNC_START_TIME_HOURS.inWholeHours.toInt(),
+                        // Even though the WorkManager will trigger the work approximately at the set time, it's
+                        // better to randomize time in 3-4 a.m. This generates a number between 0 (inclusive) and 60
+                        // (exclusive)
+                        minute = Random.nextInt(0, SYNC_START_TIME_MINUTES.inWholeMinutes.toInt())
+                    )
+
+            Twig.debug { "BG Sync: calculated target time: ${targetTime.time}" }
+
+            return now.until(
+                other = targetTime.toInstant(currentTimeZone),
+                unit = DateTimeUnit.MILLISECOND,
+                timeZone = currentTimeZone
+            ).toDuration(DurationUnit.MILLISECONDS)
         }
     }
 }
 
-private data class StatusAndProgress(val status: Synchronizer.Status, val progress: PercentDecimal)
+// Enhancement to this implementation would be returning a better status information
+private data class StatusAndProgress(
+    val status: Synchronizer.Status,
+    val progress: PercentDecimal
+)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/work/WorkIds.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/work/WorkIds.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.work
 import android.content.Context
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
+import co.electriccoin.zcash.spackle.Twig
 
 object WorkIds {
     const val WORK_ID_BACKGROUND_SYNC = "co.electriccoin.zcash.background_sync"
@@ -10,11 +11,23 @@ object WorkIds {
     fun enableBackgroundSynchronization(context: Context) {
         val workManager = WorkManager.getInstance(context)
 
+        Twig.debug {
+            "BG Sync: existing work details:" +
+                " ${workManager.getWorkInfosForUniqueWork(WORK_ID_BACKGROUND_SYNC).get()}"
+        }
+
+        // Note: Re-enqueuing existing work is okay. Another approach would be to validate the existing work and
+        // enqueue it if it is not planned yet or not in a valid state
         workManager.enqueueUniquePeriodicWork(
             WORK_ID_BACKGROUND_SYNC,
             ExistingPeriodicWorkPolicy.KEEP,
             SyncWorker.newWorkRequest()
         )
+
+        Twig.debug {
+            "BG Sync: newly enqueued work details:" +
+                " ${workManager.getWorkInfosForUniqueWork(WORK_ID_BACKGROUND_SYNC).get()}"
+        }
     }
 
     fun disableBackgroundSynchronization(context: Context) {


### PR DESCRIPTION
- A periodic background block synchronization has been added. When the device is connected to the internet using an unmetered connection and is plugged into the power, the background task will start to synchronize blocks randomly between 3 and 4 a.m.
- The background worker was in place but not fully working, plus was set to trigger randomly in 24 hours
- Changelog update
- Closes #1151
- Closes #634
- Its follow-up #1249

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._