### PR TITLE
Render ZAP1 memos in transaction details

### DIFF
--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/Zap1MemoFormatterTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/Zap1MemoFormatterTest.kt
@@ -1,0 +1,87 @@
+package co.electriccoin.zcash.ui.common
+
+import androidx.test.filters.SmallTest
+import co.electriccoin.zcash.ui.common.util.Zap1MemoFormatter
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Zap1MemoFormatterTest {
+    @Test
+    @SmallTest
+    fun parse_program_entry() {
+        val attestation =
+            Zap1MemoFormatter.parse(
+                "ZAP1:01:075b00df286038a7b3f6bb70054df61343e3481fba579591354a00214e9e019b"
+            )
+
+        requireNotNull(attestation)
+        assertThat(attestation.prefix, equalTo("ZAP1"))
+        assertThat(attestation.typeHex, equalTo("01"))
+        assertThat(attestation.event, equalTo("PROGRAM_ENTRY"))
+        assertThat(attestation.shortHash, equalTo("075b00df2860..."))
+        assertFalse(attestation.isLegacy)
+    }
+
+    @Test
+    @SmallTest
+    fun parse_legacy_nsm1() {
+        val attestation =
+            Zap1MemoFormatter.parse(
+                "NSM1:04:f265b9a06a61b2b8c6eeed7fc00c7aa686ad511053467815bf1f1037d460e1f1"
+            )
+
+        requireNotNull(attestation)
+        assertThat(attestation.prefix, equalTo("NSM1"))
+        assertThat(attestation.event, equalTo("DEPLOYMENT"))
+        assertTrue(attestation.isLegacy)
+    }
+
+    @Test
+    @SmallTest
+    fun parse_governance_uppercase_hex() {
+        val attestation =
+            Zap1MemoFormatter.parse(
+                "ZAP1:0D:A487C25F5867A9E3760C45AE7EED24D84E771568F1826A889CCD94B3C7C3A5B5"
+            )
+
+        requireNotNull(attestation)
+        assertThat(attestation.typeHex, equalTo("0d"))
+        assertThat(attestation.event, equalTo("GOVERNANCE_PROPOSAL"))
+    }
+
+    @Test
+    @SmallTest
+    fun rejects_invalid_memos() {
+        assertNull(Zap1MemoFormatter.parse("Hello world"))
+        assertNull(Zap1MemoFormatter.parse("ZAP1:xx:notahash"))
+        assertNull(Zap1MemoFormatter.parse("ZAP1:01:tooshort"))
+        assertNull(Zap1MemoFormatter.parse(""))
+        assertNull(
+            Zap1MemoFormatter.parse(
+                "ZAP2:01:075b00df286038a7b3f6bb70054df61343e3481fba579591354a00214e9e019b"
+            )
+        )
+    }
+
+    @Test
+    @SmallTest
+    fun format_returns_readable_string() {
+        val formatted =
+            Zap1MemoFormatter.format(
+                "ZAP1:09:024e36515ea30efc15a0a7962dd8f677455938079430b9eab174f46a4328a07a"
+            )
+
+        requireNotNull(formatted)
+        assertThat(formatted, equalTo("ZAP1: MERKLE_ROOT  024e36515ea3..."))
+    }
+
+    @Test
+    @SmallTest
+    fun format_returns_null_for_non_zap1() {
+        assertNull(Zap1MemoFormatter.format("Just a regular memo"))
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/util/Zap1MemoFormatter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/util/Zap1MemoFormatter.kt
@@ -1,0 +1,55 @@
+package co.electriccoin.zcash.ui.common.util
+
+/**
+ * Parses ZAP1 and legacy NSM1 attestation memos into structured data.
+ */
+object Zap1MemoFormatter {
+    private val pattern = Regex("^(ZAP1|NSM1):([0-9a-fA-F]{2}):([0-9a-fA-F]{64})$")
+
+    private val events = mapOf(
+        "01" to "PROGRAM_ENTRY",
+        "02" to "OWNERSHIP_ATTEST",
+        "03" to "CONTRACT_ANCHOR",
+        "04" to "DEPLOYMENT",
+        "05" to "HOSTING_PAYMENT",
+        "06" to "SHIELD_RENEWAL",
+        "07" to "TRANSFER",
+        "08" to "EXIT",
+        "09" to "MERKLE_ROOT",
+        "0a" to "STAKING_DEPOSIT",
+        "0b" to "STAKING_WITHDRAW",
+        "0c" to "STAKING_REWARD",
+        "0d" to "GOVERNANCE_PROPOSAL",
+        "0e" to "GOVERNANCE_VOTE",
+        "0f" to "GOVERNANCE_RESULT"
+    )
+
+    fun parse(memo: String): Attestation? {
+        val match = pattern.matchEntire(memo.trim()) ?: return null
+        val prefix = match.groupValues[1]
+        val typeHex = match.groupValues[2].lowercase()
+        val hash = match.groupValues[3]
+
+        return Attestation(
+            prefix = prefix,
+            typeHex = typeHex,
+            event = events[typeHex] ?: "TYPE_0x$typeHex",
+            hash = hash
+        )
+    }
+
+    fun format(memo: String): String? {
+        val attestation = parse(memo) ?: return null
+        return "ZAP1: ${attestation.event}  ${attestation.shortHash}"
+    }
+
+    data class Attestation(
+        val prefix: String,
+        val typeHex: String,
+        val event: String,
+        val hash: String
+    ) {
+        val shortHash get() = "${hash.take(12)}..."
+        val isLegacy get() = prefix == "NSM1"
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactiondetail/TransactionDetailVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactiondetail/TransactionDetailVM.kt
@@ -21,6 +21,7 @@ import co.electriccoin.zcash.ui.common.model.SwapStatus.SUCCESS
 import co.electriccoin.zcash.ui.common.repository.ReceiveTransaction
 import co.electriccoin.zcash.ui.common.repository.SendTransaction
 import co.electriccoin.zcash.ui.common.repository.ShieldTransaction
+import co.electriccoin.zcash.ui.common.util.Zap1MemoFormatter
 import co.electriccoin.zcash.ui.common.usecase.CopyToClipboardUseCase
 import co.electriccoin.zcash.ui.common.usecase.DetailedTransactionData
 import co.electriccoin.zcash.ui.common.usecase.FlipTransactionBookmarkUseCase
@@ -272,7 +273,7 @@ class TransactionDetailVM(
                                 TransactionDetailMemosState(
                                     transaction.memos.orEmpty().map { memo ->
                                         TransactionDetailMemoState(
-                                            content = stringRes(memo),
+                                            content = stringRes(Zap1MemoFormatter.format(memo) ?: memo),
                                             onClick = { onCopyToClipboard(memo) }
                                         )
                                     }
@@ -314,7 +315,7 @@ class TransactionDetailVM(
                             TransactionDetailMemosState(
                                 transaction.memos?.map { memo ->
                                     TransactionDetailMemoState(
-                                        content = stringRes(memo),
+                                        content = stringRes(Zap1MemoFormatter.format(memo) ?: memo),
                                         onClick = { onCopyToClipboard(memo) }
                                     )
                                 }


### PR DESCRIPTION
Closes #2172

## Summary

- add `Zap1MemoFormatter` to parse `ZAP1:` and legacy `NSM1:` memo strings and map known event type bytes to readable event names
- intercept transaction detail memo rendering in `TransactionDetailVM.kt` so valid attestations display as `ZAP1: EVENT_NAME  hash_prefix...` instead of the raw protocol string
- preserve the existing raw memo fallback and copy behavior for malformed ZAP1-like strings and all non-ZAP1 memos

## Scope

- transaction detail rendering only
- no send flow changes
- no sync changes
- no new dependencies
- no external link UI in this PR

## Test Plan

- [ ] Open a transaction with a valid `ZAP1:01:<64 hex>` memo and confirm it renders as `ZAP1: PROGRAM_ENTRY  <12 hex>...`
- [ ] Open a transaction with a valid `NSM1:04:<64 hex>` memo and confirm it renders with the same typed format
- [ ] Open a transaction with a malformed `ZAP1`-like memo and confirm the raw memo is unchanged
- [ ] Open a transaction with a non-ZAP1 memo and confirm the raw memo is unchanged
- [ ] Tap the memo row and confirm the original memo string is copied to the clipboard
- [ ] Run the formatter Android test target
