### PR TITLE
Say "Shielded Privacy" for UA that contain a T-address

### DIFF
--- a/ui-lib/src/main/res/ui/qr_code/values/strings.xml
+++ b/ui-lib/src/main/res/ui/qr_code/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="qr_code_wallet_address_shielded">Zcash Shielded Address</string>
     <string name="qr_code_wallet_address_sapling">Zcash Sapling Address</string>
     <string name="qr_code_wallet_address_transparent">Zcash Transparent Address</string>
-    <string name="qr_code_privacy_level_shielded">Maximum Privacy</string>
+    <string name="qr_code_privacy_level_shielded">Shielded Privacy</string>
     <string name="qr_code_privacy_level_transparent">Low Privacy</string>
     <string name="qr_code_share_btn">Share QR Code</string>
     <string name="qr_code_copy_btn">Copy Address</string>

--- a/ui-lib/src/main/res/ui/request/values/strings.xml
+++ b/ui-lib/src/main/res/ui/request/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="request_memo_btn">Request</string>
     <string name="request_qr_share_btn">Share QR Code</string>
     <string name="request_qr_close_btn">Close</string>
-    <string name="request_privacy_level_shielded">Maximum Privacy</string>
+    <string name="request_privacy_level_shielded">Shielded Privacy</string>
     <string name="request_privacy_level_transparent">Low Privacy</string>
 
     <string name="request_amount_empty">0</string>


### PR DESCRIPTION
When a user views their Zashi Shielded Address, it is described as having "Maximum Privacy".

In reality, the UA has an embedded T-address, rendering it highly-likely that the user is doxxed by a motivated adversary.

Long-term let's allow Orchard-only UAs like in other ZEC wallets, perhaps as a "lockdown mode" expert feature in settings.

User story:

1. Human rights activist/anon swaps USDC to ZEC using a swap interface which only supports T-addresses (NEAR, Maya).
2. User shields their transparent ZEC into the Orchard pool using Zashi.
3. User posts their "Zashi Shielded Address" publicly on their social media profile, feeling safe by the phrase "Maximum Privacy".
4. Adversary sees their T-address in the UA, searches the address in NEAR or Maya's transaction history, determines their USDC came from a KYC exchange, is able to identify the activist.