### PR TITLE
[#1448] Screenshot testing enabled

### DIFF
--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/WelcomeAnimation.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/WelcomeAnimation.kt
@@ -27,10 +27,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import co.electriccoin.zcash.ui.design.R
 import co.electriccoin.zcash.ui.design.component.AnimationConstants.ANIMATION_DURATION
 import co.electriccoin.zcash.ui.design.component.AnimationConstants.INITIAL_DELAY
+import co.electriccoin.zcash.ui.design.component.AnimationConstants.WELCOME_ANIM_TEST_TAG
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.util.screenHeight
 import kotlinx.coroutines.delay
@@ -40,6 +42,7 @@ import kotlin.time.Duration.Companion.milliseconds
 object AnimationConstants {
     const val ANIMATION_DURATION = 700
     const val INITIAL_DELAY = 1000
+    const val WELCOME_ANIM_TEST_TAG = "WELCOME_ANIM_TEST_TAG"
 
     fun together() = (ANIMATION_DURATION + INITIAL_DELAY).toLong()
 }
@@ -56,7 +59,7 @@ fun WelcomeAnimationAutostart(
 
     WelcomeAnimation(
         animationState = currentAnimationState,
-        modifier = modifier
+        modifier = modifier.testTag(WELCOME_ANIM_TEST_TAG)
     )
 
     // Let's start the animation automatically in case e.g. authentication is not involved

--- a/ui-screenshot-test/src/main/java/co/electroniccoin/zcash/ui/screenshot/ScreenshotTest.kt
+++ b/ui-screenshot-test/src/main/java/co/electroniccoin/zcash/ui/screenshot/ScreenshotTest.kt
@@ -2,26 +2,14 @@
 
 package co.electroniccoin.zcash.ui.screenshot
 
-import org.junit.Test
-
-// NOTE: this is just a placeholder test to satisfy this module test settings and will be removed once the below
-// issue is resolved
-class ScreenshotTest {
-    @Test
-    fun placeholderTest() {
-        assert(true)
-    }
-}
-/*
-TODO [#1448]: Re-enable or rework screenshot testing
-TODO [#1448]: https://github.com/Electric-Coin-Company/zashi-android/issues/1448
-
 import android.content.Context
 import android.os.Build
 import android.os.LocaleList
 import androidx.activity.viewModels
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -54,6 +42,7 @@ import co.electriccoin.zcash.ui.MainActivity
 import co.electriccoin.zcash.ui.NavigationTargets
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.viewmodel.SecretState
+import co.electriccoin.zcash.ui.design.component.AnimationConstants.WELCOME_ANIM_TEST_TAG
 import co.electriccoin.zcash.ui.design.component.ConfigurationOverride
 import co.electriccoin.zcash.ui.design.component.UiMode
 import co.electriccoin.zcash.ui.screen.account.AccountTag
@@ -168,6 +157,7 @@ class ScreenshotTest : UiTestPrerequisites() {
         }
     }
 
+    @OptIn(ExperimentalTestApi::class)
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     private fun takeScreenshotsForRestoreWallet(
         resContext: Context,
@@ -182,6 +172,8 @@ class ScreenshotTest : UiTestPrerequisites() {
         composeTestRule.waitUntil(DEFAULT_TIMEOUT_MILLISECONDS) {
             composeTestRule.activity.walletViewModel.secretState.value is SecretState.None
         }
+
+        composeTestRule.waitUntilDoesNotExist(hasTestTag(WELCOME_ANIM_TEST_TAG), DEFAULT_TIMEOUT_MILLISECONDS)
 
         composeTestRule.onNodeWithText(
             text =
@@ -324,6 +316,7 @@ class ScreenshotTest : UiTestPrerequisites() {
     }
 }
 
+@OptIn(ExperimentalTestApi::class)
 private fun onboardingScreenshots(
     resContext: Context,
     tag: String,
@@ -339,6 +332,8 @@ private fun onboardingScreenshots(
         ScreenshotTest.takeScreenshot(tag, "Onboarding 1")
     }
 
+    composeTestRule.waitUntilDoesNotExist(hasTestTag(WELCOME_ANIM_TEST_TAG), DEFAULT_TIMEOUT_MILLISECONDS)
+
     composeTestRule.onNodeWithText(
         text = resContext.getString(R.string.onboarding_create_new_wallet),
         ignoreCase = true
@@ -347,7 +342,10 @@ private fun onboardingScreenshots(
     }
 
     // Security Warning screen
-    composeTestRule.onNodeWithText(text = resContext.getString(R.string.security_warning_acknowledge)).also {
+    composeTestRule.onNodeWithText(
+        text = resContext.getString(R.string.security_warning_acknowledge),
+        ignoreCase = true
+    ).also {
         it.assertExists()
         it.performClick()
         ScreenshotTest.takeScreenshot(tag, "Security Warning")
@@ -551,4 +549,3 @@ private fun seedScreenshots(
 
     ScreenshotTest.takeScreenshot(tag, "Seed 1")
 }
-*/


### PR DESCRIPTION
Closes #1448

# Author

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._