### PR TITLE
fix: add `zcash_is_testnet` override to Internal flavors

### DIFF
--- a/app/src/zcashtestnetInternalDebug/res/values/bools.xml
+++ b/app/src/zcashtestnetInternalDebug/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="zcash_is_testnet">true</bool>
+</resources>

--- a/app/src/zcashtestnetInternalRelease/res/values/bools.xml
+++ b/app/src/zcashtestnetInternalRelease/res/values/bools.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Overlay from sdk-ext-lib. -->
+    <bool name="zcash_is_testnet">true</bool>
+</resources>


### PR DESCRIPTION
## Summary

The `Internal` Debug and Release testnet flavors are missing the `zcash_is_testnet=true` override that `Foss` and `Store` testnet flavors carry in `res/values/bools.xml`.

Without it, both Internal flavors inherit `zcash_is_testnet=false` from the `sdk-ext-lib` default and surface a runtime error when pointed at any server reporting `chainName="test"`:

> this client expects a server using mainnet but it was test

This was surfaced by an end-to-end integration test against a custom testnet server. The fix adds the same override that the `Foss` and `Store` testnet flavors already ship.

## Author

- [x] **Self-review** your own code in GitHub's web interface
- [x] Add **automated tests** as appropriate
- [x] Update the **manual tests** as appropriate
- [x] Check the **code coverage** report for the automated tests
- [x] Update **documentation** as appropriate
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer