### PR TITLE
Activity Compose Composition Strategy handling

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.os.SystemClock
-import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
@@ -29,6 +28,7 @@ import cash.z.ecc.sdk.type.fromResources
 import co.electriccoin.zcash.spackle.FirebaseTestLabUtil
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.compose.BindCompLocalProvider
+import co.electriccoin.zcash.ui.common.extension.setContentCompat
 import co.electriccoin.zcash.ui.common.model.OnboardingState
 import co.electriccoin.zcash.ui.common.model.WalletRestoringState
 import co.electriccoin.zcash.ui.common.viewmodel.AuthenticationUIState
@@ -126,8 +126,7 @@ class MainActivity : FragmentActivity() {
         // including IME animations, and go edge-to-edge.
         // This also sets up the initial system bar style based on the platform theme
         enableEdgeToEdge()
-
-        setContent {
+        setContentCompat {
             Override(configurationOverrideFlow) {
                 ZcashTheme {
                     BlankSurface(
@@ -160,6 +159,7 @@ class MainActivity : FragmentActivity() {
                 Twig.debug { "Authentication initial state" }
                 // Wait for the state update
             }
+
             AuthenticationUIState.NotRequired -> {
                 Twig.debug { "App access authentication NOT required - welcome animation only" }
                 if (animateAppAccess) {
@@ -173,6 +173,7 @@ class MainActivity : FragmentActivity() {
                     }
                 }
             }
+
             AuthenticationUIState.Required -> {
                 Twig.debug { "App access authentication required" }
 
@@ -198,12 +199,14 @@ class MainActivity : FragmentActivity() {
                     useCase = AuthenticationUseCase.AppAccess
                 )
             }
+
             AuthenticationUIState.SupportedRequired -> {
                 Twig.debug { "Authentication support required" }
                 WrapSupport(
                     goBack = { finish() }
                 )
             }
+
             AuthenticationUIState.Successful -> {
                 Twig.debug { "Authentication successful - entering the app" }
                 // No action is needed - the main app content is laid out now
@@ -229,6 +232,7 @@ class MainActivity : FragmentActivity() {
                     SecretState.None -> {
                         WrapOnboarding()
                     }
+
                     is SecretState.NeedsWarning -> {
                         WrapSecurityWarning(
                             onBack = { walletViewModel.persistOnboardingState(OnboardingState.NONE) },
@@ -249,15 +253,18 @@ class MainActivity : FragmentActivity() {
                             }
                         )
                     }
+
                     is SecretState.NeedsBackup -> {
                         WrapNewWalletRecovery(
                             secretState.persistableWallet,
                             onBackupComplete = { walletViewModel.persistOnboardingState(OnboardingState.READY) }
                         )
                     }
+
                     is SecretState.Ready -> {
                         Navigation()
                     }
+
                     else -> {
                         error("Unhandled secret state: $secretState")
                     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/extension/ComponentActivityExt.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/extension/ComponentActivityExt.kt
@@ -1,0 +1,67 @@
+package co.electriccoin.zcash.ui.common.extension
+
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionContext
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+
+/**
+ * Same like [ComponentActivity.setContent] but allows for addition of [ViewCompositionStrategy].
+ */
+fun ComponentActivity.setContentCompat(
+    viewCompositionStrategy: ViewCompositionStrategy = ViewCompositionStrategy.DisposeOnDetachedFromWindow,
+    parent: CompositionContext? = null,
+    content: @Composable () -> Unit
+) {
+    val existingComposeView =
+        window.decorView
+            .findViewById<ViewGroup>(android.R.id.content)
+            .getChildAt(0) as? ComposeView
+
+    if (existingComposeView != null) {
+        with(existingComposeView) {
+            setParentCompositionContext(parent)
+            setContent(content)
+        }
+    } else {
+        ComposeView(this).apply {
+            // Set content and parent **before** setContentView
+            // to have ComposeView create the composition on attach
+            setViewCompositionStrategy(viewCompositionStrategy)
+            setParentCompositionContext(parent)
+            setContent(content)
+            // Set the view tree owners before setting the content view so that the inflation process
+            // and attach listeners will see them already present
+            setOwners()
+            setContentView(
+                this,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+            )
+        }
+    }
+}
+
+private fun ComponentActivity.setOwners() {
+    val decorView = window.decorView
+    if (decorView.findViewTreeLifecycleOwner() == null) {
+        decorView.setViewTreeLifecycleOwner(this)
+    }
+    if (decorView.findViewTreeViewModelStoreOwner() == null) {
+        decorView.setViewTreeViewModelStoreOwner(this)
+    }
+    if (decorView.findViewTreeSavedStateRegistryOwner() == null) {
+        decorView.setViewTreeSavedStateRegistryOwner(this)
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/extension/ComponentActivityExt.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/extension/ComponentActivityExt.kt
@@ -17,7 +17,7 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 /**
  * Same like [ComponentActivity.setContent] but allows for addition of [ViewCompositionStrategy].
  */
-fun ComponentActivity.setContentCompat(
+internal fun ComponentActivity.setContentCompat(
     viewCompositionStrategy: ViewCompositionStrategy = ViewCompositionStrategy.DisposeOnDetachedFromWindow,
     parent: CompositionContext? = null,
     content: @Composable () -> Unit


### PR DESCRIPTION
# Author
Composition strategy handling for MainActivity.

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [x] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [x] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._