### PR TITLE
ci: publish to self-hosted F-Droid repo + switch to ZODL GPG signer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,29 +33,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Authenticate to Google Cloud for GCS/KMS
-        id: auth_gcs
-        uses: google-github-actions/auth@v3
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          role-to-assume: ${{ secrets.AWS_RELEASE_ROLE_ARN }}
+          aws-region: us-east-1
 
-      - name: Download file from GCS
+      - name: Import GPG signing key from AWS Secrets Manager
         run: |
-          gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
-          gsutil -q cp gs://${{ secrets.SOLANA_GCS_BUCKET }}/encrypted_gpg.kms encrypted_gpg.kms
-
-      - name: Decrypt file using KMS
-        run: |
-          gcloud kms decrypt \
-            --key gpg \
-            --keyring gpg \
-            --location global \
-            --plaintext-file private.pgp \
-            --ciphertext-file encrypted_gpg.kms
-
-      - name: Import GPG
-        run: |
-          gpg --import private.pgp
+          aws secretsmanager get-secret-value \
+            --secret-id /release/gpg-signing-key \
+            --query SecretString --output text > private.pgp
+          gpg --batch --import private.pgp
+          shred -u private.pgp
 
       - name: Set up Java
         uses: ./.github/actions/setup-java
@@ -131,30 +121,14 @@ jobs:
         run: |
           mv app/build/outputs/apk/zcashmainnetFoss/release/app-zcashmainnet-foss-release.apk artifacts/app-zcashmainnet-foss-release-full-externallibs.apk
 
-      - name: Build FOSS (F-Droid) APK
-        env:
-          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
-          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
-          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
-          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.UPLOAD_KEY_ALIAS_PASSWORD }}
-          # ORG_GRADLE_PROJECT_ZCASH_FLEXA_KEY: ${{ secrets.FLEXA_PUBLISHABLE_KEY }}
-          # ORG_GRADLE_PROJECT_ZCASH_CMC_KEY: ${{ secrets.CMC_PUBLISHABLE_KEY }}
-        run: |
-          ./gradlew clean :app:assembleZcashmainnetFossRelease
-
-      - name: Prepare FOSS (F-Droid) artifacts
-        run: |
-          mv app/build/outputs/apk/zcashmainnetFoss/release/app-zcashmainnet-foss-release.apk artifacts/
-
       - name: Prepare Signature artifacts
         run: |
           cd artifacts/
           TAG=$(git describe --tags --abbrev=0)
           VERSION_CODE=$(echo "$TAG" | cut -d'-' -f2)
           echo $VERSION_CODE > version_code.txt
-          gpg -u sysadmin@z.cash --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release.apk
-          gpg -u sysadmin@z.cash --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release-full-externallibs.apk
-          gpg -u sysadmin@z.cash --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-google-play-store-release-universal.apk
+          gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release-full-externallibs.apk
+          gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-google-play-store-release-universal.apk
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v3
@@ -326,3 +300,135 @@ jobs:
 
           echo "Config updated in GCS"
           echo "Backup: gs://${{ secrets.SOLANA_GCS_BUCKET }}/backups/encrypted_config.yaml.kms.${TIMESTAMP}"
+
+  publish_to_fdroid:
+    needs: [release]
+    environment: deployment
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC -> AWS
+    steps:
+      - name: Get release tag
+        id: release_info
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION_NAME=$(echo "$TAG" | sed 's/^v//' | cut -d'-' -f1)
+          VERSION_CODE=$(echo "$TAG" | cut -d'-' -f2)
+
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version_name=${VERSION_NAME}" >> $GITHUB_OUTPUT
+          echo "version_code=${VERSION_CODE}" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_RELEASE_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Load F-Droid index keystore + SSH deploy key from Secrets Manager
+        id: secrets
+        run: |
+          KEYSTORE_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id /infra/zodl-android/fdroid_index_keystore \
+            --query SecretString --output text)
+          echo "$KEYSTORE_JSON" | jq -r '.keystore_b64'         | base64 -d > /tmp/fdroid-index.jks
+          echo "keystore_password=$(echo "$KEYSTORE_JSON" | jq -r '.keystore_password')" >> $GITHUB_OUTPUT
+          echo "key_alias=$(echo "$KEYSTORE_JSON" | jq -r '.key_alias')"                 >> $GITHUB_OUTPUT
+          echo "key_password=$(echo "$KEYSTORE_JSON" | jq -r '.key_password')"           >> $GITHUB_OUTPUT
+          echo "::add-mask::$(echo "$KEYSTORE_JSON" | jq -r '.keystore_password')"
+          echo "::add-mask::$(echo "$KEYSTORE_JSON" | jq -r '.key_password')"
+
+          mkdir -p ~/.ssh
+          aws secretsmanager get-secret-value \
+            --secret-id /infra/zodl-android/fdroid_deploy_ssh_key \
+            --query SecretString --output text > ~/.ssh/id_fdroid
+          chmod 600 ~/.ssh/id_fdroid
+          ssh-keyscan -t ed25519,rsa github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat > ~/.ssh/config <<'EOF'
+          Host github.com-fdroid
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/id_fdroid
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Install fdroidserver + deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            fdroidserver openjdk-21-jdk-headless apksigner git python3
+          fdroid --version
+
+      - name: Clone zodl-inc/fdroid (SSH)
+        run: |
+          git config --global user.name  "zodl-inc-bot"
+          git config --global user.email "sysadmin@zodl.com"
+          git clone --depth 1 \
+            git@github.com-fdroid:zodl-inc/fdroid.git fdroid-repo
+          mkdir -p fdroid-repo/fdroid/repo fdroid-repo/fdroid/archive
+
+      - name: Download FOSS APK from GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release_info.outputs.tag }}
+        run: |
+          gh release download "$TAG" \
+            --repo zodl-inc/zodl-android \
+            -p "app-zcashmainnet-foss-release-full-externallibs.apk" \
+            -D fdroid-repo/fdroid/repo/
+
+      - name: Initialize fdroid config
+        working-directory: fdroid-repo/fdroid
+        env:
+          KEYSTORE_PASSWORD: ${{ steps.secrets.outputs.keystore_password }}
+          KEY_ALIAS: ${{ steps.secrets.outputs.key_alias }}
+          KEY_PASSWORD: ${{ steps.secrets.outputs.key_password }}
+        run: |
+          # fdroid init expects config.yml at repo root; write one pointing at
+          # the shared keystore that lives in /tmp.
+          cat > config.yml <<EOF
+          repo_url: https://foss.zodl.com/fdroid/repo
+          repo_name: Zodl F-Droid Repo
+          repo_icon: icon.png
+          repo_description: >-
+            Official self-hosted F-Droid repository for the Zodl Zcash Wallet.
+            APKs are built by zodl-inc/zodl-android CI and signed with the
+            production upload key (same as Google Play).
+          archive_url: https://foss.zodl.com/fdroid/archive
+          archive_name: Zodl F-Droid Archive
+          archive_description: Archive of older Zodl wallet builds.
+          archive_older: 3
+          keystore: /tmp/fdroid-index.jks
+          repo_keyalias: ${KEY_ALIAS}
+          keystorepass: ${KEYSTORE_PASSWORD}
+          keypass: ${KEY_PASSWORD}
+          EOF
+
+      - name: Run fdroid update
+        working-directory: fdroid-repo/fdroid
+        run: |
+          fdroid update --create-metadata --pretty --verbose
+          # fdroid writes config.yml with secrets — delete before committing.
+          rm -f config.yml
+
+      - name: Commit + push
+        working-directory: fdroid-repo
+        env:
+          TAG: ${{ steps.release_info.outputs.tag }}
+        run: |
+          git add fdroid/repo fdroid/archive fdroid/metadata || true
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+          git commit -m "Publish ${TAG}"
+          git push origin HEAD:main
+
+      - name: Cleanup
+        if: always()
+        run: |
+          shred -u /tmp/fdroid-index.jks ~/.ssh/id_fdroid 2>/dev/null || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -355,19 +355,27 @@ jobs:
           KEYSTORE_JSON=$(aws secretsmanager get-secret-value \
             --secret-id /infra/zodl-android/fdroid_index_keystore \
             --query SecretString --output text)
-          echo "$KEYSTORE_JSON" | jq -r '.keystore_b64'         | base64 -d > /tmp/fdroid-index.jks
-          echo "keystore_password=$(echo "$KEYSTORE_JSON" | jq -r '.keystore_password')" >> $GITHUB_OUTPUT
-          echo "key_alias=$(echo "$KEYSTORE_JSON" | jq -r '.key_alias')"                 >> $GITHUB_OUTPUT
-          echo "key_password=$(echo "$KEYSTORE_JSON" | jq -r '.key_password')"           >> $GITHUB_OUTPUT
-          echo "::add-mask::$(echo "$KEYSTORE_JSON" | jq -r '.keystore_password')"
-          echo "::add-mask::$(echo "$KEYSTORE_JSON" | jq -r '.key_password')"
+          echo "$KEYSTORE_JSON" | jq -r '.keystore_b64' | base64 -d > /tmp/fdroid-index.jks
+
+          # Read into shell vars first, register the mask, then write to
+          # GITHUB_OUTPUT. Reversing this order risks the runner flushing
+          # the output line to the log before the mask command takes effect.
+          KEYSTORE_PASS=$(echo "$KEYSTORE_JSON" | jq -r '.keystore_password')
+          KEY_ALIAS=$(echo "$KEYSTORE_JSON" | jq -r '.key_alias')
+          KEY_PASS=$(echo "$KEYSTORE_JSON" | jq -r '.key_password')
+          echo "::add-mask::${KEYSTORE_PASS}"
+          echo "::add-mask::${KEY_PASS}"
+
+          echo "keystore_password=${KEYSTORE_PASS}" >> "$GITHUB_OUTPUT"
+          echo "key_alias=${KEY_ALIAS}"             >> "$GITHUB_OUTPUT"
+          echo "key_password=${KEY_PASS}"           >> "$GITHUB_OUTPUT"
 
           mkdir -p ~/.ssh
           aws secretsmanager get-secret-value \
             --secret-id /infra/zodl-android/fdroid_deploy_ssh_key \
             --query SecretString --output text > ~/.ssh/id_fdroid
           chmod 600 ~/.ssh/id_fdroid
-          ssh-keyscan -t ed25519,rsa github.com >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -t ed25519,rsa github.com >> ~/.ssh/known_hosts
           cat > ~/.ssh/config <<'EOF'
           Host github.com-fdroid
             HostName github.com
@@ -433,8 +441,10 @@ jobs:
         working-directory: fdroid-repo/fdroid
         run: |
           fdroid update --create-metadata --pretty --verbose
-          # fdroid writes config.yml with secrets — delete before committing.
-          rm -f config.yml
+          # config.yml contains plaintext keystore + key passwords.
+          # Use shred to match how the other key material in this job is
+          # disposed of (JKS, SSH deploy key) and to reduce recoverability.
+          shred -u config.yml
 
       - name: Commit + push
         working-directory: fdroid-repo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,12 +121,33 @@ jobs:
         run: |
           mv app/build/outputs/apk/zcashmainnetFoss/release/app-zcashmainnet-foss-release.apk artifacts/app-zcashmainnet-foss-release-full-externallibs.apk
 
+      # Second FOSS build with Flexa/CMC keys intentionally NOT injected:
+      # this is the build that f-droid.org's reproducible build farm needs to
+      # match (their builders cannot see those secrets). Keep it in sync with
+      # the externallibs build above so fdroidserver metadata generation has
+      # the artifact it expects under the un-suffixed filename.
+      - name: Build FOSS (F-Droid) APK
+        env:
+          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
+          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
+          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.UPLOAD_KEY_ALIAS_PASSWORD }}
+          # ORG_GRADLE_PROJECT_ZCASH_FLEXA_KEY: ${{ secrets.FLEXA_PUBLISHABLE_KEY }}
+          # ORG_GRADLE_PROJECT_ZCASH_CMC_KEY: ${{ secrets.CMC_PUBLISHABLE_KEY }}
+        run: |
+          ./gradlew clean :app:assembleZcashmainnetFossRelease
+
+      - name: Prepare FOSS (F-Droid) artifacts
+        run: |
+          mv app/build/outputs/apk/zcashmainnetFoss/release/app-zcashmainnet-foss-release.apk artifacts/
+
       - name: Prepare Signature artifacts
         run: |
           cd artifacts/
           TAG=$(git describe --tags --abbrev=0)
           VERSION_CODE=$(echo "$TAG" | cut -d'-' -f2)
           echo $VERSION_CODE > version_code.txt
+          gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release.apk
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release-full-externallibs.apk
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-google-play-store-release-universal.apk
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,27 @@ Zcash mobile wallet leveraging the [Zcash Android SDK](https://github.com/zcash/
 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
      alt="Get it on F-Droid"
-     height="80">](https://f-droid.org/packages/co.electriccoin.zcash.foss/)
+     height="80">](https://foss.zodl.com)
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
      alt="Get it on Google Play"
      height="80">](https://play.google.com/store/apps/details?id=co.electriccoin.zcash)
 
-Or download the latest APK from the [Releases Section](https://github.com/zodl-inc/zashi-android/releases/latest).
+Zodl runs its own F-Droid repository at <https://foss.zodl.com>. To add it to
+your F-Droid client, tap this link on Android:
+
+```
+fdroidrepos://foss.zodl.com/fdroid/repo?fingerprint=7e751ab710159dff44f55631f910ba4033f0ebd2f867691af633cece4ddb62e4
+```
+
+…or add the URL manually in **F-Droid → Settings → Repositories → +**:
+`https://foss.zodl.com/fdroid/repo` (fingerprint
+`7e751ab710159dff44f55631f910ba4033f0ebd2f867691af633cece4ddb62e4`).
+
+Unlike the `f-droid.org` build, our repo ships the same build-time
+integrations as the Google Play release (Flexa, CMC, Crashlytics) and is
+signed with the same upload key — no reinstall needed when switching.
+
+Or download the latest APK from the [Releases Section](https://github.com/zodl-inc/zodl-android/releases/latest).
 
 # Zodl Discord
 


### PR DESCRIPTION
## Summary

- Replace GCS + Cloud KMS GPG fetch with **AWS OIDC + Secrets Manager**. The release job assumes `zodl-android-release-github-actions` and reads `/release/gpg-signing-key` directly — no more `gsutil` or `gcloud kms decrypt`.
- Switch GPG detached signatures from `sysadmin@z.cash` (ECC key) to `sysadmin@zodl.com` (ZODL key `0338…6AB1`). The ECC key is scheduled for revocation 2026-06-23; existing release `.asc` files remain verifiable until then.
- Drop the redundant *Build FOSS (F-Droid) APK* step. A single FOSS `externallibs` build now feeds both Solana and F-Droid.
- New **`publish_to_fdroid`** job (parallel to `publish_to_solana`): pulls the FOSS APK from the GitHub Release, runs `fdroid update` signed by the Secrets-Manager-held index keystore, and pushes the result to `zodl-inc/fdroid` over SSH. GitHub Pages auto-publishes to **foss.zodl.com**.
- **README**: swap the F-Droid badge target to `foss.zodl.com` and embed the repo fingerprint + `fdroidrepos://` deeplink.

## Why our own F-Droid repo

The upstream `gitlab.com/fdroid/fdroiddata` build farm has no access to our build-time secrets (Flexa/CMC/Crashlytics), so its output is feature-stripped relative to the Play Store build. Our self-hosted repo builds with the full secret set while remaining fully-FOSS-compatible (same repo layout, same signing semantics).

## Signing keys — unchanged vs new

| Purpose | Key | Status |
|---|---|---|
| APK signing | `UPLOAD_KEYSTORE_BASE_64` (existing GH secret) | **unchanged** — clients keep getting updates without reinstall |
| `.asc` detached sigs on Release artifacts | ZODL GPG key `sysadmin@zodl.com` | **new** (replaces ECC `sysadmin@z.cash`) |
| F-Droid index (`index-v1.jar`, `index-v2.json`) | `/infra/zodl-android/fdroid_index_keystore` | new |

## Companion PR

Infra (IAM role, Secrets Manager, DNS, repo seed content, runbook): [zodl-inc/infra#2](https://github.com/zodl-inc/infra/pull/2). Merge order does not strictly matter — the new workflow only runs on `release: published`, by which time infra is expected to be applied. Infra has already been applied to AWS.

## Test plan

- [x] YAML is syntactically valid (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Job names resolve: `validate_gradle_wrapper`, `release`, `publish_to_solana`, `publish_to_fdroid`.
- [x] IAM role, Secrets Manager entries, SSH deploy key on `zodl-inc/fdroid`, and GitHub Pages are provisioned.
- [x] `dig foss.zodl.com` resolves to GitHub Pages.
- [ ] Trigger a GitHub Release (or re-run the last one as `workflow_dispatch`) and confirm:
  - `.asc` detached signatures verify with the ZODL public key.
  - `publish_to_fdroid` pushes a commit to `zodl-inc/fdroid` with `fdroid/repo/{APK, index-v1.jar, index-v2.json}`.
  - F-Droid client at `foss.zodl.com` reports the new version.