### PR TITLE
fix: increase deposit QR error correction

### DIFF
--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/util/JvmQrCodeGenerator.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/util/JvmQrCodeGenerator.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.design.util
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 
 const val QR_CODE_IMAGE_MARGIN_IN_PIXELS = 2
 
@@ -14,7 +15,10 @@ object JvmQrCodeGenerator : QrCodeGenerator {
                 BarcodeFormat.QR_CODE,
                 sizePixels,
                 sizePixels,
-                mapOf(EncodeHintType.MARGIN to QR_CODE_IMAGE_MARGIN_IN_PIXELS)
+                mapOf(
+                    EncodeHintType.MARGIN to QR_CODE_IMAGE_MARGIN_IN_PIXELS,
+                    EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
+                    )
             )
 
         return BooleanArray(sizePixels * sizePixels).apply {


### PR DESCRIPTION
The low level of error correction (default 7% with ZXing) results in a transparent deposit QR that's unparsable by Zashi itself and other barcode scanners / wallets, due to the presence of the superimposed Zcash logo.

This pull increases the error correction to 15%, increasing redundancy and resulting in a scannable transparent address.

However, because this utility generates both the transparent and shielded QRs, it necessarily makes the shielded QR more dense. This might be undesired, as it's already fairly dense and has no issues scanning as is. (QR code scanners such as those on ATMs can reduce image resolution to increase processing speed, so this may make shielded QRs harder to scan.) Thus, you might want to separate out the QR generation for each address type.

I've tested three transparent QR codes generated from iOS wallets, and they were scannable, but unless the iOS wallet is using a higher-than-default error correction level, I'm unsure why these two platforms differ.

**Before (low correction):**
<img width="270" height="600" alt="before_transparent_with_low_correction" src="https://github.com/user-attachments/assets/4357ee06-5ce1-42c8-878d-c813bc0e5581" />

**After (medium correction):**
<img width="270" height="600" alt="after_transparent_with_medium_correction" src="https://github.com/user-attachments/assets/4747549c-1e42-49cd-a0c6-419dd247abbe" />

**Shielded before (low correction):**
<img width="270" height="600" alt="before_shielded_with_low_correction" src="https://github.com/user-attachments/assets/5eed0895-0d62-4250-bf9e-1eb7a09a7026" />

**Shielded after (medium correction):**
<img width="270" height="600" alt="after_shielded_with_medium_correction" src="https://github.com/user-attachments/assets/61d6a033-f3e9-43ec-a38f-1e5017c9642f" />
