### PR TITLE
[#1467] Activity resizing according to soft keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 - The Restore Success dialog has been reworked into a separate screen, allowing users to opt out of the Keep screen
   on while restoring option 
 
+## Fixed
+- Support Screen now shows the Send button above keyboard instead of overlaying it. This was achieved by setting 
+  `adjustResize` to `MainActivity` and adding `imePadding` to top level composable
+
 ## [1.1.3 (682)] - 2024-07-03
 
 ### Added

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -16,3 +16,6 @@ directly impact users rather than highlighting other key architectural updates.*
 - The About screen has been redesigned to align with the new design guidelines
 - The Restore Success dialog has been reworked into a separate screen, allowing users to opt out of the Keep screen 
   on while restoring option
+
+### Fixed
+- Support Screen now shows the Send button above keyboard instead of overlaying it

--- a/ui-lib/src/main/AndroidManifest.xml
+++ b/ui-lib/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="false"
+            android:windowSoftInputMode="adjustResize"
             android:label="@string/app_name"
             android:theme="@style/Theme.App.Starting" />
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -133,6 +134,7 @@ class MainActivity : AppCompatActivity() {
                         Modifier
                             .fillMaxWidth()
                             .fillMaxHeight()
+                            .imePadding()
                     ) {
                         BindCompLocalProvider {
                             MainContent()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -47,7 +46,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
@@ -400,7 +398,7 @@ private fun RestoreSeedMainContent(
     goNext: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val scope = rememberCoroutineScope()
+    val focusManager = LocalFocusManager.current
     val scrollState = rememberScrollState()
     val focusRequester = remember { FocusRequester() }
     val textFieldScrollToHeight = rememberSaveable { mutableIntStateOf(0) }
@@ -468,24 +466,21 @@ private fun RestoreSeedMainContent(
         Spacer(modifier = Modifier.height(ZcashTheme.dimens.spacingHuge))
     }
 
-    if (isSeedValid) {
-        // Clear focus and hide keyboard to make it easier for users to see the next button
-        LocalSoftwareKeyboardController.current?.hide()
-        LocalFocusManager.current.clearFocus()
+    LaunchedEffect(isSeedValid) {
+        if (isSeedValid) {
+            // Clear focus and hide keyboard to make it easier for users to see the next button
+            focusManager.clearFocus()
+        }
     }
 
-    DisposableEffect(parseResult) {
+    LaunchedEffect(parseResult) {
         // Causes the TextFiled to refocus
         if (!isSeedValid) {
             focusRequester.requestFocus()
         }
-        // Causes scroll to the TextField after the first type action
         if (text.isNotEmpty() && userWordList.current.value.isEmpty()) {
-            scope.launch {
-                scrollState.animateScrollTo(textFieldScrollToHeight.intValue)
-            }
+            scrollState.animateScrollTo(textFieldScrollToHeight.intValue)
         }
-        onDispose { /* Nothing to dispose */ }
     }
 }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
@@ -235,6 +235,8 @@ fun RestoreWallet(
     LaunchedEffect(Unit) {
         userWordList.wordValidation().collect {
             if (it is SeedPhraseValidation.Valid) {
+                // temporary fix to wait for other states to update first
+                // https://github.com/Electric-Coin-Company/zashi-android/issues/1522
                 @Suppress("MagicNumber")
                 delay(100)
                 isSeedValid = true

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
@@ -235,8 +235,8 @@ fun RestoreWallet(
     LaunchedEffect(Unit) {
         userWordList.wordValidation().collect {
             if (it is SeedPhraseValidation.Valid) {
-                // temporary fix to wait for other states to update first
-                // https://github.com/Electric-Coin-Company/zashi-android/issues/1522
+                // TODO [1522]: temporary fix to wait for other states to update first
+                // TODO [1522]: https://github.com/Electric-Coin-Company/zashi-android/issues/1522
                 @Suppress("MagicNumber")
                 delay(100)
                 isSeedValid = true

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/view/RestoreView.kt
@@ -235,8 +235,8 @@ fun RestoreWallet(
     LaunchedEffect(Unit) {
         userWordList.wordValidation().collect {
             if (it is SeedPhraseValidation.Valid) {
-                // TODO [1522]: temporary fix to wait for other states to update first
-                // TODO [1522]: https://github.com/Electric-Coin-Company/zashi-android/issues/1522
+                // TODO [#1522]: temporary fix to wait for other states to update first
+                // TODO [#1522]: https://github.com/Electric-Coin-Company/zashi-android/issues/1522
                 @Suppress("MagicNumber")
                 delay(100)
                 isSeedValid = true


### PR DESCRIPTION
Closes #1467

This approach works for all screens universally - it resizes the window according to the soft keyboard and imePadding makes sure compose handles and animates this change correctly.

Without this approach we show the keyboard simply above the activity and hope there is enough space on the screen of the user to show the rest of the view.

On the second screenshot you can see that it really pushes everything up including the tabs. Such elements can be handled separately - we can hide them if necessary. However I left it this way becuase I don't feel like it's an issue.

| Feedback  | Receive funds |
| ------------- | ------------- |
| ![Screenshot_20240708_131842](https://github.com/Electric-Coin-Company/zashi-android/assets/173177868/96002517-39ff-4dbf-8365-a7a848cfd41c) | ![Screenshot_20240708_131907](https://github.com/Electric-Coin-Company/zashi-android/assets/173177868/f79405f4-f2cd-4bd4-9727-0bb05d518676) |

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [x] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [x] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [x] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._