### PR TITLE
fix: add missing content descriptions for TalkBack accessibility

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/compose/ZashiTooltip.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/compose/ZashiTooltip.kt
@@ -121,7 +121,8 @@ fun ZashiTooltip(
                 IconButton(onClick = onDismissRequest) {
                     Icon(
                         painter = painterResource(R.drawable.ic_exchange_rate_unavailable_dialog_close),
-                        contentDescription = null,
+                        contentDescription =
+                            androidx.compose.ui.res.stringResource(R.string.tooltip_close_content_description),
                         tint = ZashiColors.HintTooltips.defaultFg
                     )
                 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/about/view/AboutView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/about/view/AboutView.kt
@@ -107,7 +107,7 @@ private fun DebugMenu(
     ) {
         var expanded by rememberSaveable { mutableStateOf(false) }
         IconButton(onClick = { expanded = true }) {
-            Icon(Icons.Default.MoreVert, contentDescription = null)
+            Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.about_overflow_menu_content_description))
         }
         DropdownMenu(
             expanded = expanded,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/receive/ReceiveView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/receive/ReceiveView.kt
@@ -117,7 +117,7 @@ private fun ReceiveContents(
         Image(
             modifier = Modifier.align(Alignment.CenterHorizontally),
             painter = painterResource(R.drawable.ic_receive_info),
-            contentDescription = ""
+            contentDescription = null
         )
         Spacer(8.dp)
         Text(
@@ -185,7 +185,7 @@ private fun AddressPanel(
                                 .align(Alignment.BottomEnd)
                                 .offset(1.5.dp, .5.dp),
                         painter = painterResource(co.electriccoin.zcash.ui.design.R.drawable.ic_zec_shielded),
-                        contentDescription = "",
+                        contentDescription = null,
                     )
                 }
             }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/date/RestoreBDDateView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/date/RestoreBDDateView.kt
@@ -100,7 +100,7 @@ private fun Content(
         ) {
             Image(
                 painterResource(co.electriccoin.zcash.ui.design.R.drawable.ic_info),
-                contentDescription = "",
+                contentDescription = null,
                 colorFilter = ColorFilter.tint(color = ZashiColors.Utility.Indigo.utilityIndigo700)
             )
             Spacer(Modifier.width(8.dp))

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/info/SeedInfoView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/info/SeedInfoView.kt
@@ -111,7 +111,7 @@ private fun Info(text: AnnotatedString) {
     Row {
         Image(
             painterResource(co.electriccoin.zcash.ui.design.R.drawable.ic_info),
-            contentDescription = ""
+            contentDescription = null
         )
         Spacer(Modifier.width(8.dp))
         Text(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
@@ -540,7 +540,7 @@ fun SendFormAddressTextField(
                                         interactionSource = remember { MutableInteractionSource() }
                                     ),
                                 painter = painterResource(sendAddressBookState.mode.icon),
-                                contentDescription = null,
+                                contentDescription = stringResource(R.string.send_address_book_content_description),
                             )
 
                             Spacer(modifier = Modifier.width(4.dp))

--- a/ui-lib/src/main/res/ui/about/values-es/strings.xml
+++ b/ui-lib/src/main/res/ui/about/values-es/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="about_title">Acerca de</string>
     <string name="about_subtitle">Presentando Zodl</string>
+    <string name="about_overflow_menu_content_description">M�s opciones</string>
     <string name="about_version_format" formatted="true">Versión de Zodl <xliff:g example="1" id="version">%s</xliff:g></string>
     <string name="about_debug_menu_app_name">Nombre de la app:<xliff:g example="Zodl" id="app_name">%1$s</xliff:g></string>
     <string name="about_debug_menu_build">Compilación: <xliff:g example="635dac0eb9ddc2bc6da5177f0dd495d8b76af4dc" id="git_commit_hash">%1$s</xliff:g></string>

--- a/ui-lib/src/main/res/ui/about/values/strings.xml
+++ b/ui-lib/src/main/res/ui/about/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="about_version_format" formatted="true">Zodl Version <xliff:g example="1" id="version">%s</xliff:g></string>
     <string name="about_debug_menu_app_name">App name:<xliff:g example="Zodl" id="app_name">%1$s</xliff:g></string>
     <string name="about_debug_menu_build">Build: <xliff:g example="635dac0eb9ddc2bc6da5177f0dd495d8b76af4dc" id="git_commit_hash">%1$s</xliff:g></string>
+    <string name="about_overflow_menu_content_description">More options</string>
     <string name="about_description">Zodl is a Zcash-powered mobile wallet, built for unstoppable private payments.
         It’s optimized for storage and real-world use of shielded $ZEC—the truly private cryptocurrency.\n\nDeveloped by the team that set the industry standard for onchain privacy, the original developers of the Zcash protocol.
     </string>

--- a/ui-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-lib/src/main/res/ui/common/values-es/strings.xml
@@ -3,6 +3,7 @@
     <string name="back_navigation">Atrás</string>
     <string name="back_navigation_content_description">Atrás</string>
     <string name="close_navigation_content_description">Cerrar</string>
+    <string name="tooltip_close_content_description">Cerrar tooltip</string>
 
     <string name="fiat_currency_conversion_rate_unavailable">No disponible</string>
     <string name="empty_char">-</string>

--- a/ui-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-lib/src/main/res/ui/common/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="back_navigation">Back</string>
     <string name="back_navigation_content_description">Back</string>
     <string name="close_navigation_content_description">Close</string>
+    <string name="tooltip_close_content_description">Close tooltip</string>
 
     <string name="fiat_currency_conversion_rate_unavailable">Unavailable</string>
     <string name="empty_char">-</string>

--- a/ui-lib/src/main/res/ui/send/values-es/strings.xml
+++ b/ui-lib/src/main/res/ui/send/values-es/strings.xml
@@ -26,5 +26,6 @@
     <string name="send_transparent_memo">Las transacciones transparentes no pueden tener mensajes</string>
 
     <string name="send_address_book_hint">Agrega un contacto tocando el ícono de la libreta de direcciones.</string>
+    <string name="send_address_book_content_description">Abrir libreta de direcciones.</string>
 
 </resources>

--- a/ui-lib/src/main/res/ui/send/values/strings.xml
+++ b/ui-lib/src/main/res/ui/send/values/strings.xml
@@ -26,5 +26,6 @@
     <string name="send_transparent_memo">Transparent transactions can\'t have memos</string>
 
     <string name="send_address_book_hint">Add contact by tapping on Address Book icon.</string>
+    <string name="send_address_book_content_description">Open address book</string>
 
 </resources>


### PR DESCRIPTION
## Summary
Fixes missing and incorrect `contentDescription` values on several UI elements 
to improve accessibility for TalkBack users.

## Changes

### Interactive elements — were silent, now labeled
- **SendView**: address book suffix icon button
- **ZashiTooltip**: dismiss/close icon button  
- **AboutView**: overflow menu icon button (MoreVert)

### Decorative images — empty string replaced with null
- **RestoreBDDateView**, **ReceiveView**, **SeedInfoView**: 
  `contentDescription = ""` → `contentDescription = null`
  
  In Compose, `null` correctly marks an image as decorative and tells 
  TalkBack to skip it. An empty string leaves ambiguous semantics.

## Why this matters
Users who rely on TalkBack (Android's screen reader) could not interact 
with these buttons — they had no spoken label. Privacy-focused users 
are more likely to use accessibility features, so this aligns with 
Zodl's audience.

## Testing
Manually verified with TalkBack enabled on Android emulator:
- Address book button announces "Open address book"
- Tooltip close button announces "Close tooltip"  
- About overflow button announces "More options"
- Decorative icons are correctly skipped by TalkBack