### PR TITLE
Use exact zatoshi conversion for swap proposals

### DIFF
--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -1,0 +1,48 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import androidx.test.filters.SmallTest
+import cash.z.ecc.android.sdk.model.Zatoshi
+import org.junit.Test
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class RequestSwapQuoteUseCaseTest {
+    @Test
+    @SmallTest
+    fun toExactQuoteZatoshi_acceptsWholeNumber() {
+        val result = BigDecimal("123").toExactQuoteZatoshi()
+
+        assertEquals(Zatoshi(123), result)
+    }
+
+    @Test
+    @SmallTest
+    fun toExactQuoteZatoshi_acceptsEquivalentWholeNumberWithScale() {
+        val result = BigDecimal("123.0").toExactQuoteZatoshi()
+
+        assertEquals(Zatoshi(123), result)
+    }
+
+    @Test
+    @SmallTest
+    fun toExactQuoteZatoshi_rejectsNonIntegralAmount() {
+        val exception =
+            assertFailsWith<InvalidSwapQuoteAmountException> {
+                BigDecimal("123.9").toExactQuoteZatoshi()
+            }
+
+        assertEquals(BigDecimal("123.9"), exception.amount)
+    }
+
+    @Test
+    @SmallTest
+    fun toExactQuoteZatoshi_rejectsOverflow() {
+        val exception =
+            assertFailsWith<InvalidSwapQuoteAmountException> {
+                BigDecimal("9223372036854775808").toExactQuoteZatoshi()
+            }
+
+        assertEquals(BigDecimal("9223372036854775808"), exception.amount)
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -141,7 +141,7 @@ class RequestSwapQuoteUseCase(
         val send =
             ZecSend(
                 destination = getWalletAddress(quote.depositAddress.address),
-                amount = Zatoshi(quote.amountIn.toLong()),
+                amount = quote.amountIn.toExactQuoteZatoshi(),
                 memo = Memo(""),
                 proposal = null
             )
@@ -173,3 +173,15 @@ class RequestSwapQuoteUseCase(
             is AddressType.Invalid -> throw IllegalStateException(result.reason)
         }
 }
+
+internal fun BigDecimal.toExactQuoteZatoshi(): Zatoshi =
+    try {
+        Zatoshi(longValueExact())
+    } catch (e: ArithmeticException) {
+        throw InvalidSwapQuoteAmountException(this, e)
+    }
+
+internal class InvalidSwapQuoteAmountException(
+    val amount: BigDecimal,
+    cause: ArithmeticException
+) : IllegalArgumentException("Swap quote amount must be an exact zatoshi value: $amount", cause)


### PR DESCRIPTION
## Summary

Use exact zatoshi conversion when creating swap proposals.

## Problem

`RequestSwapQuoteUseCase` used `quote.amountIn.toLong()` when building the proposal amount, which could silently truncate fractional values or fail on overflow.

## Solution

- replace `toLong()` with exact conversion
- throw an explicit exception for invalid quote amounts
- add tests for whole numbers, fractional values, and overflow
