### PR TITLE
[#2177] Add birthday height picker to Keystone import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added:
+- We added a wallet birthday height picker to the Keystone hardware wallet import flow.
+
 ## [3.2.1 (1605)] - 2025-03-28
 
 ### Added:

--- a/ui-lib/build.gradle.kts
+++ b/ui-lib/build.gradle.kts
@@ -210,6 +210,10 @@ dependencies {
 
     api(libs.keystone)
 
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.navigation.compose)
+
     androidTestImplementation(projects.testLib)
     androidTestImplementation(libs.bundles.androidx.test)
     androidTestImplementation(libs.androidx.compose.test.junit)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/ViewModelModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/ViewModelModule.kt
@@ -56,6 +56,9 @@ import co.electriccoin.zcash.ui.screen.scan.ScanZashiAddressVM
 import co.electriccoin.zcash.ui.screen.scan.thirdparty.ThirdPartyScanViewModel
 import co.electriccoin.zcash.ui.screen.scankeystone.viewmodel.ScanKeystonePCZTViewModel
 import co.electriccoin.zcash.ui.screen.scankeystone.viewmodel.ScanKeystoneSignInRequestViewModel
+import co.electriccoin.zcash.ui.screen.keystonebirthday.date.KeystoneBDDateVM
+import co.electriccoin.zcash.ui.screen.keystonebirthday.estimation.KeystoneBDEstimationVM
+import co.electriccoin.zcash.ui.screen.keystonebirthday.height.KeystoneBDHeightVM
 import co.electriccoin.zcash.ui.screen.selectkeystoneaccount.viewmodel.SelectKeystoneAccountViewModel
 import co.electriccoin.zcash.ui.screen.send.SendViewModel
 import co.electriccoin.zcash.ui.screen.signkeystonetransaction.SignKeystoneTransactionVM
@@ -116,6 +119,9 @@ val viewModelModule =
         viewModelOf(::AccountListVM)
         viewModelOf(::ZashiTopAppBarVM)
         viewModelOf(::SelectKeystoneAccountViewModel)
+        viewModelOf(::KeystoneBDHeightVM)
+        viewModelOf(::KeystoneBDDateVM)
+        viewModelOf(::KeystoneBDEstimationVM)
         viewModelOf(::ReviewTransactionVM)
         viewModelOf(::TransactionFiltersVM)
         viewModelOf(::TransactionProgressVM)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/WalletNavGraph.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/WalletNavGraph.kt
@@ -118,6 +118,12 @@ import co.electriccoin.zcash.ui.screen.scankeystone.ScanKeystonePCZTRequest
 import co.electriccoin.zcash.ui.screen.scankeystone.ScanKeystoneSignInRequest
 import co.electriccoin.zcash.ui.screen.scankeystone.WrapScanKeystonePCZTRequest
 import co.electriccoin.zcash.ui.screen.scankeystone.WrapScanKeystoneSignInRequest
+import co.electriccoin.zcash.ui.screen.keystonebirthday.date.KeystoneBDDateArgs
+import co.electriccoin.zcash.ui.screen.keystonebirthday.date.KeystoneBDDateScreen
+import co.electriccoin.zcash.ui.screen.keystonebirthday.estimation.KeystoneBDEstimationArgs
+import co.electriccoin.zcash.ui.screen.keystonebirthday.estimation.KeystoneBDEstimationScreen
+import co.electriccoin.zcash.ui.screen.keystonebirthday.height.KeystoneBDHeightArgs
+import co.electriccoin.zcash.ui.screen.keystonebirthday.height.KeystoneBDHeightScreen
 import co.electriccoin.zcash.ui.screen.selectkeystoneaccount.AndroidSelectKeystoneAccount
 import co.electriccoin.zcash.ui.screen.selectkeystoneaccount.SelectKeystoneAccount
 import co.electriccoin.zcash.ui.screen.send.Send
@@ -233,6 +239,9 @@ fun NavGraphBuilder.walletNavGraph(
         }
         composable<ConnectKeystoneArgs> { ConnectKeystoneScreen() }
         composable<SelectKeystoneAccount> { AndroidSelectKeystoneAccount(it.toRoute()) }
+        composable<KeystoneBDHeightArgs> { KeystoneBDHeightScreen(it.toRoute()) }
+        composable<KeystoneBDDateArgs> { KeystoneBDDateScreen(it.toRoute()) }
+        composable<KeystoneBDEstimationArgs> { KeystoneBDEstimationScreen(it.toRoute()) }
         composable<ReviewTransactionArgs> { AndroidReviewTransaction() }
         composable<TransactionProgressArgs> { TransactionProgressScreen(it.toRoute()) }
         composable<ActivityHistoryArgs> { ActivityHistoryScreen() }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.AccountImportSetup
 import cash.z.ecc.android.sdk.model.AccountPurpose
+import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.UnifiedAddressRequest
 import cash.z.ecc.android.sdk.model.UnifiedFullViewingKey
@@ -66,7 +67,7 @@ interface AccountDataSource {
 
     suspend fun selectAccount(account: WalletAccount)
 
-    suspend fun importKeystoneAccount(ufvk: String, seedFingerprint: String, index: Long): Account
+    suspend fun importKeystoneAccount(ufvk: String, seedFingerprint: String, index: Long, birthdayHeight: Long? = null): Account
 
     suspend fun requestNextShieldedAddress()
 
@@ -160,7 +161,8 @@ class AccountDataSourceImpl(
     override suspend fun importKeystoneAccount(
         ufvk: String,
         seedFingerprint: String,
-        index: Long
+        index: Long,
+        birthdayHeight: Long?
     ): Account =
         withContext(Dispatchers.IO) {
             synchronizerProvider
@@ -174,7 +176,8 @@ class AccountDataSourceImpl(
                             AccountPurpose.Spending(
                                 seedFingerprint = seedFingerprint.hexToByteArray(),
                                 zip32AccountIndex = Zip32AccountIndex.new(index)
-                            )
+                            ),
+                        birthdayHeight = birthdayHeight?.let { BlockHeight.new(it) }
                     ),
                 )
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateKeystoneAccountUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateKeystoneAccountUseCase.kt
@@ -13,13 +13,15 @@ class CreateKeystoneAccountUseCase(
     @Throws(InitializeException.ImportAccountException::class)
     suspend operator fun invoke(
         accounts: ZcashAccounts,
-        account: ZcashAccount
+        account: ZcashAccount,
+        birthdayHeight: Long? = null
     ) {
         val createdAccount =
             accountDataSource.importKeystoneAccount(
                 ufvk = account.ufvk,
                 seedFingerprint = accounts.seedFingerprint,
-                index = account.index.toLong()
+                index = account.index.toLong(),
+                birthdayHeight = birthdayHeight
             )
         accountDataSource.selectAccount(createdAccount)
         navigationRouter.backToRoot()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/date/KeystoneBDDateArgs.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/date/KeystoneBDDateArgs.kt
@@ -1,0 +1,9 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.date
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KeystoneBDDateArgs(
+    val ur: String,
+    val accountIndex: Int
+)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/date/KeystoneBDDateScreen.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/date/KeystoneBDDateScreen.kt
@@ -1,0 +1,17 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.date
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.electriccoin.zcash.ui.screen.restore.date.RestoreBDDateView
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@Composable
+fun KeystoneBDDateScreen(args: KeystoneBDDateArgs) {
+    val vm = koinViewModel<KeystoneBDDateVM> { parametersOf(args) }
+    val state by vm.state.collectAsStateWithLifecycle()
+    BackHandler(enabled = state != null) { state?.onBack?.invoke() }
+    state?.let { RestoreBDDateView(it) }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/date/KeystoneBDDateVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/date/KeystoneBDDateVM.kt
@@ -1,0 +1,94 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.date
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cash.z.ecc.android.sdk.SdkSynchronizer
+import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.model.VersionInfo
+import co.electriccoin.zcash.ui.design.component.ButtonState
+import co.electriccoin.zcash.ui.design.component.IconButtonState
+import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.screen.keystonebirthday.estimation.KeystoneBDEstimationArgs
+import co.electriccoin.zcash.ui.screen.restore.date.RestoreBDDateState
+import co.electriccoin.zcash.ui.screen.restore.info.SeedInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.YearMonth
+import java.time.ZoneId
+import kotlin.time.toKotlinInstant
+
+class KeystoneBDDateVM(
+    private val args: KeystoneBDDateArgs,
+    private val navigationRouter: NavigationRouter,
+    private val application: Application,
+) : ViewModel() {
+    @Suppress("MagicNumber")
+    private val selection = MutableStateFlow<YearMonth>(YearMonth.of(2018, 10))
+
+    val state: StateFlow<RestoreBDDateState?> =
+        selection
+            .map {
+                createState(it)
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
+                initialValue = createState(selection.value)
+            )
+
+    private fun createState(selection: YearMonth) =
+        RestoreBDDateState(
+            title = stringRes(R.string.restore_title),
+            subtitle = stringRes(R.string.restore_bd_date_subtitle),
+            message = stringRes(R.string.restore_bd_date_message),
+            note = stringRes(R.string.restore_bd_date_note),
+            next = ButtonState(stringRes(R.string.restore_bd_height_btn), onClick = ::onEstimateClick),
+            dialogButton =
+                IconButtonState(
+                    icon = R.drawable.ic_help,
+                    onClick = ::onInfoButtonClick,
+                ),
+            onBack = ::onBack,
+            onYearMonthChange = ::onYearMonthChange,
+            selection = selection
+        )
+
+    private fun onEstimateClick() {
+        viewModelScope.launch {
+            val instant =
+                selection.value
+                    .atDay(1)
+                    .atStartOfDay()
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()
+                    .toKotlinInstant()
+            val bday =
+                SdkSynchronizer.estimateBirthdayHeight(
+                    context = application,
+                    date = instant,
+                    network = VersionInfo.NETWORK
+                )
+            navigationRouter.forward(
+                KeystoneBDEstimationArgs(
+                    ur = args.ur,
+                    accountIndex = args.accountIndex,
+                    blockHeight = bday.value
+                )
+            )
+        }
+    }
+
+    private fun onBack() = navigationRouter.back()
+
+    private fun onInfoButtonClick() = navigationRouter.forward(SeedInfo)
+
+    private fun onYearMonthChange(yearMonth: YearMonth) = selection.update { yearMonth }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/estimation/KeystoneBDEstimationArgs.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/estimation/KeystoneBDEstimationArgs.kt
@@ -1,0 +1,10 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.estimation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KeystoneBDEstimationArgs(
+    val ur: String,
+    val accountIndex: Int,
+    val blockHeight: Long
+)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/estimation/KeystoneBDEstimationScreen.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/estimation/KeystoneBDEstimationScreen.kt
@@ -1,0 +1,17 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.estimation
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.electriccoin.zcash.ui.screen.restore.estimation.RestoreBDEstimationView
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@Composable
+fun KeystoneBDEstimationScreen(args: KeystoneBDEstimationArgs) {
+    val vm = koinViewModel<KeystoneBDEstimationVM> { parametersOf(args) }
+    val state by vm.state.collectAsStateWithLifecycle()
+    BackHandler { state.onBack() }
+    RestoreBDEstimationView(state)
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/estimation/KeystoneBDEstimationVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/estimation/KeystoneBDEstimationVM.kt
@@ -1,0 +1,96 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.estimation
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cash.z.ecc.android.sdk.exception.InitializeException
+import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.usecase.CopyToClipboardUseCase
+import co.electriccoin.zcash.ui.common.usecase.CreateKeystoneAccountUseCase
+import co.electriccoin.zcash.ui.common.usecase.ParseKeystoneUrToZashiAccountsUseCase
+import co.electriccoin.zcash.ui.design.component.ButtonState
+import co.electriccoin.zcash.ui.design.component.IconButtonState
+import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.util.stringResByNumber
+import co.electriccoin.zcash.ui.screen.restore.estimation.RestoreBDEstimationState
+import co.electriccoin.zcash.ui.screen.restore.info.SeedInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class KeystoneBDEstimationVM(
+    private val args: KeystoneBDEstimationArgs,
+    private val navigationRouter: NavigationRouter,
+    private val copyToClipboard: CopyToClipboardUseCase,
+    private val createKeystoneAccount: CreateKeystoneAccountUseCase,
+    private val parseKeystoneUrToZashiAccounts: ParseKeystoneUrToZashiAccountsUseCase,
+) : ViewModel() {
+    private val isImporting = MutableStateFlow(false)
+
+    val state: StateFlow<RestoreBDEstimationState> =
+        isImporting
+            .map { createState(it) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.Eagerly,
+                initialValue = createState(false)
+            )
+
+    private fun createState(isImporting: Boolean) =
+        RestoreBDEstimationState(
+            title = stringRes(R.string.restore_title),
+            subtitle = stringRes(R.string.restore_bd_estimation_subtitle),
+            message = stringRes(R.string.restore_bd_estimation_message),
+            dialogButton =
+                IconButtonState(
+                    icon = R.drawable.ic_help,
+                    onClick = ::onInfoButtonClick,
+                ),
+            onBack = ::onBack,
+            text = stringResByNumber(args.blockHeight, 0),
+            copy =
+                ButtonState(
+                    text = stringRes(R.string.restore_bd_estimation_copy),
+                    icon = R.drawable.ic_copy,
+                    onClick = ::onCopyClick
+                ),
+            restore =
+                ButtonState(
+                    text = stringRes(R.string.restore_bd_estimation_restore),
+                    onClick = ::onRestoreClick,
+                    isEnabled = !isImporting,
+                    isLoading = isImporting,
+                    hapticFeedbackType = HapticFeedbackType.Confirm
+                ),
+        )
+
+    private fun onCopyClick() {
+        copyToClipboard(value = args.blockHeight.toString())
+    }
+
+    private fun onRestoreClick() {
+        viewModelScope.launch {
+            if (isImporting.value) return@launch
+            try {
+                isImporting.update { true }
+                val accounts = parseKeystoneUrToZashiAccounts(args.ur)
+                val account = accounts.accounts[args.accountIndex]
+                createKeystoneAccount(accounts, account, birthdayHeight = args.blockHeight)
+            } catch (e: InitializeException.ImportAccountException) {
+                Twig.error(e) { "Error importing keystone account" }
+            } finally {
+                isImporting.update { false }
+            }
+        }
+    }
+
+    private fun onBack() = navigationRouter.back()
+
+    private fun onInfoButtonClick() = navigationRouter.forward(SeedInfo)
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/height/KeystoneBDHeightArgs.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/height/KeystoneBDHeightArgs.kt
@@ -1,0 +1,9 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.height
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KeystoneBDHeightArgs(
+    val ur: String,
+    val accountIndex: Int
+)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/height/KeystoneBDHeightScreen.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/height/KeystoneBDHeightScreen.kt
@@ -1,0 +1,17 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.height
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.electriccoin.zcash.ui.screen.restore.height.RestoreBDHeightView
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@Composable
+fun KeystoneBDHeightScreen(args: KeystoneBDHeightArgs) {
+    val vm = koinViewModel<KeystoneBDHeightVM> { parametersOf(args) }
+    val state by vm.state.collectAsStateWithLifecycle()
+    BackHandler { state.onBack() }
+    RestoreBDHeightView(state)
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/height/KeystoneBDHeightVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keystonebirthday/height/KeystoneBDHeightVM.kt
@@ -1,0 +1,114 @@
+package co.electriccoin.zcash.ui.screen.keystonebirthday.height
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cash.z.ecc.android.sdk.exception.InitializeException
+import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
+import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.model.VersionInfo
+import co.electriccoin.zcash.ui.common.usecase.CreateKeystoneAccountUseCase
+import co.electriccoin.zcash.ui.common.usecase.ParseKeystoneUrToZashiAccountsUseCase
+import co.electriccoin.zcash.ui.design.component.ButtonState
+import co.electriccoin.zcash.ui.design.component.IconButtonState
+import co.electriccoin.zcash.ui.design.component.NumberTextFieldInnerState
+import co.electriccoin.zcash.ui.design.component.NumberTextFieldState
+import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.screen.keystonebirthday.date.KeystoneBDDateArgs
+import co.electriccoin.zcash.ui.screen.restore.height.RestoreBDHeightState
+import co.electriccoin.zcash.ui.screen.restore.info.SeedInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class KeystoneBDHeightVM(
+    private val args: KeystoneBDHeightArgs,
+    private val navigationRouter: NavigationRouter,
+    private val createKeystoneAccount: CreateKeystoneAccountUseCase,
+    private val parseKeystoneUrToZashiAccounts: ParseKeystoneUrToZashiAccountsUseCase,
+) : ViewModel() {
+    private val blockHeightText = MutableStateFlow(NumberTextFieldInnerState())
+    private val isImporting = MutableStateFlow(false)
+
+    val state: StateFlow<RestoreBDHeightState> =
+        combine(blockHeightText, isImporting) { text, importing ->
+            createState(text, importing)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
+            initialValue = createState(blockHeightText.value, false)
+        )
+
+    private fun createState(
+        blockHeight: NumberTextFieldInnerState,
+        isImporting: Boolean
+    ): RestoreBDHeightState {
+        val isHigherThanSaplingActivationHeight =
+            blockHeight
+                .amount
+                ?.let {
+                    it.toLong() >= VersionInfo.NETWORK.saplingActivationHeight.value
+                }
+                ?: false
+        val isValid = !blockHeight.innerTextFieldState.value.isEmpty() && isHigherThanSaplingActivationHeight
+
+        return RestoreBDHeightState(
+            title = stringRes(R.string.restore_title),
+            subtitle = stringRes(R.string.restore_bd_subtitle),
+            message = stringRes(R.string.restore_bd_message),
+            textFieldTitle = stringRes(R.string.restore_bd_text_field_title),
+            textFieldHint = stringRes(R.string.restore_bd_text_field_hint),
+            textFieldNote = stringRes(R.string.restore_bd_text_field_note),
+            onBack = ::onBack,
+            dialogButton =
+                IconButtonState(
+                    icon = R.drawable.ic_help,
+                    onClick = ::onInfoButtonClick,
+                ),
+            restore =
+                ButtonState(
+                    stringRes(R.string.restore_bd_restore_btn),
+                    onClick = ::onRestoreClick,
+                    isEnabled = isValid && !isImporting,
+                    isLoading = isImporting,
+                    hapticFeedbackType = HapticFeedbackType.Confirm
+                ),
+            estimate = ButtonState(stringRes(R.string.restore_bd_height_btn), onClick = ::onEstimateClick),
+            blockHeight = NumberTextFieldState(innerState = blockHeight, onValueChange = ::onValueChanged)
+        )
+    }
+
+    private fun onEstimateClick() {
+        navigationRouter.forward(KeystoneBDDateArgs(ur = args.ur, accountIndex = args.accountIndex))
+    }
+
+    private fun onRestoreClick() {
+        viewModelScope.launch {
+            if (isImporting.value) return@launch
+            try {
+                isImporting.update { true }
+                val accounts = parseKeystoneUrToZashiAccounts(args.ur)
+                val account = accounts.accounts[args.accountIndex]
+                val height = blockHeightText.value.amount?.toLong() ?: return@launch
+                createKeystoneAccount(accounts, account, birthdayHeight = height)
+            } catch (e: InitializeException.ImportAccountException) {
+                Twig.error(e) { "Error importing keystone account" }
+            } finally {
+                isImporting.update { false }
+            }
+        }
+    }
+
+    private fun onBack() = navigationRouter.back()
+
+    private fun onInfoButtonClick() = navigationRouter.forward(SeedInfo)
+
+    private fun onValueChanged(state: NumberTextFieldInnerState) = blockHeightText.update { state }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/selectkeystoneaccount/viewmodel/SelectKeystoneAccountViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/selectkeystoneaccount/viewmodel/SelectKeystoneAccountViewModel.kt
@@ -3,17 +3,15 @@ package co.electriccoin.zcash.ui.screen.selectkeystoneaccount.viewmodel
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
-import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.NavigationRouter
-import co.electriccoin.zcash.ui.common.usecase.CreateKeystoneAccountUseCase
 import co.electriccoin.zcash.ui.common.usecase.DeriveKeystoneAccountUnifiedAddressUseCase
 import co.electriccoin.zcash.ui.common.usecase.ParseKeystoneUrToZashiAccountsUseCase
 import co.electriccoin.zcash.ui.design.R
 import co.electriccoin.zcash.ui.design.component.ButtonState
 import co.electriccoin.zcash.ui.design.component.listitem.checkbox.ZashiExpandedCheckboxListItemState
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.screen.keystonebirthday.height.KeystoneBDHeightArgs
 import co.electriccoin.zcash.ui.screen.selectkeystoneaccount.SelectKeystoneAccount
 import co.electriccoin.zcash.ui.screen.selectkeystoneaccount.model.SelectKeystoneAccountState
 import com.keystone.module.ZcashAccount
@@ -22,16 +20,13 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
 class SelectKeystoneAccountViewModel(
-    args: SelectKeystoneAccount,
+    private val args: SelectKeystoneAccount,
     parseKeystoneUrToZashiAccounts: ParseKeystoneUrToZashiAccountsUseCase,
-    private val createKeystoneAccount: CreateKeystoneAccountUseCase,
     private val deriveKeystoneAccountUnifiedAddress: DeriveKeystoneAccountUnifiedAddressUseCase,
     private val navigationRouter: NavigationRouter,
 ) : ViewModel() {
@@ -39,14 +34,10 @@ class SelectKeystoneAccountViewModel(
 
     private val selectedAccount = MutableStateFlow<ZcashAccount?>(null)
 
-    private val isCreatingAccount = MutableStateFlow(false)
-
     @OptIn(ExperimentalCoroutinesApi::class)
     val state =
-        combine(isCreatingAccount, selectedAccount) { isCreatingAccount, selection ->
-            isCreatingAccount to selection
-        }.mapLatest { (isCreatingAccount, selection) ->
-            createState(selection, isCreatingAccount)
+        selectedAccount.mapLatest { selection ->
+            createState(selection)
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
@@ -55,7 +46,6 @@ class SelectKeystoneAccountViewModel(
 
     private suspend fun createState(
         selection: ZcashAccount?,
-        isCreatingAccount: Boolean
     ): SelectKeystoneAccountState =
         SelectKeystoneAccountState(
             onBackClick = ::onBackClick,
@@ -76,7 +66,6 @@ class SelectKeystoneAccountViewModel(
                         }
                     },
                     isEnabled = selection != null,
-                    isLoading = isCreatingAccount,
                     hapticFeedbackType = HapticFeedbackType.Confirm
                 ),
             negativeButtonState =
@@ -113,30 +102,20 @@ class SelectKeystoneAccountViewModel(
     }
 
     private fun onBackClick() {
-        if (!isCreatingAccount.value) {
-            navigationRouter.backToRoot()
-        }
+        navigationRouter.backToRoot()
     }
 
     private fun onUnlockClick(
         accounts: ZcashAccounts,
         account: ZcashAccount
-    ) = viewModelScope.launch {
-        if (isCreatingAccount.value) return@launch
-
-        try {
-            isCreatingAccount.update { true }
-            createKeystoneAccount(accounts, account)
-        } catch (e: InitializeException.ImportAccountException) {
-            Twig.error(e) { "Error importing account" }
-        } finally {
-            isCreatingAccount.update { false }
-        }
+    ) {
+        val accountIndex = accounts.accounts.indexOf(account)
+        navigationRouter.forward(
+            KeystoneBDHeightArgs(ur = args.ur, accountIndex = accountIndex)
+        )
     }
 
     private fun onForgetDeviceClick() {
-        if (!isCreatingAccount.value) {
-            navigationRouter.backToRoot()
-        }
+        navigationRouter.backToRoot()
     }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/CreateKeystoneAccountUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/CreateKeystoneAccountUseCaseTest.kt
@@ -1,0 +1,124 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountUuid
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import com.keystone.module.ZcashAccount
+import com.keystone.module.ZcashAccounts
+import androidx.navigation.NavBackStackEntry
+import co.electriccoin.zcash.ui.BaseNavigationCommand
+import co.electriccoin.zcash.ui.NavigationCommand
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CreateKeystoneAccountUseCaseTest {
+
+    private val dummyAccount = Account.new(AccountUuid.new(ByteArray(16)))
+
+    private fun makeAccounts() = ZcashAccounts("aabb", listOf(ZcashAccount("ufvk1", 0, "Test")))
+
+    // Verifies that when birthdayHeight is provided, it is forwarded to
+    // AccountDataSource.importKeystoneAccount as-is.
+    @Test
+    fun `invoke with birthday forwards height to data source`() = runTest {
+        val captured = CapturedImportArgs()
+        val useCase = CreateKeystoneAccountUseCase(
+            accountDataSource = FakeAccountDataSource(captured, dummyAccount),
+            navigationRouter = FakeNavigationRouter()
+        )
+
+        val accounts = makeAccounts()
+        useCase(accounts, accounts.accounts.first(), birthdayHeight = 1_700_000L)
+
+        assertEquals(1_700_000L, captured.birthdayHeight)
+        assertEquals("ufvk1", captured.ufvk)
+        assertEquals("aabb", captured.seedFingerprint)
+        assertEquals(0L, captured.index)
+    }
+
+    // Verifies that when birthdayHeight is omitted or explicitly null,
+    // null is forwarded to the data source (letting the SDK use its default).
+    @Test
+    fun `invoke without birthday forwards null to data source`() = runTest {
+        val captured = CapturedImportArgs()
+        val useCase = CreateKeystoneAccountUseCase(
+            accountDataSource = FakeAccountDataSource(captured, dummyAccount),
+            navigationRouter = FakeNavigationRouter()
+        )
+
+        val accounts = makeAccounts()
+
+        // Explicit null
+        useCase(accounts, accounts.accounts.first(), birthdayHeight = null)
+        assertNull(captured.birthdayHeight)
+
+        // Default parameter (omitted)
+        captured.birthdayHeight = -1L
+        useCase(accounts, accounts.accounts.first())
+        assertNull(captured.birthdayHeight)
+    }
+}
+
+private class CapturedImportArgs {
+    var ufvk: String? = null
+    var seedFingerprint: String? = null
+    var index: Long? = null
+    var birthdayHeight: Long? = -1L // sentinel to distinguish "not called" from "called with null"
+}
+
+@Suppress("TooManyFunctions")
+private class FakeAccountDataSource(
+    private val captured: CapturedImportArgs,
+    private val accountToReturn: Account
+) : AccountDataSource {
+    override val allAccounts: StateFlow<List<WalletAccount>?>
+        get() = MutableStateFlow(null)
+    override val selectedAccount: Flow<WalletAccount?>
+        get() = emptyFlow()
+    override val zashiAccount: Flow<ZashiAccount?>
+        get() = emptyFlow()
+
+    override suspend fun getAllAccounts(): List<WalletAccount> = emptyList()
+    override suspend fun getSelectedAccount(): WalletAccount = error("not implemented")
+    override suspend fun getZashiAccount(): ZashiAccount = error("not implemented")
+    override suspend fun selectAccount(account: Account) {}
+    override suspend fun selectAccount(account: WalletAccount) {}
+
+    override suspend fun importKeystoneAccount(
+        ufvk: String,
+        seedFingerprint: String,
+        index: Long,
+        birthdayHeight: Long?
+    ): Account {
+        captured.ufvk = ufvk
+        captured.seedFingerprint = seedFingerprint
+        captured.index = index
+        captured.birthdayHeight = birthdayHeight
+        return accountToReturn
+    }
+
+    override suspend fun requestNextShieldedAddress() {}
+}
+
+private class FakeNavigationRouter : NavigationRouter {
+    var didBackToRoot = false
+
+    override fun forward(vararg routes: Any) {}
+    override fun replace(vararg routes: Any) {}
+    override fun replaceAll(vararg routes: Any) {}
+    override fun back() {}
+    override fun backTo(route: KClass<*>) {}
+    override fun custom(block: (NavBackStackEntry?) -> NavigationCommand?) {}
+    override fun backToRoot() { didBackToRoot = true }
+    override fun observePipeline(): Flow<BaseNavigationCommand> = emptyFlow()
+}


### PR DESCRIPTION
Closes #2177

## Summary
- Adds wallet birthday picker to the Keystone hardware wallet import flow, reusing existing restore birthday UI
- Users can enter a block height manually or estimate from a date before the account is imported
- Depends on SDK change: zcash/zcash-android-wallet-sdk#1904

## Motivation
Previously, importing a Keystone account hardcoded the birthday to the chain tip, causing the wallet to miss all historical notes and transactions. This was one of the most confusing bugs in syncing Keystones (see also zcash/zcash-swift-wallet-sdk#1663).

## Testing
Manual testing via Android Studio emulator.

<table>
  <tr>
    <td><img width="330" alt="IMG_0664" src="https://github.com/user-attachments/assets/4419696e-f192-4d45-bbe2-bc6b48137b32" /></td>
    <td><img width="330" alt="IMG_0665" src="https://github.com/user-attachments/assets/b78cc89b-726b-44b3-9723-eed043a09bb8" /></td>
  </tr>
</table>

---

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [x] Add **automated tests** as appropriate
- [x] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [x] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._