### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [3.4.0 (1691)] - 2026-05-12
+
+### Added:
+- We added Wallet Birthday Height when connecting a Keystone.
+
+### Changed:
+- We refreshed the Restore flow copy.
+
+### Fixed:
+- Locale bugs that could truncate ZEC, block Send, or cause an oversend with a comma decimal separator.
+- A bug where a shielded address could be reused as a swap refund address.
+- A missing copy-confirmation toast on Receive.
+- Tor sync turning off after a low-disk-space interrupt, plus other UX/UI fixes.
+
 ## [3.3.1 (1643)] - 2026-04-10
 
 ### Fixed:

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -12,6 +12,20 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.4.0 (1691)] - 2026-05-12
+
+### Added:
+- We added Wallet Birthday Height when connecting a Keystone.
+
+### Changed:
+- We refreshed the Restore flow copy.
+
+### Fixed:
+- Locale bugs that could truncate ZEC, block Send, or cause an oversend with a comma decimal separator.
+- A bug where a shielded address could be reused as a swap refund address.
+- A missing copy-confirmation toast on Receive.
+- Tor sync turning off after a low-disk-space interrupt, plus other UX/UI fixes.
+
 ## [3.3.1 (1643)] - 2026-04-10
 
 ### Added:

--- a/docs/whatsNew/WHATS_NEW_ES.md
+++ b/docs/whatsNew/WHATS_NEW_ES.md
@@ -12,6 +12,20 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.4.0 (1691)] - 2026-05-12
+
+### Añadido:
+- Añadimos altura de cumpleaños al conectar una billetera Keystone.
+
+### Cambiado:
+- Actualizamos los textos del flujo de Restauración.
+
+### Corregido:
+- Errores de localización con separador decimal de coma.
+- Un error que permitía reutilizar una dirección protegida como reembolso de swap.
+- Falta de confirmación al copiar una dirección de recepción.
+- Tor desactivado tras una alerta de poco espacio, además de otros detalles de UX/UI.
+
 ## [3.3.1 (1643)] - 2026-04-10
 
 ### Añadido:

--- a/fastlane/metadata/android/en-US/changelogs/1691.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1691.txt
@@ -1,0 +1,11 @@
+Added:
+- We added Wallet Birthday Height when connecting a Keystone.
+
+Changed:
+- We refreshed the Restore flow copy.
+
+Fixed:
+- Locale bugs that could truncate ZEC, block Send, or cause an oversend with a comma decimal separator.
+- A bug where a shielded address could be reused as a swap refund address.
+- A missing copy-confirmation toast on Receive.
+- Tor sync turning off after a low-disk-space interrupt, plus other UX/UI fixes.

--- a/fastlane/metadata/android/es/changelogs/1691.txt
+++ b/fastlane/metadata/android/es/changelogs/1691.txt
@@ -1,0 +1,11 @@
+Añadido:
+- Añadimos altura de cumpleaños al conectar una billetera Keystone.
+
+Cambiado:
+- Actualizamos los textos del flujo de Restauración.
+
+Corregido:
+- Errores de localización con separador decimal de coma.
+- Un error que permitía reutilizar una dirección protegida como reembolso de swap.
+- Falta de confirmación al copiar una dirección de recepción.
+- Tor desactivado tras una alerta de poco espacio, además de otros detalles de UX/UI.

--- a/gradle.properties
+++ b/gradle.properties
@@ -212,7 +212,7 @@ KTOR_VERSION =3.4.0
 # WARNING: Ensure a non-snapshot version is used before releasing to production
 ZCASH_BIP39_VERSION=1.0.9
 # WARNING: Ensure a non-snapshot version is used before releasing to production
-ZCASH_SDK_VERSION=2.4.8
+ZCASH_SDK_VERSION=2.5.0
 
 # Toolchain is the Java version used to build the application, which is separate from the
 # Java version used to run the application.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateKeystoneAccountUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateKeystoneAccountUseCase.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.android.sdk.model.BlockHeight
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.screen.connectkeystone.connected.KeystoneConnectedArgs
 import co.electriccoin.zcash.ui.screen.keepopen.KeepOpenArgs
 import co.electriccoin.zcash.ui.screen.keepopen.KeepOpenFlow
@@ -12,6 +13,7 @@ import com.keystone.module.ZcashAccounts
 
 class CreateKeystoneAccountUseCase(
     private val accountDataSource: AccountDataSource,
+    private val synchronizerProvider: SynchronizerProvider,
     private val navigationRouter: NavigationRouter,
 ) {
     @Throws(InitializeException.ImportAccountException::class)
@@ -28,6 +30,7 @@ class CreateKeystoneAccountUseCase(
                 birthday = birthday,
             )
         accountDataSource.selectAccount(createdAccount)
+        synchronizerProvider.resetSynchronizer()
         if (birthday != null) {
             navigationRouter.forward(KeepOpenArgs(KeepOpenFlow.KEYSTONE))
         } else {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/advancedsettings/AdvancedSettingsVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/advancedsettings/AdvancedSettingsVM.kt
@@ -100,12 +100,12 @@ class AdvancedSettingsVM(
                         bigIcon = imageRes(R.drawable.ic_advanced_settings_choose_server),
                         onClick = ::onChooseServerClick
                     ),
-                    ListItemState(
-                        title = stringRes(R.string.advanced_settings_resync_wallet),
-                        bigIcon = imageRes(R.drawable.ic_advanced_settings_resync),
-                        isEnabled = !restoring,
-                        onClick = ::onResyncWalletClick,
-                    ),
+                    // ListItemState(
+                    //     title = stringRes(R.string.advanced_settings_resync_wallet),
+                    //     bigIcon = imageRes(R.drawable.ic_advanced_settings_resync),
+                    //     isEnabled = !restoring,
+                    //     onClick = ::onResyncWalletClick,
+                    // ),
                     ListItemState(
                         title = stringRes(R.string.advanced_settings_privacy),
                         bigIcon = imageRes(R.drawable.ic_advanced_settings_privacy),
@@ -159,5 +159,5 @@ class AdvancedSettingsVM(
         navigationRouter.forward(DisconnectArgs)
     }
 
-    private fun onResyncWalletClick() = navigationRouter.forward(ResyncConfirmArgs)
+    // private fun onResyncWalletClick() = navigationRouter.forward(ResyncConfirmArgs)
 }


### PR DESCRIPTION
Closes #2220
Resolves MOB-1169

## Changes

Added:
- We added Wallet Birthday Height when connecting a Keystone.

Changed:
- We refreshed the Restore flow copy.

Fixed:
- Locale bugs that could truncate ZEC, block Send, or cause an oversend with a comma decimal separator.
- A bug where a shielded address could be reused as a swap refund address.
- A missing copy-confirmation toast on Receive.
- Tor sync turning off after a low-disk-space interrupt, plus other UX/UI fixes.