### PR TITLE
fix: validate restore birthday height as integer with lower bound

### DIFF
--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/restore/height/RestoreBDHeightValidatorTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/restore/height/RestoreBDHeightValidatorTest.kt
@@ -1,0 +1,144 @@
+package co.electriccoin.zcash.ui.screen.restore.height
+
+import androidx.test.filters.SmallTest
+import co.electriccoin.zcash.ui.design.component.InnerTextFieldState
+import co.electriccoin.zcash.ui.design.component.NumberTextFieldInnerState
+import co.electriccoin.zcash.ui.design.component.TextSelection
+import co.electriccoin.zcash.ui.design.util.stringRes
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RestoreBDHeightValidatorTest {
+    @Test
+    @SmallTest
+    fun empty_input_has_no_error_and_is_not_valid() {
+        val actual = RestoreBDHeightValidator.validate(newState("", null), SAPLING_ACTIVATION_HEIGHT)
+
+        assertFalse(actual.isValid)
+        assertNull(actual.error)
+        assertNull(actual.blockHeight)
+    }
+
+    @Test
+    @SmallTest
+    fun invalid_separator_only_input_returns_integer_error() {
+        val actual = RestoreBDHeightValidator.validate(newState(".", null), SAPLING_ACTIVATION_HEIGHT)
+
+        assertEquals(RestoreBDHeightValidationError.INVALID_INTEGER, actual.error)
+        assertFalse(actual.isValid)
+    }
+
+    @Test
+    @SmallTest
+    fun decimal_input_returns_integer_error() {
+        val actual =
+            RestoreBDHeightValidator.validate(
+                newState("123.9", BigDecimal("123.9")),
+                SAPLING_ACTIVATION_HEIGHT
+            )
+
+        assertEquals(RestoreBDHeightValidationError.INVALID_INTEGER, actual.error)
+        assertFalse(actual.isValid)
+    }
+
+    @Test
+    @SmallTest
+    fun trailing_decimal_input_returns_integer_error() {
+        val actual =
+            RestoreBDHeightValidator.validate(
+                newState("123.", BigDecimal("123")),
+                SAPLING_ACTIVATION_HEIGHT
+            )
+
+        assertEquals(RestoreBDHeightValidationError.INVALID_INTEGER, actual.error)
+        assertFalse(actual.isValid)
+    }
+
+    @Test
+    @SmallTest
+    fun decimal_with_zero_fraction_returns_integer_error() {
+        val actual =
+            RestoreBDHeightValidator.validate(
+                newState("123.0", BigDecimal("123.0")),
+                SAPLING_ACTIVATION_HEIGHT
+            )
+
+        assertEquals(RestoreBDHeightValidationError.INVALID_INTEGER, actual.error)
+        assertFalse(actual.isValid)
+    }
+
+    @Test
+    @SmallTest
+    fun lower_than_sapling_activation_height_returns_minimum_error() {
+        val actual =
+            RestoreBDHeightValidator.validate(
+                newState("419199", BigDecimal("419199")),
+                SAPLING_ACTIVATION_HEIGHT
+            )
+
+        assertEquals(RestoreBDHeightValidationError.BELOW_SAPLING_ACTIVATION, actual.error)
+        assertFalse(actual.isValid)
+    }
+
+    @Test
+    @SmallTest
+    fun sapling_activation_height_is_valid() {
+        val actual =
+            RestoreBDHeightValidator.validate(
+                newState("419200", BigDecimal("419200")),
+                SAPLING_ACTIVATION_HEIGHT
+            )
+
+        assertTrue(actual.isValid)
+        assertEquals(419200L, actual.blockHeight)
+        assertNull(actual.error)
+    }
+
+    @Test
+    @SmallTest
+    fun max_long_value_is_valid() {
+        val actual =
+            RestoreBDHeightValidator.validate(
+                newState(Long.MAX_VALUE.toString(), BigDecimal(Long.MAX_VALUE)),
+                SAPLING_ACTIVATION_HEIGHT
+            )
+
+        assertTrue(actual.isValid)
+        assertEquals(Long.MAX_VALUE, actual.blockHeight)
+        assertNull(actual.error)
+    }
+
+    @Test
+    @SmallTest
+    fun larger_than_long_max_returns_integer_error() {
+        val actual =
+            RestoreBDHeightValidator.validate(
+                newState("9223372036854775808", BigDecimal("9223372036854775808")),
+                SAPLING_ACTIVATION_HEIGHT
+            )
+
+        assertEquals(RestoreBDHeightValidationError.INVALID_INTEGER, actual.error)
+        assertFalse(actual.isValid)
+    }
+
+    private fun newState(
+        inputText: String,
+        amount: BigDecimal?,
+    ) = NumberTextFieldInnerState(
+        innerTextFieldState =
+            InnerTextFieldState(
+                value = stringRes(inputText),
+                selection = TextSelection.Start
+            ),
+        amount = amount,
+        lastValidAmount = amount
+    )
+
+    private companion object {
+        private const val SAPLING_ACTIVATION_HEIGHT = 419200L
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/height/RestoreBDHeightValidator.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/height/RestoreBDHeightValidator.kt
@@ -1,0 +1,53 @@
+package co.electriccoin.zcash.ui.screen.restore.height
+
+import co.electriccoin.zcash.ui.design.component.NumberTextFieldInnerState
+import co.electriccoin.zcash.ui.design.util.StringResource
+
+internal data class RestoreBDHeightValidation(
+    val blockHeight: Long? = null,
+    val error: RestoreBDHeightValidationError? = null,
+) {
+    val isValid = blockHeight != null && error == null
+}
+
+internal enum class RestoreBDHeightValidationError {
+    INVALID_INTEGER,
+    BELOW_SAPLING_ACTIVATION
+}
+
+internal object RestoreBDHeightValidator {
+    fun validate(
+        blockHeight: NumberTextFieldInnerState,
+        saplingActivationHeight: Long
+    ): RestoreBDHeightValidation {
+        val inputText = blockHeight.inputText()
+        if (inputText.isEmpty()) {
+            return RestoreBDHeightValidation()
+        }
+
+        val amount =
+            blockHeight.amount
+                ?: return RestoreBDHeightValidation(error = RestoreBDHeightValidationError.INVALID_INTEGER)
+        if (inputText.contains('.') || inputText.contains(',')) {
+            return RestoreBDHeightValidation(error = RestoreBDHeightValidationError.INVALID_INTEGER)
+        }
+
+        val exactHeight =
+            try {
+                amount.longValueExact()
+            } catch (_: ArithmeticException) {
+                return RestoreBDHeightValidation(error = RestoreBDHeightValidationError.INVALID_INTEGER)
+            }
+
+        return if (exactHeight < saplingActivationHeight) {
+            RestoreBDHeightValidation(
+                error = RestoreBDHeightValidationError.BELOW_SAPLING_ACTIVATION
+            )
+        } else {
+            RestoreBDHeightValidation(blockHeight = exactHeight)
+        }
+    }
+}
+
+private fun NumberTextFieldInnerState.inputText(): String =
+    (innerTextFieldState.value as? StringResource.ByString)?.value.orEmpty()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/height/RestoreHeightVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/restore/height/RestoreHeightVM.kt
@@ -12,6 +12,7 @@ import co.electriccoin.zcash.ui.design.component.IconButtonState
 import co.electriccoin.zcash.ui.design.component.NumberTextFieldInnerState
 import co.electriccoin.zcash.ui.design.component.NumberTextFieldState
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.util.stringResByNumber
 import co.electriccoin.zcash.ui.screen.common.BlockHeightState
 import co.electriccoin.zcash.ui.screen.restore.date.RestoreDateArgs
 import co.electriccoin.zcash.ui.screen.restore.info.SeedInfo
@@ -28,6 +29,7 @@ class RestoreHeightVM(
     private val restoreHeight: RestoreHeight,
     private val navigationRouter: NavigationRouter,
 ) : ViewModel() {
+    private val saplingActivationHeight = VersionInfo.NETWORK.saplingActivationHeight.value
     private val blockHeightText = MutableStateFlow(NumberTextFieldInnerState())
 
     val state: StateFlow<BlockHeightState> =
@@ -41,14 +43,7 @@ class RestoreHeightVM(
             )
 
     private fun createState(blockHeight: NumberTextFieldInnerState): BlockHeightState {
-        val isHigherThanSaplingActivationHeight =
-            blockHeight
-                .amount
-                ?.let {
-                    it.toLong() >= VersionInfo.NETWORK.saplingActivationHeight.value
-                }
-                ?: false
-        val isValid = !blockHeight.innerTextFieldState.value.isEmpty() && isHigherThanSaplingActivationHeight
+        val validation = RestoreBDHeightValidator.validate(blockHeight, saplingActivationHeight)
 
         return BlockHeightState(
             title = stringRes(R.string.restore_title),
@@ -63,21 +58,33 @@ class RestoreHeightVM(
                 ButtonState(
                     stringRes(R.string.restore_bd_restore_btn),
                     onClick = ::onRestoreClick,
-                    isEnabled = isValid,
+                    isEnabled = validation.isValid,
                     hapticFeedbackType = HapticFeedbackType.Confirm
                 ),
-            secondaryButton = ButtonState(stringRes(R.string.restore_bd_height_btn), onClick = ::onEstimateClick),
-            blockHeight = NumberTextFieldState(innerState = blockHeight, onValueChange = ::onValueChanged)
+            secondaryButton =
+                ButtonState(
+                    stringRes(R.string.restore_bd_height_btn),
+                    onClick = ::onEstimateClick
+                ),
+            blockHeight =
+                NumberTextFieldState(
+                    innerState = blockHeight,
+                    explicitError = validation.asErrorString(),
+                    onValueChange = ::onValueChanged
+                )
         )
     }
 
     private fun onEstimateClick() = navigationRouter.forward(RestoreDateArgs(seed = restoreHeight.seed))
 
     private fun onRestoreClick() {
+        val validation = RestoreBDHeightValidator.validate(blockHeightText.value, saplingActivationHeight)
+        val validBlockHeight = validation.blockHeight ?: return
+
         navigationRouter.forward(
             RestoreTorArgs(
                 seed = restoreHeight.seed.trim(),
-                blockHeight = blockHeightText.value.amount?.toLong() ?: return
+                blockHeight = validBlockHeight
             )
         )
     }
@@ -87,4 +94,15 @@ class RestoreHeightVM(
     private fun onInfoButtonClick() = navigationRouter.forward(SeedInfo)
 
     private fun onValueChanged(state: NumberTextFieldInnerState) = blockHeightText.update { state }
+
+    private fun RestoreBDHeightValidation.asErrorString() =
+        when (error) {
+            null -> null
+            RestoreBDHeightValidationError.INVALID_INTEGER -> stringRes(R.string.restore_bd_text_field_error_integer)
+            RestoreBDHeightValidationError.BELOW_SAPLING_ACTIVATION ->
+                stringRes(
+                    R.string.restore_bd_text_field_error_minimum,
+                    stringResByNumber(saplingActivationHeight, minDecimals = 0)
+                )
+        }
 }

--- a/ui-lib/src/main/res/ui/restore/values-es/strings.xml
+++ b/ui-lib/src/main/res/ui/restore/values-es/strings.xml
@@ -1,45 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="restore_title">Restaurar</string>
-    <string name="restore_subtitle">Frase de Recuperación</string>
-    <string name="restore_message">Por favor, ingresa tu frase secreta de recuperación de 24 palabras en el orden correcto.</string>
+    <string name="restore_subtitle">Frase de RecuperaciÃ³n</string>
+    <string name="restore_message">Por favor, ingresa tu frase secreta de recuperaciÃ³n de 24 palabras en el orden correcto.</string>
     <string name="restore_button">Siguiente</string>
 
-    <string name="restore_dialog_title">¿Necesitas más información?</string>
-    <string name="restore_dialog_message_1_bold_part">La Frase Secreta de Recuperación</string>
-    <string name="restore_dialog_message_1">es un conjunto único de 24 palabras que aparecen en un orden preciso. Puede usarse para obtener control total de tus fondos desde cualquier dispositivo a través de cualquier app de billetera Zcash. Piénsala como la llave maestra de tu billetera. Está guardada en la Configuración Avanzada de Zodl.</string>
-    <string name="restore_dialog_message_2_bold_part">La Altura de Cumpleaños de la Billetera</string>
-    <string name="restore_dialog_message_2">es la altura de bloque (número de bloque en la cadena de bloques) en la que se creó tu billetera. Si alguna vez pierdes acceso a tu app de Zodl y necesitas recuperar tus fondos, proporcionar esta altura junto con tu frase de recuperación puede acelerar significativamente el proceso.</string>
+    <string name="restore_dialog_title">Â¿Necesitas mÃ¡s informaciÃ³n?</string>
+    <string name="restore_dialog_message_1_bold_part">La Frase Secreta de RecuperaciÃ³n</string>
+    <string name="restore_dialog_message_1">es un conjunto Ãºnico de 24 palabras que aparecen en un orden preciso. Puede usarse para obtener control total de tus fondos desde cualquier dispositivo a travÃ©s de cualquier app de billetera Zcash. PiÃ©nsala como la llave maestra de tu billetera. EstÃ¡ guardada en la ConfiguraciÃ³n Avanzada de Zodl.</string>
+    <string name="restore_dialog_message_2_bold_part">La Altura de CumpleaÃ±os de la Billetera</string>
+    <string name="restore_dialog_message_2">es la altura de bloque (nÃºmero de bloque en la cadena de bloques) en la que se creÃ³ tu billetera. Si alguna vez pierdes acceso a tu app de Zodl y necesitas recuperar tus fondos, proporcionar esta altura junto con tu frase de recuperaciÃ³n puede acelerar significativamente el proceso.</string>
 
     <string name="restore_bd_height_btn">Estimar mi altura de bloque</string>
     <string name="restore_bd_restore_btn">Restaurar</string>
 
-    <string name="restore_bd_date_message">Decide hasta dónde debe escanear Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior.</string>
+    <string name="restore_bd_date_message">Decide hasta dÃ³nde debe escanear Zodl. Ingresa una fecha anterior a tu primera transacciÃ³n recibida. Si no estÃ¡s seguro/a, elige una fecha anterior.</string>
+    <string name="restore_bd_text_field_error_integer">Ingresa una altura de bloque entera.</string>
+    <string name="restore_bd_text_field_error_minimum">Ingresa una altura de bloque de %1$s o superior.</string>
 
     <string name="restore_bd_estimation_restore">Restaurar</string>
 
-    <string name="restore_seed_warning_suggestions">Esta palabra no está en el diccionario de frases de recuperación. Por favor selecciona la correcta de las sugerencias.</string>
+    <string name="restore_seed_warning_suggestions">Esta palabra no estÃ¡ en el diccionario de frases de recuperaciÃ³n. Por favor selecciona la correcta de las sugerencias.</string>
 
-    <string name="restore_tor_title">Habilitar Protección Tor</string>
-    <string name="restore_tor_subtitle">Si Tor está disponible en tu región, recomendamos habilitarlo para una mayor privacidad durante la restauración de la billetera. Este paso es completamente opcional.</string>
-    <string name="restore_tor_checkbox_title">Habilitar Protección Tor</string>
-    <string name="restore_tor_checkbox_subtitle">Redirige tu conexión a través de la red Tor para mayor anonimato y protección de privacidad.</string>
+    <string name="restore_tor_title">Habilitar ProtecciÃ³n Tor</string>
+    <string name="restore_tor_subtitle">Si Tor estÃ¡ disponible en tu regiÃ³n, recomendamos habilitarlo para una mayor privacidad durante la restauraciÃ³n de la billetera. Este paso es completamente opcional.</string>
+    <string name="restore_tor_checkbox_title">Habilitar ProtecciÃ³n Tor</string>
+    <string name="restore_tor_checkbox_subtitle">Redirige tu conexiÃ³n a travÃ©s de la red Tor para mayor anonimato y protecciÃ³n de privacidad.</string>
 
     <string name="resync_title">Resincronizar Billetera</string>
-    <string name="resync_bd_date_message">Decide hasta dónde debe resincronizarse Zodl. Ingresa una fecha anterior a tu primera transacción recibida. Si no estás seguro/a, elige una fecha anterior.</string>
+    <string name="resync_bd_date_message">Decide hasta dÃ³nde debe resincronizarse Zodl. Ingresa una fecha anterior a tu primera transacciÃ³n recibida. Si no estÃ¡s seguro/a, elige una fecha anterior.</string>
 
-    <string name="resync_bd_estimation_message">Tu billetera se resincronizará desde %1$s (%2$s bloques). Zodl escaneará y recuperará todas las transacciones realizadas después del siguiente número de bloque.</string>
+    <string name="resync_bd_estimation_message">Tu billetera se resincronizarÃ¡ desde %1$s (%2$s bloques). Zodl escanearÃ¡ y recuperarÃ¡ todas las transacciones realizadas despuÃ©s del siguiente nÃºmero de bloque.</string>
 
-    <string name="confirm_resync_title">Confirmar Resincronización</string>
-    <string name="confirm_resync_subtitle">Resincroniza la billetera actual sin restablecer la app. Esto puede usarse para solucionar problemas que normalmente requerirían restaurar tu billetera como corregir tu balance de Keystone.</string>
-    <string name="confirm_resync_message">A menos que especifiques lo contrario a continuación, Zodl se resincronizará desde la fecha mostrada.</string>
-    <string name="confirm_resync_info">Tu billetera se resincronizará desde %1$s (%2$s bloques). Usa el botón de abajo si deseas cambiarlo.</string>
+    <string name="confirm_resync_title">Confirmar ResincronizaciÃ³n</string>
+    <string name="confirm_resync_subtitle">Resincroniza la billetera actual sin restablecer la app. Esto puede usarse para solucionar problemas que normalmente requerirÃ­an restaurar tu billetera como corregir tu balance de Keystone.</string>
+    <string name="confirm_resync_message">A menos que especifiques lo contrario a continuaciÃ³n, Zodl se resincronizarÃ¡ desde la fecha mostrada.</string>
+    <string name="confirm_resync_info">Tu billetera se resincronizarÃ¡ desde %1$s (%2$s bloques). Usa el botÃ³n de abajo si deseas cambiarlo.</string>
     <string name="confirm_resync_change">Cambiar</string>
     <string name="confirm_resync_confirm">Confirmar</string>
 
-<string name="resync_wbh_confirm_button">Confirmar</string>
+    <string name="resync_wbh_confirm_button">Confirmar</string>
 
-    <string name="resync_confirm_failed_title">Error de resincronización</string>
-    <string name="resync_confirm_failed_message">No se pudo completar la resincronización de la billetera. Inténtalo de nuevo o informa del problema.</string>
-
+    <string name="resync_confirm_failed_title">Error de resincronizaciÃ³n</string>
+    <string name="resync_confirm_failed_message">No se pudo completar la resincronizaciÃ³n de la billetera. IntÃ©ntalo de nuevo o informa del problema.</string>
 </resources>

--- a/ui-lib/src/main/res/ui/restore/values/strings.xml
+++ b/ui-lib/src/main/res/ui/restore/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="restore_dialog_message_1_bold_part">The Secret Recovery Phrase</string>
     <string name="restore_dialog_message_1">is a unique set of 24 words, appearing in a
         precise order. It can be used to gain full control of your funds from any device via any Zcash wallet app.
-        Think of it as the master key to your wallet. It is stored in Zodl’s Advanced Settings.</string>
+        Think of it as the master key to your wallet. It is stored in Zodlâ€™s Advanced Settings.</string>
     <string name="restore_dialog_message_2_bold_part">The Wallet Birthday Height</string>
     <string name="restore_dialog_message_2">is the block height (block # in the
         blockchain) at which your wallet was created. If you ever lose access to your Zodl app and need to recover
@@ -19,7 +19,9 @@
     <string name="restore_bd_height_btn">Estimate my block height</string>
     <string name="restore_bd_restore_btn">Restore</string>
 
-    <string name="restore_bd_date_message">Decide how far Zodl should scan. Enter a date before your first received transaction. If you\’re not sure, choose an earlier date.</string>
+    <string name="restore_bd_date_message">Decide how far Zodl should scan. Enter a date before your first received transaction. If you\â€™re not sure, choose an earlier date.</string>
+    <string name="restore_bd_text_field_error_integer">Enter a whole block height.</string>
+    <string name="restore_bd_text_field_error_minimum">Enter a block height of %1$s or higher.</string>
 
     <string name="restore_bd_estimation_restore">Restore</string>
 
@@ -46,6 +48,6 @@
     <string name="resync_wbh_confirm_button">Confirm</string>
 
     <string name="resync_confirm_failed_title">Resync Failed</string>
-    <string name="resync_confirm_failed_message">Resync of the wallet couldn’t be finalized. Please try again or report an issue.</string>
+    <string name="resync_confirm_failed_message">Resync of the wallet couldnâ€™t be finalized. Please try again or report an issue.</string>
 
 </resources>


### PR DESCRIPTION
## Summary

This change hardens birthday height validation in the restore flow.

## Problem

The restore birthday height screen accepted user input as `BigDecimal` and converted it with `toLong()`. That left a few bad cases:

- decimal values could be interpreted incorrectly instead of being rejected
- very large values could fail conversion in an unsafe way
- invalid input did not surface a clear user-facing error
- values below `saplingActivationHeight` were not explained well to the user

## Solution

This PR:

- adds a dedicated birthday height validator
- accepts only whole-number input
- uses exact long conversion so fractional and overflow values are rejected
- enforces the lower bound at `saplingActivationHeight`
- shows explicit error text in the restore birthday height field
- adds tests for empty input, separator-only input, decimal input, lower bound, boundary values, and overflow

## Notes

- upper-bound validation against the current network height is intentionally left out to keep this PR small and focused
- tests were added, but local execution may depend on Java/Android environment availability
