### PR TITLE
[#1449] Display Synchronizer details in dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ directly impact users rather than highlighting other key architectural updates.*
   cases: Send funds, Recovery Phrase, Export Private Data, and Delete Wallet. 
 - The app entry animation has been reworked to apply on every app access point, i.e. it will be displayed when 
   users return to an already set up app as well.
+- Synchronizer status details are now available to users by pressing the simple status view placed above the
+  synchronization progress bar. The details are displayed within a dialog window on the Balances and Account screens.
+  This view also occasionally presents information about a possible Zashi app update available on Google Play. The 
+  app redirects users to the Google Play Zashi page by pressing the view.
+
+### Changed
+- The app dialog window has now a bit more rounded corners
+- A few more minor UI improvements
 
 ## [1.0 (650)] - 2024-05-07
 

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Dialog.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Dialog.kt
@@ -1,12 +1,13 @@
 package co.electriccoin.zcash.ui.design.component
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -61,7 +62,7 @@ fun AppAlertDialog(
     properties: DialogProperties = DialogProperties()
 ) {
     AlertDialog(
-        shape = RectangleShape,
+        shape = RoundedCornerShape(corner = CornerSize(ZcashTheme.dimens.regularRippleEffectCorner)),
         onDismissRequest = onDismissRequest?.let { onDismissRequest } ?: {},
         confirmButton = {
             confirmButtonText?.let {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/Dimens.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/Dimens.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 data class Dimens(
     // Default spacings:
     val spacingNone: Dp,
+    val spacingMini: Dp,
     val spacingXtiny: Dp,
     val spacingMin: Dp,
     val spacingTiny: Dp,
@@ -61,6 +62,7 @@ data class Dimens(
 private val defaultDimens =
     Dimens(
         spacingNone = 0.dp,
+        spacingMini = 1.dp,
         spacingXtiny = 2.dp,
         spacingTiny = 4.dp,
         spacingMin = 6.dp,

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/account/AccountTestSetup.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/account/AccountTestSetup.kt
@@ -1,5 +1,6 @@
 package co.electriccoin.zcash.ui.screen.account
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import co.electriccoin.zcash.ui.common.model.WalletRestoringState
@@ -70,6 +71,10 @@ class AccountTestSetup(
             onTransactionItemAction = {
                 onItemClickCount.incrementAndGet()
             },
+            hideStatusDialog = {},
+            showStatusDialog = null,
+            onStatusClick = {},
+            snackbarHostState = SnackbarHostState(),
             walletRestoringState = WalletRestoringState.NONE,
             walletSnapshot = WalletSnapshotFixture.new()
         )

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/account/history/HistoryTestSetup.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/account/history/HistoryTestSetup.kt
@@ -30,6 +30,7 @@ class HistoryTestSetup(
             ZcashTheme {
                 HistoryContainer(
                     transactionState = initialHistoryUiState,
+                    onStatusClick = {},
                     onTransactionItemAction = {
                         onItemIdClickCount.incrementAndGet()
                     },

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/balances/BalancesTestSetup.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/balances/BalancesTestSetup.kt
@@ -1,5 +1,6 @@
 package co.electriccoin.zcash.ui.screen.balances
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import co.electriccoin.zcash.ui.common.model.WalletRestoringState
@@ -35,7 +36,10 @@ class BalancesTestSetup(
             onSettings = {
                 onSettingsCount.incrementAndGet()
             },
-            isDetailedStatus = false,
+            hideStatusDialog = {},
+            showStatusDialog = null,
+            onStatusClick = {},
+            snackbarHostState = SnackbarHostState(),
             isFiatConversionEnabled = isShowFiatConversion,
             isUpdateAvailable = false,
             isShowingErrorDialog = false,

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/balances/model/WalletDisplayValuesTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/balances/model/WalletDisplayValuesTest.kt
@@ -31,8 +31,7 @@ class WalletDisplayValuesTest {
             WalletDisplayValues.getNextValues(
                 context = getAppContext(),
                 walletSnapshot = walletSnapshot,
-                isUpdateAvailable = false,
-                isDetailedStatus = false
+                isUpdateAvailable = false
             )
 
         assertNotNull(values)

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/update/util/PlayStoreUtilTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/update/util/PlayStoreUtilTest.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.screen.update.util
 import android.content.Intent
 import androidx.test.filters.SmallTest
 import co.electriccoin.zcash.ui.test.getAppContext
+import co.electriccoin.zcash.ui.util.PlayStoreUtil
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/compose/BalanceWidget.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/compose/BalanceWidget.kt
@@ -80,6 +80,7 @@ sealed class BalanceState(open val totalBalance: Zatoshi) {
 }
 
 @Composable
+@Suppress("LongMethod")
 fun BalanceWidget(
     balanceState: BalanceState,
     isReferenceToBalances: Boolean,
@@ -104,11 +105,22 @@ fun BalanceWidget(
                     text = stringResource(id = co.electriccoin.zcash.ui.R.string.balance_widget_available),
                     onClick = onReferenceClick,
                     fontWeight = FontWeight.Normal,
-                    modifier = Modifier.padding(all = ZcashTheme.dimens.spacingTiny)
+                    modifier =
+                        Modifier
+                            .padding(
+                                vertical = ZcashTheme.dimens.spacingSmall,
+                                horizontal = ZcashTheme.dimens.spacingMini,
+                            )
                 )
             } else {
                 Body(
                     text = stringResource(id = co.electriccoin.zcash.ui.R.string.balance_widget_available),
+                    modifier =
+                        Modifier
+                            .padding(
+                                vertical = ZcashTheme.dimens.spacingSmall,
+                                horizontal = ZcashTheme.dimens.spacingMini,
+                            )
                 )
             }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/compose/SynchronizationStatus.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/compose/SynchronizationStatus.kt
@@ -1,13 +1,19 @@
 package co.electriccoin.zcash.ui.common.compose
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -18,11 +24,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import cash.z.ecc.sdk.extension.toPercentageWithDecimal
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.WalletSnapshot
+import co.electriccoin.zcash.ui.design.component.AppAlertDialog
 import co.electriccoin.zcash.ui.design.component.BodySmall
 import co.electriccoin.zcash.ui.design.component.GradientSurface
 import co.electriccoin.zcash.ui.design.component.SmallLinearProgressIndicator
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.fixture.WalletSnapshotFixture
+import co.electriccoin.zcash.ui.screen.balances.model.StatusAction
 import co.electriccoin.zcash.ui.screen.balances.model.WalletDisplayValues
 
 @Preview(device = Devices.PIXEL_4_XL)
@@ -34,8 +42,8 @@ private fun BalanceWidgetPreview() {
         ) {
             SynchronizationStatus(
                 isUpdateAvailable = false,
-                isDetailedStatus = false,
-                walletSnapshot = WalletSnapshotFixture.new()
+                onStatusClick = {},
+                walletSnapshot = WalletSnapshotFixture.new(),
             )
         }
     }
@@ -44,7 +52,7 @@ private fun BalanceWidgetPreview() {
 @Composable
 fun SynchronizationStatus(
     isUpdateAvailable: Boolean,
-    isDetailedStatus: Boolean,
+    onStatusClick: (StatusAction) -> Unit,
     walletSnapshot: WalletSnapshot,
     modifier: Modifier = Modifier,
     testTag: String? = null,
@@ -54,7 +62,6 @@ fun SynchronizationStatus(
             context = LocalContext.current,
             walletSnapshot = walletSnapshot,
             isUpdateAvailable = isUpdateAvailable,
-            isDetailedStatus = isDetailedStatus
         )
 
     Column(
@@ -64,11 +71,14 @@ fun SynchronizationStatus(
         if (walletDisplayValues.statusText.isNotEmpty()) {
             BodySmall(
                 text = walletDisplayValues.statusText,
-                modifier = testTag?.let { Modifier.testTag(testTag) } ?: Modifier,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(ZcashTheme.dimens.regularRippleEffectCorner))
+                        .clickable { onStatusClick(walletDisplayValues.statusAction) }
+                        .padding(all = ZcashTheme.dimens.spacingSmall)
+                        .then(testTag?.let { Modifier.testTag(testTag) } ?: Modifier),
             )
-
-            Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingSmall))
         }
 
         BodySmall(
@@ -86,8 +96,27 @@ fun SynchronizationStatus(
             progress = walletSnapshot.progress.decimal,
             modifier =
                 Modifier.padding(
-                    horizontal = ZcashTheme.dimens.spacingUpLarge
+                    horizontal = ZcashTheme.dimens.spacingDefault
                 )
         )
     }
+}
+
+@Composable
+fun StatusDialog(
+    statusAction: StatusAction.Detailed,
+    onDone: () -> Unit
+) {
+    AppAlertDialog(
+        title = stringResource(id = R.string.balances_status_error_dialog_title),
+        text = {
+            Column(
+                Modifier.verticalScroll(rememberScrollState())
+            ) {
+                Text(text = statusAction.details)
+            }
+        },
+        confirmButtonText = stringResource(id = R.string.balances_status_dialog_button),
+        onConfirmButtonClick = onDone
+    )
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
@@ -185,8 +185,6 @@ class AuthenticationViewModel(
                             // Biometric authentication is disabled until the user unlocks with their device credential
                             // (i.e. PIN, pattern, or password).
                             BiometricPrompt.ERROR_LOCKOUT_PERMANENT,
-                            // The user does not have any biometrics enrolled
-                            BiometricPrompt.ERROR_NO_BIOMETRICS,
                             // The device does not have the required authentication hardware
                             BiometricPrompt.ERROR_HW_NOT_PRESENT,
                             // The user pressed the negative button
@@ -214,9 +212,12 @@ class AuthenticationViewModel(
                                 // We could consider splitting ERROR_CANCELED from ERROR_USER_CANCELED
                                 authenticationResult.value = AuthenticationResult.Canceled
                             }
+                            // The user does not have any biometrics enrolled
+                            BiometricPrompt.ERROR_NO_BIOMETRICS,
                             // The device does not have pin, pattern, or password set up
                             BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL -> {
                                 // Allow unauthenticated access if no authentication method is available on the device
+                                // These 2 errors can come for a different Android SDK versions, but they mean the same
                                 authenticationResult.value = AuthenticationResult.Success
                             }
                         }
@@ -346,7 +347,7 @@ class AuthenticationViewModel(
             }
             else -> {
                 Twig.error { "Unexpected biometric framework status" }
-                BiometricSupportResult.StatusExpected
+                BiometricSupportResult.StatusUnexpected
             }
         }
     }
@@ -411,5 +412,5 @@ private sealed class BiometricSupportResult {
 
     data object StatusUnknown : BiometricSupportResult()
 
-    data object StatusExpected : BiometricSupportResult()
+    data object StatusUnexpected : BiometricSupportResult()
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/account/view/HistoryView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/account/view/HistoryView.kt
@@ -62,6 +62,7 @@ import co.electriccoin.zcash.ui.screen.account.model.TransactionUi
 import co.electriccoin.zcash.ui.screen.account.model.TransactionUiState
 import co.electriccoin.zcash.ui.screen.account.model.TrxItemState
 import co.electriccoin.zcash.ui.screen.balances.BalancesTag
+import co.electriccoin.zcash.ui.screen.balances.model.StatusAction
 import co.electriccoin.zcash.ui.screen.send.view.DEFAULT_LESS_THAN_FEE
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
@@ -76,6 +77,7 @@ private fun ComposablePreview() {
         GradientSurface {
             HistoryContainer(
                 onTransactionItemAction = {},
+                onStatusClick = {},
                 transactionState = TransactionUiState.Loading,
                 walletRestoringState = WalletRestoringState.SYNCING,
                 walletSnapshot = WalletSnapshotFixture.new()
@@ -92,6 +94,7 @@ private fun ComposableHistoryListPreview() {
             HistoryContainer(
                 transactionState = TransactionUiState.Done(transactions = TransactionsFixture.new()),
                 onTransactionItemAction = {},
+                onStatusClick = {},
                 walletRestoringState = WalletRestoringState.RESTORING,
                 walletSnapshot = WalletSnapshotFixture.new()
             )
@@ -107,7 +110,9 @@ private val dateFormat: DateFormat by lazy {
 }
 
 @Composable
+@Suppress("LongParameterList")
 internal fun HistoryContainer(
+    onStatusClick: (StatusAction) -> Unit,
     onTransactionItemAction: (TrxItemAction) -> Unit,
     transactionState: TransactionUiState,
     walletRestoringState: WalletRestoringState,
@@ -127,15 +132,19 @@ internal fun HistoryContainer(
             Column(
                 modifier = Modifier.background(color = ZcashTheme.colors.historySyncingColor)
             ) {
-                Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))
+                Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingSmall))
 
-                // Do not show the app update information and the detailed sync status in the restoring status
-                // on Account screen
+                // Do not calculate and use the app update information here, as the sync bar won't be displayed after
+                // the wallet is fully restored
                 SynchronizationStatus(
-                    isDetailedStatus = false,
                     isUpdateAvailable = false,
+                    onStatusClick = onStatusClick,
                     testTag = BalancesTag.STATUS,
                     walletSnapshot = walletSnapshot,
+                    modifier =
+                        Modifier
+                            .padding(horizontal = ZcashTheme.dimens.spacingDefault)
+                            .animateContentSize()
                 )
 
                 Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingDefault))

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/AndroidHome.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/AndroidHome.kt
@@ -18,7 +18,6 @@ import cash.z.ecc.android.sdk.model.ZecSend
 import co.electriccoin.zcash.ui.MainActivity
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.compose.RestoreScreenBrightness
-import co.electriccoin.zcash.ui.common.model.VersionInfo
 import co.electriccoin.zcash.ui.common.model.WalletRestoringState
 import co.electriccoin.zcash.ui.common.model.WalletSnapshot
 import co.electriccoin.zcash.ui.common.viewmodel.HomeViewModel
@@ -56,13 +55,6 @@ internal fun MainActivity.WrapHome(
 
     val isRestoringInitialWarningSeen = homeViewModel.isRestoringInitialWarningSeen.collectAsStateWithLifecycle().value
 
-    // Detailed sync status info is used if set in configuration or if the app is built as debuggable
-    // (i.e. mainly in development)
-    val isDetailedSyncStatus =
-        homeViewModel.isDetailedSyncStatus.collectAsStateWithLifecycle().value.run {
-            this ?: false || VersionInfo.new(this@WrapHome).isDebuggable
-        }
-
     val walletSnapshot = walletViewModel.walletSnapshot.collectAsStateWithLifecycle().value
 
     val walletRestoringState = walletViewModel.walletRestoringState.collectAsStateWithLifecycle().value
@@ -98,7 +90,6 @@ internal fun MainActivity.WrapHome(
         goSettings = goSettings,
         goMultiTrxSubmissionFailure = goMultiTrxSubmissionFailure,
         homeScreenIndex = homeScreenIndex,
-        isDetailedSyncStatus = isDetailedSyncStatus,
         isKeepScreenOnWhileSyncing = isKeepScreenOnWhileSyncing,
         isShowingRestoreInitDialog = isShowingRestoreInitDialog,
         onPageChange = {
@@ -120,7 +111,6 @@ internal fun WrapHome(
     goScan: () -> Unit,
     goSendConfirmation: (ZecSend) -> Unit,
     homeScreenIndex: HomeScreenIndex,
-    isDetailedSyncStatus: Boolean,
     isKeepScreenOnWhileSyncing: Boolean?,
     isShowingRestoreInitDialog: Boolean,
     onPageChange: (HomeScreenIndex) -> Unit,
@@ -203,7 +193,6 @@ internal fun WrapHome(
                 screenContent = {
                     WrapBalances(
                         activity = activity,
-                        isDetailedSyncStatus = isDetailedSyncStatus,
                         goSettings = goSettings,
                         goMultiTrxSubmissionFailure = goMultiTrxSubmissionFailure
                     )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/update/AndroidUpdate.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/update/AndroidUpdate.kt
@@ -16,9 +16,9 @@ import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.viewmodel.CheckUpdateViewModel
 import co.electriccoin.zcash.ui.screen.update.model.UpdateInfo
 import co.electriccoin.zcash.ui.screen.update.model.UpdateState
-import co.electriccoin.zcash.ui.screen.update.util.PlayStoreUtil
 import co.electriccoin.zcash.ui.screen.update.view.Update
 import co.electriccoin.zcash.ui.screen.update.viewmodel.UpdateViewModel
+import co.electriccoin.zcash.ui.util.PlayStoreUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -111,7 +111,7 @@ internal fun WrapUpdate(
         },
         onLater = onLaterAction,
         onReference = {
-            openPlayStoreAppPage(
+            openPlayStoreAppSite(
                 activity.applicationContext,
                 snackbarHostState,
                 scope
@@ -120,7 +120,7 @@ internal fun WrapUpdate(
     )
 }
 
-fun openPlayStoreAppPage(
+private fun openPlayStoreAppSite(
     context: Context,
     snackbarHostState: SnackbarHostState,
     scope: CoroutineScope
@@ -131,7 +131,7 @@ fun openPlayStoreAppPage(
     }.onFailure {
         scope.launch {
             snackbarHostState.showSnackbar(
-                message = context.getString(R.string.update_unable_to_open_play_store)
+                message = context.getString(R.string.unable_to_open_play_store)
             )
         }
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/update/view/UpdateView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/update/view/UpdateView.kt
@@ -234,7 +234,7 @@ private fun UpdateContentContent(
                 } else {
                     ImageVector.vectorResource(R.drawable.ic_zashi_logo_update_available)
                 },
-            contentDescription = stringResource(id = R.string.update_image_content_description)
+            contentDescription = null
         )
 
         Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingBig))

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/util/PlayStoreUtil.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/util/PlayStoreUtil.kt
@@ -1,4 +1,4 @@
-package co.electriccoin.zcash.ui.screen.update.util
+package co.electriccoin.zcash.ui.util
 
 import android.content.Context
 import android.content.Intent

--- a/ui-lib/src/main/res/ui/balances/values/strings.xml
+++ b/ui-lib/src/main/res/ui/balances/values/strings.xml
@@ -22,13 +22,22 @@
     <string name="balances_status_synced">Synced</string>
     <string name="balances_status_update">Please update <xliff:g id="app_name" example="Zashi">%1$s</xliff:g> using Google Play</string>
     <string name="balances_status_error_simple"><xliff:g id="app_name" example="Zashi">%1$s</xliff:g> encountered an error while syncing, attempting to resolve…</string>
-    <string name="balances_status_error_detailed" formatted="true">Error: <xliff:g id="error_type" example="Lost connection">%1$s</xliff:g></string>
-    <string name="balances_status_error_detailed_connection">Disconnected</string>
-    <string name="balances_status_error_detailed_unknown">Unknown cause</string>
-    <string name="balances_status_detailed_stopped">Synchronizer stopped</string>
     <string name="balances_status_restoring_text">The restore process can take several hours on lower-powered devices, and even on powerful devices is likely to take more than an hour.</string>
 
     <string name="balances_shielding_successful">Shielding has been successfully submitted</string>
+
+    <string name="balances_status_error_dialog_title">Error</string>
+    <string name="balances_status_error_dialog_connection">
+        Disconnected. Please check your internet connection.
+    </string>
+    <string name="balances_status_error_dialog_cause" formatted="true">
+        Error: <xliff:g id="error_cause" example="Block scanning problem">%1$s</xliff:g>
+    </string>
+    <string name="balances_status_error_dialog_unknown">
+        Unknown cause. Please contact our support team if the problem persists.
+    </string>
+    <string name="balances_status_dialog_stopped">Synchronization is stopped. It will resume soon.</string>
+    <string name="balances_status_dialog_button">OK</string>
 
     <string name="balances_shielding_dialog_error_title">Failed to shield funds</string>
     <string name="balances_shielding_dialog_error_text">Error: The attempt to shield the transparent funds failed. Try it again, please.</string>

--- a/ui-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-lib/src/main/res/ui/common/values/strings.xml
@@ -7,4 +7,5 @@
     <!-- This is replaced by a resource overlay via app/build.gradle.kts -->
     <string name="support_email_address" />
     <string name="restoring_wallet_label">[Restoring Your Wallet…]</string>
+    <string name="unable_to_open_play_store">Unable to launch Google Play store app…</string>
 </resources>

--- a/ui-lib/src/main/res/ui/update/values/strings.xml
+++ b/ui-lib/src/main/res/ui/update/values/strings.xml
@@ -2,7 +2,6 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="update_header">Update available</string>
     <string name="update_critical_header">Update required</string>
-    <string name="update_image_content_description"></string>
     <string name="update_title_available"><xliff:g id="app_name" example="Zcash">%1$s</xliff:g> here.</string>
     <string name="update_title_required">It\'s not you, it\'s me.</string>
     <string name="update_description_required">
@@ -17,5 +16,4 @@
     <string name="update_download_button">Update</string>
     <string name="update_later_enabled_button">Remind me later</string>
     <string name="update_later_disabled_button">(required)</string>
-    <string name="update_unable_to_open_play_store">Unable to launch Google Play store app.</string>
 </resources>


### PR DESCRIPTION
- Closes #1449
- Synchronizer status details are now available to users by pressing the simple status view. The details are displayed within the predefined Zashi dialog on the Balances and Account screens
- As this view also presents information about Zashi app updates available on Google Play, by pressing the view, the app redirects users to Google Play Zashi’s page
- As agreed, we’re moving towards more rounded corners in dialogs, which is part of these changes, too
- Added also several minor Balances screen UI improvements
- Improved biometric flow without any authentication method set on older Android versions
- Changelog update

The error message in the dialog below is just a showcase:
<img src="https://github.com/Electric-Coin-Company/zashi-android/assets/9017390/b7df333f-5428-4b68-b5ee-bd659a85b532" width="300" />

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._