### PR TITLE
Android 15 strict mode update for unsafe intents

### DIFF
--- a/crash-android-lib/src/androidTest/kotlin/co/electriccoin/zcash/crash/android/internal/local/Components.kt
+++ b/crash-android-lib/src/androidTest/kotlin/co/electriccoin/zcash/crash/android/internal/local/Components.kt
@@ -26,7 +26,7 @@ class Components {
 }
 
 private fun PackageManager.getProviderInfoCompat(componentName: ComponentName) =
-    if (AndroidApiVersion.isAtLeastT) {
+    if (AndroidApiVersion.isAtLeastTiramisu) {
         getProviderInfo(componentName, PackageManager.ComponentInfoFlags.of(0))
     } else {
         @Suppress("Deprecation")
@@ -34,7 +34,7 @@ private fun PackageManager.getProviderInfoCompat(componentName: ComponentName) =
     }
 
 private fun PackageManager.getReceiverInfoCompat(componentName: ComponentName) =
-    if (AndroidApiVersion.isAtLeastT) {
+    if (AndroidApiVersion.isAtLeastTiramisu) {
         getReceiverInfo(componentName, PackageManager.ComponentInfoFlags.of(0))
     } else {
         @Suppress("Deprecation")

--- a/spackle-android-lib/src/androidTest/java/co/electriccoin/zcash/spackle/process/VersionCodeCompatTest.kt
+++ b/spackle-android-lib/src/androidTest/java/co/electriccoin/zcash/spackle/process/VersionCodeCompatTest.kt
@@ -17,7 +17,7 @@ class VersionCodeCompatTest {
             PackageInfo().apply {
                 @Suppress("Deprecation")
                 versionCode = expectedVersionCode.toInt()
-                if (AndroidApiVersion.isAtLeastT) {
+                if (AndroidApiVersion.isAtLeastTiramisu) {
                     longVersionCode = expectedVersionCode
                 }
             }

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/AndroidApiVersion.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/AndroidApiVersion.kt
@@ -46,7 +46,13 @@ object AndroidApiVersion {
     val isAtLeastS = isAtLeast(Build.VERSION_CODES.S)
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
-    val isAtLeastT = isAtLeast(Build.VERSION_CODES.TIRAMISU)
+    val isAtLeastTiramisu = isAtLeast(Build.VERSION_CODES.TIRAMISU)
+
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    val isAtLeastUpsideDownCake = isAtLeast(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    val isAtLeastVanillaIceCream = isAtLeast(Build.VERSION_CODES.VANILLA_ICE_CREAM)
 
     val isPreview = 0 != Build.VERSION.PREVIEW_SDK_INT
 }

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/ClipboardManagerUtil.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/ClipboardManagerUtil.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.runBlocking
 object ClipboardManagerUtil {
     private val extraIsSensitive: String
         get() =
-            if (AndroidApiVersion.isAtLeastT) {
+            if (AndroidApiVersion.isAtLeastTiramisu) {
                 ClipDescription.EXTRA_IS_SENSITIVE
             } else {
                 "android.content.extra.IS_SENSITIVE"
@@ -32,7 +32,7 @@ object ClipboardManagerUtil {
                         putBoolean(extraIsSensitive, true)
                     }
             }
-        if (AndroidApiVersion.isAtLeastT) {
+        if (AndroidApiVersion.isAtLeastTiramisu) {
             // API 33 and later implement their system Toast UI.
             clipboardManager.setPrimaryClip(data)
         } else {

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/PackageManagerCompat.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/PackageManagerCompat.kt
@@ -11,7 +11,7 @@ fun PackageManager.getPackageInfoCompat(
     packageName: String,
     flags: Long
 ): PackageInfo =
-    if (AndroidApiVersion.isAtLeastT) {
+    if (AndroidApiVersion.isAtLeastTiramisu) {
         getPackageInfoTPlus(packageName, flags)
     } else {
         getPackageInfoLegacy(packageName, flags)
@@ -21,7 +21,7 @@ suspend fun PackageManager.getPackageInfoCompatSuspend(
     packageName: String,
     flags: Long
 ): PackageInfo =
-    if (AndroidApiVersion.isAtLeastT) {
+    if (AndroidApiVersion.isAtLeastTiramisu) {
         withContext(Dispatchers.IO) { getPackageInfoTPlus(packageName, flags) }
     } else {
         withContext(Dispatchers.IO) { getPackageInfoLegacy(packageName, flags) }

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/StrictModeCompat.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/StrictModeCompat.kt
@@ -27,7 +27,7 @@ object StrictModeCompat {
         // Don't enable missing network tags, because those are noisy.
         StrictMode.setVmPolicy(
             StrictMode.VmPolicy.Builder().apply {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (AndroidApiVersion.isAtLeastS) {
                     detectUnsafeIntentLaunch()
                 }
                 detectActivityLeaks()

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/StrictModeCompat.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/StrictModeCompat.kt
@@ -1,6 +1,7 @@
 package co.electriccoin.zcash.spackle
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.StrictMode
 
 object StrictModeCompat {
@@ -26,6 +27,9 @@ object StrictModeCompat {
         // Don't enable missing network tags, because those are noisy.
         StrictMode.setVmPolicy(
             StrictMode.VmPolicy.Builder().apply {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    detectUnsafeIntentLaunch()
+                }
                 detectActivityLeaks()
                 detectCleartextNetwork()
                 detectContentUriWithoutPermission()

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/StrictModeCompat.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/StrictModeCompat.kt
@@ -1,7 +1,6 @@
 package co.electriccoin.zcash.spackle
 
 import android.annotation.SuppressLint
-import android.os.Build
 import android.os.StrictMode
 
 object StrictModeCompat {

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/process/AbstractProcessNameContentProvider.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/process/AbstractProcessNameContentProvider.kt
@@ -27,7 +27,7 @@ open class AbstractProcessNameContentProvider : ContentProvider() {
         super.attachInfo(context, info)
 
         val processName: String =
-            if (AndroidApiVersion.isAtLeastT) {
+            if (AndroidApiVersion.isAtLeastTiramisu) {
                 getProcessNameTPlus()
             } else if (AndroidApiVersion.isAtLeastP) {
                 getProcessNamePPlus()

--- a/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/process/ProcessNameCompat.kt
+++ b/spackle-android-lib/src/main/kotlin/co/electriccoin/zcash/spackle/process/ProcessNameCompat.kt
@@ -55,7 +55,7 @@ object ProcessNameCompat {
      * due to some race conditions in Android.
      */
     private fun searchForProcessName(context: Context): String? {
-        return if (AndroidApiVersion.isAtLeastT) {
+        return if (AndroidApiVersion.isAtLeastTiramisu) {
             getProcessNameTPlus()
         } else if (AndroidApiVersion.isAtLeastP) {
             getProcessNamePPlus()


### PR DESCRIPTION
# Author

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [x] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._