### PR TITLE
[#1190] Add native debug symbols to app build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ android {
         releaseKeystorePassword,
         releaseKeyAlias,
         releaseKeyAliasPassword
-    ).all { !it.isNullOrBlank() }
+    ).all { it.isNotBlank() }
 
     signingConfigs {
         if (isReleaseSigningConfigured) {
@@ -120,6 +120,8 @@ android {
         getByName("release").apply {
             isMinifyEnabled = project.property("IS_MINIFY_ENABLED").toString().toBoolean()
             isShrinkResources = project.property("IS_MINIFY_ENABLED").toString().toBoolean()
+            ndk.debugSymbolLevel = project.property("NDK_DEBUG_SYMBOL_LEVEL").toString()
+
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-project.txt"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ tasks {
             "ZCASH_EMULATOR_WTF_API_KEY" to "",
 
             "IS_MINIFY_ENABLED" to "true",
+            "NDK_DEBUG_SYMBOL_LEVEL" to "symbol_table",
 
             "ZCASH_RELEASE_APP_NAME" to "Zashi",
             "ZCASH_RELEASE_PACKAGE_NAME" to "co.electriccoin.zcash",

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,14 @@ ZCASH_FIREBASE_TEST_LAB_PROJECT=
 # Optionally disable minification
 IS_MINIFY_ENABLED=true
 
+# Optionally change the NDK debug symbols generation level
+# Supported values are:
+# - none (default, no native debug metadata will be packaged)
+# - symbol_table (only the symbol tables will be packaged)
+# - full (the debug info and symbol tables will be packaged)
+# The result will be placed in app/build/outputs/native-debug-symbols/variant-name/native-debug-symbols.zip
+NDK_DEBUG_SYMBOL_LEVEL=symbol_table
+
 # If ZCASH_GOOGLE_PLAY_SERVICE_KEY_FILE_PATH is set and the deployment task is triggered, then
 # VERSION_CODE is effectively ignored. VERSION_NAME is suffixed with the version code.
 # If not using automated Google Play deployment, then these serve as the actual version numbers.


### PR DESCRIPTION
- Although this build flag is not transitive, and thus it does not cover SDK, it’s still a good approach to have it turned on
- Using the middle path with symbol_table value - this could be changed once needed
- Closes #1190 

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._