### PR TITLE
[#2216] Add multi-server transaction submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed:
 - Voting round responses now require explicit option indices from vote servers.
+- Automatic transaction submission may broadcast to multiple bundled servers. Use Manual mode to submit only through the selected server.
 
 ## [3.3.1 (1643)] - 2026-04-10
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -212,7 +212,7 @@ KTOR_VERSION =3.4.0
 # WARNING: Ensure a non-snapshot version is used before releasing to production
 ZCASH_BIP39_VERSION=1.0.9
 # WARNING: Ensure a non-snapshot version is used before releasing to production
-ZCASH_SDK_VERSION=2.4.8
+ZCASH_SDK_VERSION=2.5.0-SNAPSHOT
 
 # Toolchain is the Java version used to build the application, which is separate from the
 # Java version used to run the application.

--- a/ui-lib/build.gradle.kts
+++ b/ui-lib/build.gradle.kts
@@ -216,6 +216,7 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     testImplementation("io.ktor:ktor-client-mock")
+    testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(projects.testLib)
     androidTestImplementation(libs.bundles.androidx.test)

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
@@ -318,10 +318,6 @@ internal class MockSynchronizer(
         error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
     }
 
-    override suspend fun getTreeState(height: BlockHeight): ByteArray {
-        error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
-    }
-
     override suspend fun deleteAccount(accountUuid: AccountUuid): Boolean {
         error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
     }

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
@@ -318,6 +318,10 @@ internal class MockSynchronizer(
         error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
     }
 
+    override suspend fun getTreeState(height: BlockHeight): ByteArray {
+        error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
+    }
+
     override suspend fun deleteAccount(accountUuid: AccountUuid): Boolean {
         error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.util.Collections
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 internal class MultiEndpointTransactionSubmitter(
@@ -89,7 +89,7 @@ internal class MultiEndpointTransactionSubmitter(
     ): TransactionSubmitResult {
         val completion = CompletableDeferred<BroadcastCompletion>()
         val failureCount = AtomicInteger(0)
-        val failures = Collections.synchronizedList(mutableListOf<TransactionSubmitResult>())
+        val failures = ConcurrentLinkedQueue<TransactionSubmitResult>()
         val jobs =
             endpoints.map { endpoint ->
                 scope
@@ -133,7 +133,7 @@ internal class MultiEndpointTransactionSubmitter(
                                         if (failureCount.incrementAndGet() >= endpoints.size) {
                                             completion.complete(
                                                 BroadcastCompletion.Rejected(
-                                                    result = selectRejectedResult(transaction, failures)
+                                                    result = selectRejectedResult(transaction, failures.toList())
                                                 )
                                             )
                                         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -1,0 +1,295 @@
+package co.electriccoin.zcash.ui.common.datasource
+
+import cash.z.ecc.android.sdk.model.CreatedTransaction
+import cash.z.ecc.android.sdk.model.TransactionSubmitResult
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.spackle.Twig
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class MultiEndpointTransactionSubmitter(
+    private val scope: CoroutineScope,
+    private val globalTimeoutMillis: Long = MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS,
+    private val gracePeriodMillis: Long = MULTI_SUBMIT_GRACE_PERIOD_MILLIS,
+    private val submit: suspend (CreatedTransaction, LightWalletEndpoint) -> TransactionSubmitResult
+) {
+    suspend fun submitTransactions(
+        transactions: List<CreatedTransaction>,
+        endpoints: List<LightWalletEndpoint>,
+        logTag: String
+    ): List<TransactionSubmitResult> {
+        var anySubmissionFailed = false
+
+        return transactions.mapIndexed { index, transaction ->
+            if (anySubmissionFailed) {
+                TransactionSubmitResult.NotAttempted(transaction.txId)
+            } else {
+                val result =
+                    submitTransaction(
+                        transaction = transaction,
+                        endpoints = endpoints,
+                        index = index,
+                        transactionCount = transactions.size,
+                        logTag = logTag
+                    )
+
+                if (result !is TransactionSubmitResult.Success) {
+                    anySubmissionFailed = true
+                }
+
+                result
+            }
+        }
+    }
+
+    private suspend fun submitTransaction(
+        transaction: CreatedTransaction,
+        endpoints: List<LightWalletEndpoint>,
+        index: Int,
+        transactionCount: Int,
+        logTag: String
+    ): TransactionSubmitResult {
+        if (endpoints.isEmpty()) {
+            Twig.error { "$logTag No endpoints available for transaction ${transaction.txIdString()}." }
+            return createGrpcFailure(transaction, "No endpoints available")
+        }
+
+        return if (endpoints.size == 1) {
+            Twig.info {
+                "$logTag Submitting transaction ${index + 1}/$transactionCount to ${endpoints.first().serverString()}."
+            }
+            submitToEndpoint(
+                transaction = transaction,
+                endpoint = endpoints.first(),
+                logTag = logTag
+            )
+        } else {
+            Twig.info {
+                "$logTag Broadcasting transaction ${index + 1}/$transactionCount to ${endpoints.size} endpoints."
+            }
+            broadcastToEndpoints(
+                transaction = transaction,
+                endpoints = endpoints,
+                logTag = logTag
+            )
+        }
+    }
+
+    private suspend fun broadcastToEndpoints(
+        transaction: CreatedTransaction,
+        endpoints: List<LightWalletEndpoint>,
+        logTag: String
+    ): TransactionSubmitResult {
+        val completion = CompletableDeferred<BroadcastCompletion>()
+        val failureCount = AtomicInteger(0)
+        val failures = Collections.synchronizedList(mutableListOf<TransactionSubmitResult>())
+        val jobs =
+            endpoints.map { endpoint ->
+                scope
+                    .async {
+                        EndpointSubmission(
+                            endpoint = endpoint,
+                            result =
+                                submitToEndpoint(
+                                    transaction = transaction,
+                                    endpoint = endpoint,
+                                    logTag = logTag
+                                )
+                        )
+                    }.also { job ->
+                        job.invokeOnCompletion { throwable ->
+                            if (throwable is CancellationException) return@invokeOnCompletion
+
+                            scope.launch {
+                                val submission =
+                                    runCatching { job.await() }
+                                        .getOrElse {
+                                            EndpointSubmission(
+                                                endpoint = endpoint,
+                                                result = createGrpcFailure(transaction, it.message)
+                                            )
+                                        }
+
+                                when (val result = submission.result) {
+                                    is TransactionSubmitResult.Success -> {
+                                        completion.complete(
+                                            BroadcastCompletion.Accepted(
+                                                endpoint = submission.endpoint,
+                                                result = result
+                                            )
+                                        )
+                                    }
+
+                                    is TransactionSubmitResult.Failure,
+                                    is TransactionSubmitResult.NotAttempted -> {
+                                        failures += result
+                                        if (failureCount.incrementAndGet() >= endpoints.size) {
+                                            completion.complete(
+                                                BroadcastCompletion.Rejected(
+                                                    result = selectRejectedResult(transaction, failures)
+                                                )
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+            }
+        val timeoutJob =
+            scope.launch {
+                delay(globalTimeoutMillis)
+                val completedSubmissions =
+                    jobs.mapNotNull { job ->
+                        if (job.isCompleted && !job.isCancelled) {
+                            runCatching { job.await() }.getOrNull()
+                        } else {
+                            null
+                        }
+                    }
+                val timeoutResult =
+                    selectTimeoutCompletion(
+                        transaction = transaction,
+                        submissions = completedSubmissions
+                    )
+                if (completion.complete(timeoutResult)) {
+                    Twig.error { "$logTag Timed out waiting for any endpoint to accept ${transaction.txIdString()}." }
+                    jobs.forEach { it.cancel() }
+                }
+            }
+
+        return try {
+            when (val result = completion.await()) {
+                is BroadcastCompletion.Accepted -> {
+                    Twig.info {
+                        "$logTag Transaction ${transaction.txIdString()} accepted by ${result.endpoint.serverString()}."
+                    }
+                    scope.launch {
+                        delay(gracePeriodMillis)
+                        jobs.forEach { it.cancel() }
+                        timeoutJob.cancel()
+                    }
+                    result.result
+                }
+
+                is BroadcastCompletion.Rejected -> {
+                    timeoutJob.cancel()
+                    jobs.forEach { it.cancel() }
+                    Twig.error {
+                        "$logTag Transaction ${transaction.txIdString()} rejected by all ${endpoints.size} endpoint(s)."
+                    }
+                    result.result
+                }
+            }
+        } catch (e: CancellationException) {
+            timeoutJob.cancel()
+            jobs.forEach { it.cancel() }
+            throw e
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun submitToEndpoint(
+        transaction: CreatedTransaction,
+        endpoint: LightWalletEndpoint,
+        logTag: String
+    ): TransactionSubmitResult =
+        try {
+            val result = submit(transaction, endpoint)
+            when (result) {
+                is TransactionSubmitResult.Success -> {
+                    Twig.info { "$logTag ${endpoint.serverString()} SUCCESS ${transaction.txIdString()}." }
+                }
+
+                is TransactionSubmitResult.Failure -> {
+                    Twig.warn {
+                        "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}: " +
+                            "${result.code} ${result.description}"
+                    }
+                }
+
+                is TransactionSubmitResult.NotAttempted -> {
+                    Twig.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED ${transaction.txIdString()}." }
+                }
+            }
+            result
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Twig.warn(e) { "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}." }
+            createGrpcFailure(transaction, e.message)
+        }
+
+    private fun selectRejectedResult(
+        transaction: CreatedTransaction,
+        results: List<TransactionSubmitResult>
+    ): TransactionSubmitResult =
+        results
+            .filterIsInstance<TransactionSubmitResult.Failure>()
+            .lastOrNull { !it.grpcError }
+            ?: results
+                .filterIsInstance<TransactionSubmitResult.Failure>()
+                .lastOrNull()
+            ?: createGrpcFailure(transaction, "All endpoints rejected transaction")
+
+    private fun selectTimeoutCompletion(
+        transaction: CreatedTransaction,
+        submissions: List<EndpointSubmission>
+    ): BroadcastCompletion =
+        submissions
+            .firstNotNullOfOrNull { submission ->
+                (submission.result as? TransactionSubmitResult.Success)?.let {
+                    BroadcastCompletion.Accepted(
+                        endpoint = submission.endpoint,
+                        result = it
+                    )
+                }
+            }
+            ?: submissions
+                .map { it.result }
+                .takeIf { it.isNotEmpty() }
+                ?.let {
+                    BroadcastCompletion.Rejected(
+                        result = selectRejectedResult(transaction, it)
+                    )
+                }
+            ?: BroadcastCompletion.Rejected(
+                result = createGrpcFailure(transaction, "Timed out submitting to endpoints")
+            )
+
+    private fun createGrpcFailure(transaction: CreatedTransaction, description: String?) =
+        TransactionSubmitResult.Failure(
+            txId = transaction.txId,
+            grpcError = true,
+            code = MULTI_SUBMIT_GRPC_FAILURE_CODE,
+            description = description
+        )
+}
+
+private fun LightWalletEndpoint.serverString() = "$host:$port"
+
+private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
+private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
+private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
+
+private data class EndpointSubmission(
+    val endpoint: LightWalletEndpoint,
+    val result: TransactionSubmitResult
+)
+
+private sealed interface BroadcastCompletion {
+    data class Accepted(
+        val endpoint: LightWalletEndpoint,
+        val result: TransactionSubmitResult.Success
+    ) : BroadcastCompletion
+
+    data class Rejected(
+        val result: TransactionSubmitResult
+    ) : BroadcastCompletion
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger
 internal class MultiEndpointTransactionSubmitter(
     private val scope: CoroutineScope,
     private val globalTimeoutMillis: Long = MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS,
+    private val timeoutDrainMillis: Long = MULTI_SUBMIT_TIMEOUT_DRAIN_MILLIS,
     private val gracePeriodMillis: Long = MULTI_SUBMIT_GRACE_PERIOD_MILLIS,
     private val logger: MultiEndpointTransactionSubmitterLogger = TwigMultiEndpointTransactionSubmitterLogger,
     private val submit: suspend (CreatedTransaction, LightWalletEndpoint) -> TransactionSubmitResult
@@ -144,14 +145,13 @@ internal class MultiEndpointTransactionSubmitter(
         val timeoutJob =
             scope.launch {
                 delay(globalTimeoutMillis)
+                // Let endpoint calls that completed at the deadline publish their result before reporting timeout.
+                delay(timeoutDrainMillis)
+                if (completion.isCompleted) {
+                    return@launch
+                }
                 val completedSubmissions =
-                    jobs.mapNotNull { job ->
-                        if (job.isCompleted && !job.isCancelled) {
-                            runCatching { job.await() }.getOrNull()
-                        } else {
-                            null
-                        }
-                    }
+                    jobs.completedSubmissions()
                 val timeoutResult =
                     selectTimeoutCompletion(
                         transaction = transaction,
@@ -295,8 +295,16 @@ internal class MultiEndpointTransactionSubmitter(
             code = MULTI_SUBMIT_GRPC_FAILURE_CODE,
             description = description
         )
-
 }
+
+private suspend fun List<Deferred<EndpointSubmission>>.completedSubmissions() =
+    mapNotNull { job ->
+        if (job.isCompleted && !job.isCancelled) {
+            runCatching { job.await() }.getOrNull()
+        } else {
+            null
+        }
+    }
 
 private fun LightWalletEndpoint.serverString() = "$host:$port"
 
@@ -333,6 +341,7 @@ private object TwigMultiEndpointTransactionSubmitterLogger : MultiEndpointTransa
 
 private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
 private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
+private const val MULTI_SUBMIT_TIMEOUT_DRAIN_MILLIS = 2_000L
 private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
 
 private data class BroadcastSubmissionState(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -259,8 +259,8 @@ internal class MultiEndpointTransactionSubmitter(
             }
 
         return failures
-            .lastOrNull { !it.grpcError }
-            ?: failures.lastOrNull()
+            .firstOrNull { !it.grpcError }
+            ?: failures.firstOrNull()
             ?: createGrpcFailure(transaction, "All endpoints rejected transaction")
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -59,8 +59,9 @@ internal class MultiEndpointTransactionSubmitter(
         transactionCount: Int,
         logTag: String
     ): TransactionSubmitResult {
+        val transactionLabel = "transaction ${index + 1}/$transactionCount"
         if (endpoints.isEmpty()) {
-            logger.error { "$logTag No endpoints available for transaction ${transaction.txIdString()}." }
+            logger.error { "$logTag No endpoints available for $transactionLabel." }
             return createGrpcFailure(transaction, "No endpoints available")
         }
 
@@ -77,6 +78,7 @@ internal class MultiEndpointTransactionSubmitter(
         return broadcastToEndpoints(
             transaction = transaction,
             endpoints = endpoints,
+            transactionLabel = transactionLabel,
             logTag = logTag
         )
     }
@@ -84,6 +86,7 @@ internal class MultiEndpointTransactionSubmitter(
     private suspend fun broadcastToEndpoints(
         transaction: CreatedTransaction,
         endpoints: List<LightWalletEndpoint>,
+        transactionLabel: String,
         logTag: String
     ): TransactionSubmitResult {
         val completion = CompletableDeferred<BroadcastCompletion>()
@@ -99,6 +102,7 @@ internal class MultiEndpointTransactionSubmitter(
                                 submitToEndpoint(
                                     transaction = transaction,
                                     endpoint = endpoint,
+                                    transactionLabel = transactionLabel,
                                     logTag = logTag
                                 )
                         )
@@ -158,13 +162,12 @@ internal class MultiEndpointTransactionSubmitter(
                         submissions = completedSubmissions
                     )
                 if (completion.complete(timeoutResult)) {
-                    logger.error { "$logTag Timed out waiting for any endpoint to accept ${transaction.txIdString()}." }
+                    logger.error { "$logTag Timed out waiting for any endpoint to accept $transactionLabel." }
                     jobs.forEach { it.cancel() }
                 }
             }
 
         return awaitBroadcastCompletion(
-            transaction = transaction,
             endpointCount = endpoints.size,
             state =
                 BroadcastSubmissionState(
@@ -172,21 +175,22 @@ internal class MultiEndpointTransactionSubmitter(
                     jobs = jobs,
                     timeoutJob = timeoutJob
                 ),
+            transactionLabel = transactionLabel,
             logTag = logTag
         )
     }
 
     private suspend fun awaitBroadcastCompletion(
-        transaction: CreatedTransaction,
         endpointCount: Int,
         state: BroadcastSubmissionState,
+        transactionLabel: String,
         logTag: String
     ): TransactionSubmitResult =
         try {
             when (val result = state.completion.await()) {
                 is BroadcastCompletion.Accepted -> {
                     logger.info {
-                        "$logTag Transaction ${transaction.txIdString()} accepted by ${result.endpoint.serverString()}."
+                        "$logTag $transactionLabel accepted by ${result.endpoint.serverString()}."
                     }
                     state.cancelAfterGracePeriod()
                     result.result
@@ -195,7 +199,7 @@ internal class MultiEndpointTransactionSubmitter(
                 is BroadcastCompletion.Rejected -> {
                     state.cancel()
                     logger.error {
-                        "$logTag Transaction ${transaction.txIdString()} rejected by all $endpointCount endpoint(s)."
+                        "$logTag $transactionLabel rejected by all $endpointCount endpoint(s)."
                     }
                     result.result
                 }
@@ -221,31 +225,32 @@ internal class MultiEndpointTransactionSubmitter(
     private suspend fun submitToEndpoint(
         transaction: CreatedTransaction,
         endpoint: LightWalletEndpoint,
+        transactionLabel: String,
         logTag: String
     ): TransactionSubmitResult =
         try {
             val result = submit(transaction, endpoint)
             when (result) {
                 is TransactionSubmitResult.Success -> {
-                    logger.info { "$logTag ${endpoint.serverString()} SUCCESS ${transaction.txIdString()}." }
+                    logger.info { "$logTag ${endpoint.serverString()} SUCCESS $transactionLabel." }
                 }
 
                 is TransactionSubmitResult.Failure -> {
                     logger.warn {
-                        "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}: " +
+                        "$logTag ${endpoint.serverString()} FAILED $transactionLabel: " +
                             "${result.code} ${result.description}"
                     }
                 }
 
                 is TransactionSubmitResult.NotAttempted -> {
-                    logger.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED ${transaction.txIdString()}." }
+                    logger.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED $transactionLabel." }
                 }
             }
             result
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            logger.warn(e) { "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}." }
+            logger.warn(e) { "$logTag ${endpoint.serverString()} FAILED $transactionLabel." }
             createGrpcFailure(transaction, e.message)
         }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -63,25 +63,21 @@ internal class MultiEndpointTransactionSubmitter(
             return createGrpcFailure(transaction, "No endpoints available")
         }
 
-        return if (endpoints.size == 1) {
+        if (endpoints.size == 1) {
             logger.info {
                 "$logTag Submitting transaction ${index + 1}/$transactionCount to ${endpoints.first().serverString()}."
             }
-            submitToEndpoint(
-                transaction = transaction,
-                endpoint = endpoints.first(),
-                logTag = logTag
-            )
         } else {
             logger.info {
                 "$logTag Broadcasting transaction ${index + 1}/$transactionCount to ${endpoints.size} endpoints."
             }
-            broadcastToEndpoints(
-                transaction = transaction,
-                endpoints = endpoints,
-                logTag = logTag
-            )
         }
+
+        return broadcastToEndpoints(
+            transaction = transaction,
+            endpoints = endpoints,
+            logTag = logTag
+        )
     }
 
     private suspend fun broadcastToEndpoints(
@@ -91,7 +87,7 @@ internal class MultiEndpointTransactionSubmitter(
     ): TransactionSubmitResult {
         val completion = CompletableDeferred<BroadcastCompletion>()
         val failureCount = AtomicInteger(0)
-        val failures = ConcurrentLinkedQueue<TransactionSubmitResult>()
+        val failures = ConcurrentLinkedQueue<EndpointSubmission>()
         val jobs =
             endpoints.map { endpoint ->
                 scope
@@ -131,7 +127,7 @@ internal class MultiEndpointTransactionSubmitter(
 
                                     is TransactionSubmitResult.Failure,
                                     is TransactionSubmitResult.NotAttempted -> {
-                                        failures += result
+                                        failures += submission
                                         if (failureCount.incrementAndGet() >= endpoints.size) {
                                             completion.complete(
                                                 BroadcastCompletion.Rejected(
@@ -255,15 +251,18 @@ internal class MultiEndpointTransactionSubmitter(
 
     private fun selectRejectedResult(
         transaction: CreatedTransaction,
-        results: List<TransactionSubmitResult>
-    ): TransactionSubmitResult =
-        results
-            .filterIsInstance<TransactionSubmitResult.Failure>()
+        submissions: List<EndpointSubmission>
+    ): TransactionSubmitResult {
+        val failures =
+            submissions.mapNotNull { submission ->
+                (submission.result as? TransactionSubmitResult.Failure)?.withEndpoint(submission.endpoint)
+            }
+
+        return failures
             .lastOrNull { !it.grpcError }
-            ?: results
-                .filterIsInstance<TransactionSubmitResult.Failure>()
-                .lastOrNull()
+            ?: failures.lastOrNull()
             ?: createGrpcFailure(transaction, "All endpoints rejected transaction")
+    }
 
     private fun selectTimeoutCompletion(
         transaction: CreatedTransaction,
@@ -279,7 +278,6 @@ internal class MultiEndpointTransactionSubmitter(
                 }
             }
             ?: submissions
-                .map { it.result }
                 .takeIf { it.isNotEmpty() }
                 ?.let {
                     BroadcastCompletion.Rejected(
@@ -296,6 +294,11 @@ internal class MultiEndpointTransactionSubmitter(
             grpcError = true,
             code = MULTI_SUBMIT_GRPC_FAILURE_CODE,
             description = description
+        )
+
+    private fun TransactionSubmitResult.Failure.withEndpoint(endpoint: LightWalletEndpoint) =
+        copy(
+            description = description?.let { "${endpoint.serverString()}: $it" } ?: endpoint.serverString()
         )
 }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -296,13 +296,14 @@ internal class MultiEndpointTransactionSubmitter(
             description = description
         )
 
-    private fun TransactionSubmitResult.Failure.withEndpoint(endpoint: LightWalletEndpoint) =
-        copy(
-            description = description?.let { "${endpoint.serverString()}: $it" } ?: endpoint.serverString()
-        )
 }
 
 private fun LightWalletEndpoint.serverString() = "$host:$port"
+
+private fun TransactionSubmitResult.Failure.withEndpoint(endpoint: LightWalletEndpoint) =
+    copy(
+        description = description?.let { "${endpoint.serverString()}: $it" } ?: endpoint.serverString()
+    )
 
 internal interface MultiEndpointTransactionSubmitterLogger {
     fun info(message: () -> String)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -35,33 +35,37 @@ internal class MultiEndpointTransactionSubmitter(
         var completedNormally = false
 
         try {
-            val results = transactions.mapIndexed { index, transaction ->
-                if (anySubmissionFailed) {
-                    TransactionSubmitResult.NotAttempted(transaction.txId)
-                } else {
-                    val result =
-                        submitTransaction(
-                            transaction = transaction,
-                            endpoints = endpoints,
-                            index = index,
-                            transactionCount = transactions.size,
-                            logTag = logTag
-                        )
-
-                    if (result is TransactionSubmitResult.Success) {
-                        hasSuccessfulBroadcast = true
+            val results =
+                transactions.mapIndexed { index, transaction ->
+                    if (anySubmissionFailed) {
+                        TransactionSubmitResult.NotAttempted(transaction.txId)
                     } else {
-                        anySubmissionFailed = true
-                    }
+                        val result =
+                            submitTransaction(
+                                transaction = transaction,
+                                endpoints = endpoints,
+                                index = index,
+                                transactionCount = transactions.size,
+                                logTag = logTag
+                            )
 
-                    result
+                        if (result is TransactionSubmitResult.Success) {
+                            hasSuccessfulBroadcast = true
+                        } else {
+                            anySubmissionFailed = true
+                        }
+
+                        result
+                    }
                 }
-            }
             completedNormally = true
             return results
         } finally {
             if (completedNormally && hasSuccessfulBroadcast) {
-                closeAfterGracePeriod()
+                scope.launch {
+                    delay(gracePeriodMillis)
+                    close()
+                }
             } else {
                 close()
             }
@@ -215,13 +219,6 @@ internal class MultiEndpointTransactionSubmitter(
             state.cancel()
             throw e
         }
-
-    private fun closeAfterGracePeriod() {
-        scope.launch {
-            delay(gracePeriodMillis)
-            close()
-        }
-    }
 
     private fun BroadcastSubmissionState.cancelJobsAfterGracePeriod() {
         scope.launch {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -343,7 +343,7 @@ private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
 private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
 private const val MULTI_SUBMIT_TIMEOUT_DRAIN_MILLIS = 2_000L
 private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
-private const val MULTI_SUBMIT_TIMEOUT_DESCRIPTION =
+internal const val MULTI_SUBMIT_TIMEOUT_DESCRIPTION =
     "Timed out waiting for endpoint response; transaction may still have been broadcast"
 
 private data class BroadcastSubmissionState(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -159,7 +159,8 @@ internal class MultiEndpointTransactionSubmitter(
                 val timeoutResult =
                     selectTimeoutCompletion(
                         transaction = transaction,
-                        submissions = completedSubmissions
+                        submissions = completedSubmissions,
+                        endpointCount = endpoints.size
                     )
                 if (completion.complete(timeoutResult)) {
                     logger.error { "$logTag Timed out waiting for any endpoint to accept $transactionLabel." }
@@ -271,7 +272,8 @@ internal class MultiEndpointTransactionSubmitter(
 
     private fun selectTimeoutCompletion(
         transaction: CreatedTransaction,
-        submissions: List<EndpointSubmission>
+        submissions: List<EndpointSubmission>,
+        endpointCount: Int
     ): BroadcastCompletion =
         submissions
             .firstNotNullOfOrNull { submission ->
@@ -283,7 +285,7 @@ internal class MultiEndpointTransactionSubmitter(
                 }
             }
             ?: submissions
-                .takeIf { it.isNotEmpty() }
+                .takeIf { it.size >= endpointCount }
                 ?.let {
                     BroadcastCompletion.Rejected(
                         result = selectRejectedResult(transaction, it)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -100,55 +100,43 @@ internal class MultiEndpointTransactionSubmitter(
 
                 scope
                     .async {
-                        EndpointSubmission(
-                            endpointLabel = endpointLabel,
-                            result =
-                                submitToEndpoint(
-                                    transaction = transaction,
-                                    endpoint = endpoint,
-                                    endpointLabel = endpointLabel,
-                                    transactionLabel = transactionLabel,
-                                    logTag = logTag
+                        val submission =
+                            EndpointSubmission(
+                                endpointLabel = endpointLabel,
+                                result =
+                                    submitToEndpoint(
+                                        transaction = transaction,
+                                        endpoint = endpoint,
+                                        endpointLabel = endpointLabel,
+                                        transactionLabel = transactionLabel,
+                                        logTag = logTag
+                                    )
+                            )
+
+                        when (val result = submission.result) {
+                            is TransactionSubmitResult.Success -> {
+                                completion.complete(
+                                    BroadcastCompletion.Accepted(
+                                        endpointLabel = submission.endpointLabel,
+                                        result = result
+                                    )
                                 )
-                        )
-                    }.also { job ->
-                        job.invokeOnCompletion { throwable ->
-                            if (throwable is CancellationException) return@invokeOnCompletion
+                            }
 
-                            scope.launch {
-                                val submission =
-                                    runCatching { job.await() }
-                                        .getOrElse {
-                                            EndpointSubmission(
-                                                endpointLabel = endpointLabel,
-                                                result = createGrpcFailure(transaction, SUBMIT_EXCEPTION_DESCRIPTION)
-                                            )
-                                        }
-
-                                when (val result = submission.result) {
-                                    is TransactionSubmitResult.Success -> {
-                                        completion.complete(
-                                            BroadcastCompletion.Accepted(
-                                                endpointLabel = submission.endpointLabel,
-                                                result = result
-                                            )
+                            is TransactionSubmitResult.Failure,
+                            is TransactionSubmitResult.NotAttempted -> {
+                                failures += submission
+                                if (failureCount.incrementAndGet() >= endpoints.size) {
+                                    completion.complete(
+                                        BroadcastCompletion.Rejected(
+                                            result = selectRejectedResult(transaction, failures.toList())
                                         )
-                                    }
-
-                                    is TransactionSubmitResult.Failure,
-                                    is TransactionSubmitResult.NotAttempted -> {
-                                        failures += submission
-                                        if (failureCount.incrementAndGet() >= endpoints.size) {
-                                            completion.complete(
-                                                BroadcastCompletion.Rejected(
-                                                    result = selectRejectedResult(transaction, failures.toList())
-                                                )
-                                            )
-                                        }
-                                    }
+                                    )
                                 }
                             }
                         }
+
+                        submission
                     }
             }
         val timeoutJob =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -141,9 +141,8 @@ internal class MultiEndpointTransactionSubmitter(
             }
         val timeoutJob =
             scope.launch {
-                delay(globalTimeoutMillis)
                 // Let endpoint calls that completed at the deadline publish their result before reporting timeout.
-                delay(timeoutDrainMillis)
+                delay(globalTimeoutMillis + timeoutDrainMillis)
                 if (completion.isCompleted) {
                     return@launch
                 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -17,6 +17,7 @@ internal class MultiEndpointTransactionSubmitter(
     private val scope: CoroutineScope,
     private val globalTimeoutMillis: Long = MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS,
     private val gracePeriodMillis: Long = MULTI_SUBMIT_GRACE_PERIOD_MILLIS,
+    private val logger: MultiEndpointTransactionSubmitterLogger = TwigMultiEndpointTransactionSubmitterLogger,
     private val submit: suspend (CreatedTransaction, LightWalletEndpoint) -> TransactionSubmitResult
 ) {
     suspend fun submitTransactions(
@@ -56,12 +57,12 @@ internal class MultiEndpointTransactionSubmitter(
         logTag: String
     ): TransactionSubmitResult {
         if (endpoints.isEmpty()) {
-            Twig.error { "$logTag No endpoints available for transaction ${transaction.txIdString()}." }
+            logger.error { "$logTag No endpoints available for transaction ${transaction.txIdString()}." }
             return createGrpcFailure(transaction, "No endpoints available")
         }
 
         return if (endpoints.size == 1) {
-            Twig.info {
+            logger.info {
                 "$logTag Submitting transaction ${index + 1}/$transactionCount to ${endpoints.first().serverString()}."
             }
             submitToEndpoint(
@@ -70,7 +71,7 @@ internal class MultiEndpointTransactionSubmitter(
                 logTag = logTag
             )
         } else {
-            Twig.info {
+            logger.info {
                 "$logTag Broadcasting transaction ${index + 1}/$transactionCount to ${endpoints.size} endpoints."
             }
             broadcastToEndpoints(
@@ -159,7 +160,7 @@ internal class MultiEndpointTransactionSubmitter(
                         submissions = completedSubmissions
                     )
                 if (completion.complete(timeoutResult)) {
-                    Twig.error { "$logTag Timed out waiting for any endpoint to accept ${transaction.txIdString()}." }
+                    logger.error { "$logTag Timed out waiting for any endpoint to accept ${transaction.txIdString()}." }
                     jobs.forEach { it.cancel() }
                 }
             }
@@ -167,7 +168,7 @@ internal class MultiEndpointTransactionSubmitter(
         return try {
             when (val result = completion.await()) {
                 is BroadcastCompletion.Accepted -> {
-                    Twig.info {
+                    logger.info {
                         "$logTag Transaction ${transaction.txIdString()} accepted by ${result.endpoint.serverString()}."
                     }
                     scope.launch {
@@ -181,7 +182,7 @@ internal class MultiEndpointTransactionSubmitter(
                 is BroadcastCompletion.Rejected -> {
                     timeoutJob.cancel()
                     jobs.forEach { it.cancel() }
-                    Twig.error {
+                    logger.error {
                         "$logTag Transaction ${transaction.txIdString()} rejected by all ${endpoints.size} endpoint(s)."
                     }
                     result.result
@@ -204,25 +205,25 @@ internal class MultiEndpointTransactionSubmitter(
             val result = submit(transaction, endpoint)
             when (result) {
                 is TransactionSubmitResult.Success -> {
-                    Twig.info { "$logTag ${endpoint.serverString()} SUCCESS ${transaction.txIdString()}." }
+                    logger.info { "$logTag ${endpoint.serverString()} SUCCESS ${transaction.txIdString()}." }
                 }
 
                 is TransactionSubmitResult.Failure -> {
-                    Twig.warn {
+                    logger.warn {
                         "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}: " +
                             "${result.code} ${result.description}"
                     }
                 }
 
                 is TransactionSubmitResult.NotAttempted -> {
-                    Twig.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED ${transaction.txIdString()}." }
+                    logger.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED ${transaction.txIdString()}." }
                 }
             }
             result
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Twig.warn(e) { "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}." }
+            logger.warn(e) { "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}." }
             createGrpcFailure(transaction, e.message)
         }
 
@@ -273,6 +274,32 @@ internal class MultiEndpointTransactionSubmitter(
 }
 
 private fun LightWalletEndpoint.serverString() = "$host:$port"
+
+internal interface MultiEndpointTransactionSubmitterLogger {
+    fun info(message: () -> String)
+
+    fun warn(message: () -> String)
+
+    fun warn(
+        throwable: Throwable,
+        message: () -> String
+    )
+
+    fun error(message: () -> String)
+}
+
+private object TwigMultiEndpointTransactionSubmitterLogger : MultiEndpointTransactionSubmitterLogger {
+    override fun info(message: () -> String) = Twig.info(message)
+
+    override fun warn(message: () -> String) = Twig.warn(message)
+
+    override fun warn(
+        throwable: Throwable,
+        message: () -> String
+    ) = Twig.warn(throwable, message)
+
+    override fun error(message: () -> String) = Twig.error(message)
+}
 
 private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
 private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -285,7 +285,7 @@ internal class MultiEndpointTransactionSubmitter(
                     )
                 }
             ?: BroadcastCompletion.Rejected(
-                result = createGrpcFailure(transaction, "Timed out submitting to endpoints")
+                result = createGrpcFailure(transaction, MULTI_SUBMIT_TIMEOUT_DESCRIPTION)
             )
 
     private fun createGrpcFailure(transaction: CreatedTransaction, description: String?) =
@@ -343,6 +343,8 @@ private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
 private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
 private const val MULTI_SUBMIT_TIMEOUT_DRAIN_MILLIS = 2_000L
 private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
+private const val MULTI_SUBMIT_TIMEOUT_DESCRIPTION =
+    "Timed out waiting for endpoint response; transaction may still have been broadcast"
 
 private data class BroadcastSubmissionState(
     val completion: CompletableDeferred<BroadcastCompletion>,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -31,25 +31,39 @@ internal class MultiEndpointTransactionSubmitter(
         logTag: String
     ): List<TransactionSubmitResult> {
         var anySubmissionFailed = false
+        var hasSuccessfulBroadcast = false
+        var completedNormally = false
 
-        return transactions.mapIndexed { index, transaction ->
-            if (anySubmissionFailed) {
-                TransactionSubmitResult.NotAttempted(transaction.txId)
-            } else {
-                val result =
-                    submitTransaction(
-                        transaction = transaction,
-                        endpoints = endpoints,
-                        index = index,
-                        transactionCount = transactions.size,
-                        logTag = logTag
-                    )
+        try {
+            val results = transactions.mapIndexed { index, transaction ->
+                if (anySubmissionFailed) {
+                    TransactionSubmitResult.NotAttempted(transaction.txId)
+                } else {
+                    val result =
+                        submitTransaction(
+                            transaction = transaction,
+                            endpoints = endpoints,
+                            index = index,
+                            transactionCount = transactions.size,
+                            logTag = logTag
+                        )
 
-                if (result !is TransactionSubmitResult.Success) {
-                    anySubmissionFailed = true
+                    if (result is TransactionSubmitResult.Success) {
+                        hasSuccessfulBroadcast = true
+                    } else {
+                        anySubmissionFailed = true
+                    }
+
+                    result
                 }
-
-                result
+            }
+            completedNormally = true
+            return results
+        } finally {
+            if (completedNormally && hasSuccessfulBroadcast) {
+                closeAfterGracePeriod()
+            } else {
+                close()
             }
         }
     }
@@ -185,7 +199,7 @@ internal class MultiEndpointTransactionSubmitter(
                     logger.info {
                         "$logTag $transactionLabel accepted by ${result.endpointLabel}."
                     }
-                    state.cancelAfterGracePeriod()
+                    state.cancelJobsAfterGracePeriod()
                     result.result
                 }
 
@@ -202,7 +216,14 @@ internal class MultiEndpointTransactionSubmitter(
             throw e
         }
 
-    private fun BroadcastSubmissionState.cancelAfterGracePeriod() {
+    private fun closeAfterGracePeriod() {
+        scope.launch {
+            delay(gracePeriodMillis)
+            close()
+        }
+    }
+
+    private fun BroadcastSubmissionState.cancelJobsAfterGracePeriod() {
         scope.launch {
             delay(gracePeriodMillis)
             cancel()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -4,10 +4,12 @@ import cash.z.ecc.android.sdk.model.CreatedTransaction
 import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.util.CloseableScopeHolder
+import co.electriccoin.zcash.ui.util.CloseableScopeHolderImpl
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -16,13 +18,13 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 internal class MultiEndpointTransactionSubmitter(
-    private val scope: CoroutineScope,
+    closeableScopeHolder: CloseableScopeHolder = CloseableScopeHolderImpl(Dispatchers.IO),
     private val globalTimeoutMillis: Long = MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS,
     private val timeoutDrainMillis: Long = MULTI_SUBMIT_TIMEOUT_DRAIN_MILLIS,
     private val gracePeriodMillis: Long = MULTI_SUBMIT_GRACE_PERIOD_MILLIS,
     private val logger: MultiEndpointTransactionSubmitterLogger = TwigMultiEndpointTransactionSubmitterLogger,
     private val submit: suspend (CreatedTransaction, LightWalletEndpoint) -> TransactionSubmitResult
-) {
+) : CloseableScopeHolder by closeableScopeHolder {
     suspend fun submitTransactions(
         transactions: List<CreatedTransaction>,
         endpoints: List<LightWalletEndpoint>,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -67,7 +67,7 @@ internal class MultiEndpointTransactionSubmitter(
 
         if (endpoints.size == 1) {
             logger.info {
-                "$logTag Submitting transaction ${index + 1}/$transactionCount to ${endpoints.first().serverString()}."
+                "$logTag Submitting $transactionLabel to endpoint 1/1."
             }
         } else {
             logger.info {
@@ -93,15 +93,18 @@ internal class MultiEndpointTransactionSubmitter(
         val failureCount = AtomicInteger(0)
         val failures = ConcurrentLinkedQueue<EndpointSubmission>()
         val jobs =
-            endpoints.map { endpoint ->
+            endpoints.mapIndexed { endpointIndex, endpoint ->
+                val endpointLabel = endpointLabel(endpointIndex, endpoints.size)
+
                 scope
                     .async {
                         EndpointSubmission(
-                            endpoint = endpoint,
+                            endpointLabel = endpointLabel,
                             result =
                                 submitToEndpoint(
                                     transaction = transaction,
                                     endpoint = endpoint,
+                                    endpointLabel = endpointLabel,
                                     transactionLabel = transactionLabel,
                                     logTag = logTag
                                 )
@@ -115,8 +118,8 @@ internal class MultiEndpointTransactionSubmitter(
                                     runCatching { job.await() }
                                         .getOrElse {
                                             EndpointSubmission(
-                                                endpoint = endpoint,
-                                                result = createGrpcFailure(transaction, it.message)
+                                                endpointLabel = endpointLabel,
+                                                result = createGrpcFailure(transaction, SUBMIT_EXCEPTION_DESCRIPTION)
                                             )
                                         }
 
@@ -124,7 +127,7 @@ internal class MultiEndpointTransactionSubmitter(
                                     is TransactionSubmitResult.Success -> {
                                         completion.complete(
                                             BroadcastCompletion.Accepted(
-                                                endpoint = submission.endpoint,
+                                                endpointLabel = submission.endpointLabel,
                                                 result = result
                                             )
                                         )
@@ -191,7 +194,7 @@ internal class MultiEndpointTransactionSubmitter(
             when (val result = state.completion.await()) {
                 is BroadcastCompletion.Accepted -> {
                     logger.info {
-                        "$logTag $transactionLabel accepted by ${result.endpoint.serverString()}."
+                        "$logTag $transactionLabel accepted by ${result.endpointLabel}."
                     }
                     state.cancelAfterGracePeriod()
                     result.result
@@ -226,6 +229,7 @@ internal class MultiEndpointTransactionSubmitter(
     private suspend fun submitToEndpoint(
         transaction: CreatedTransaction,
         endpoint: LightWalletEndpoint,
+        endpointLabel: String,
         transactionLabel: String,
         logTag: String
     ): TransactionSubmitResult =
@@ -233,26 +237,25 @@ internal class MultiEndpointTransactionSubmitter(
             val result = submit(transaction, endpoint)
             when (result) {
                 is TransactionSubmitResult.Success -> {
-                    logger.info { "$logTag ${endpoint.serverString()} SUCCESS $transactionLabel." }
+                    logger.info { "$logTag $endpointLabel SUCCESS $transactionLabel." }
                 }
 
                 is TransactionSubmitResult.Failure -> {
                     logger.warn {
-                        "$logTag ${endpoint.serverString()} FAILED $transactionLabel: " +
-                            "${result.code} ${result.description}"
+                        "$logTag $endpointLabel FAILED $transactionLabel: code=${result.code} grpc=${result.grpcError}"
                     }
                 }
 
                 is TransactionSubmitResult.NotAttempted -> {
-                    logger.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED $transactionLabel." }
+                    logger.warn { "$logTag $endpointLabel NOT_ATTEMPTED $transactionLabel." }
                 }
             }
             result
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
-            logger.warn(e) { "$logTag ${endpoint.serverString()} FAILED $transactionLabel." }
-            createGrpcFailure(transaction, e.message)
+        } catch (_: Exception) {
+            logger.warn { "$logTag $endpointLabel FAILED $transactionLabel with exception." }
+            createGrpcFailure(transaction, SUBMIT_EXCEPTION_DESCRIPTION)
         }
 
     private fun selectRejectedResult(
@@ -261,7 +264,7 @@ internal class MultiEndpointTransactionSubmitter(
     ): TransactionSubmitResult {
         val failures =
             submissions.mapNotNull { submission ->
-                (submission.result as? TransactionSubmitResult.Failure)?.withEndpoint(submission.endpoint)
+                submission.result as? TransactionSubmitResult.Failure
             }
 
         return failures
@@ -279,7 +282,7 @@ internal class MultiEndpointTransactionSubmitter(
             .firstNotNullOfOrNull { submission ->
                 (submission.result as? TransactionSubmitResult.Success)?.let {
                     BroadcastCompletion.Accepted(
-                        endpoint = submission.endpoint,
+                        endpointLabel = submission.endpointLabel,
                         result = it
                     )
                 }
@@ -313,22 +316,12 @@ private suspend fun List<Deferred<EndpointSubmission>>.completedSubmissions() =
         }
     }
 
-private fun LightWalletEndpoint.serverString() = "$host:$port"
-
-private fun TransactionSubmitResult.Failure.withEndpoint(endpoint: LightWalletEndpoint) =
-    copy(
-        description = description?.let { "${endpoint.serverString()}: $it" } ?: endpoint.serverString()
-    )
+private fun endpointLabel(index: Int, count: Int) = "endpoint ${index + 1}/$count"
 
 internal interface MultiEndpointTransactionSubmitterLogger {
     fun info(message: () -> String)
 
     fun warn(message: () -> String)
-
-    fun warn(
-        throwable: Throwable,
-        message: () -> String
-    )
 
     fun error(message: () -> String)
 }
@@ -338,11 +331,6 @@ private object TwigMultiEndpointTransactionSubmitterLogger : MultiEndpointTransa
 
     override fun warn(message: () -> String) = Twig.warn(message)
 
-    override fun warn(
-        throwable: Throwable,
-        message: () -> String
-    ) = Twig.warn(throwable, message)
-
     override fun error(message: () -> String) = Twig.error(message)
 }
 
@@ -350,6 +338,7 @@ private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
 private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
 private const val MULTI_SUBMIT_TIMEOUT_DRAIN_MILLIS = 2_000L
 private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
+private const val SUBMIT_EXCEPTION_DESCRIPTION = "Endpoint submission failed"
 internal const val MULTI_SUBMIT_TIMEOUT_DESCRIPTION =
     "Timed out waiting for endpoint response; transaction may still have been broadcast"
 
@@ -360,13 +349,13 @@ private data class BroadcastSubmissionState(
 )
 
 private data class EndpointSubmission(
-    val endpoint: LightWalletEndpoint,
+    val endpointLabel: String,
     val result: TransactionSubmitResult
 )
 
 private sealed interface BroadcastCompletion {
     data class Accepted(
-        val endpoint: LightWalletEndpoint,
+        val endpointLabel: String,
         val result: TransactionSubmitResult.Success
     ) : BroadcastCompletion
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitter.kt
@@ -7,6 +7,8 @@ import co.electriccoin.zcash.spackle.Twig
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -165,34 +167,58 @@ internal class MultiEndpointTransactionSubmitter(
                 }
             }
 
-        return try {
-            when (val result = completion.await()) {
+        return awaitBroadcastCompletion(
+            transaction = transaction,
+            endpointCount = endpoints.size,
+            state =
+                BroadcastSubmissionState(
+                    completion = completion,
+                    jobs = jobs,
+                    timeoutJob = timeoutJob
+                ),
+            logTag = logTag
+        )
+    }
+
+    private suspend fun awaitBroadcastCompletion(
+        transaction: CreatedTransaction,
+        endpointCount: Int,
+        state: BroadcastSubmissionState,
+        logTag: String
+    ): TransactionSubmitResult =
+        try {
+            when (val result = state.completion.await()) {
                 is BroadcastCompletion.Accepted -> {
                     logger.info {
                         "$logTag Transaction ${transaction.txIdString()} accepted by ${result.endpoint.serverString()}."
                     }
-                    scope.launch {
-                        delay(gracePeriodMillis)
-                        jobs.forEach { it.cancel() }
-                        timeoutJob.cancel()
-                    }
+                    state.cancelAfterGracePeriod()
                     result.result
                 }
 
                 is BroadcastCompletion.Rejected -> {
-                    timeoutJob.cancel()
-                    jobs.forEach { it.cancel() }
+                    state.cancel()
                     logger.error {
-                        "$logTag Transaction ${transaction.txIdString()} rejected by all ${endpoints.size} endpoint(s)."
+                        "$logTag Transaction ${transaction.txIdString()} rejected by all $endpointCount endpoint(s)."
                     }
                     result.result
                 }
             }
         } catch (e: CancellationException) {
-            timeoutJob.cancel()
-            jobs.forEach { it.cancel() }
+            state.cancel()
             throw e
         }
+
+    private fun BroadcastSubmissionState.cancelAfterGracePeriod() {
+        scope.launch {
+            delay(gracePeriodMillis)
+            cancel()
+        }
+    }
+
+    private fun BroadcastSubmissionState.cancel() {
+        timeoutJob.cancel()
+        jobs.forEach { it.cancel() }
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -304,6 +330,12 @@ private object TwigMultiEndpointTransactionSubmitterLogger : MultiEndpointTransa
 private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
 private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
 private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
+
+private data class BroadcastSubmissionState(
+    val completion: CompletableDeferred<BroadcastCompletion>,
+    val jobs: List<Deferred<EndpointSubmission>>,
+    val timeoutJob: Job
+)
 
 private data class EndpointSubmission(
     val endpoint: LightWalletEndpoint,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -29,20 +29,13 @@ import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.ServerSelectionProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.zecdev.zip321.ZIP321
 import org.zecdev.zip321.parser.ParserContext
 import java.math.BigDecimal
-import java.util.Collections
-import java.util.concurrent.atomic.AtomicInteger
 
 interface ProposalDataSource {
     @Throws(
@@ -384,217 +377,17 @@ class ProposalDataSourceImpl(
         transactions: List<CreatedTransaction>,
         endpoints: List<LightWalletEndpoint>,
         logTag: String
-    ): List<TransactionSubmitResult> {
-        var anySubmissionFailed = false
-
-        return transactions.mapIndexed { index, transaction ->
-            if (anySubmissionFailed) {
-                TransactionSubmitResult.NotAttempted(transaction.txId)
-            } else {
-                val result =
-                    submitCreatedTransaction(
-                        synchronizer = synchronizer,
-                        transaction = transaction,
-                        endpoints = endpoints,
-                        index = index,
-                        transactionCount = transactions.size,
-                        logTag = logTag
-                    )
-
-                if (result !is TransactionSubmitResult.Success) {
-                    anySubmissionFailed = true
-                }
-
-                result
+    ): List<TransactionSubmitResult> =
+        MultiEndpointTransactionSubmitter(
+            scope = broadcastScope,
+            submit = { transaction, endpoint ->
+                synchronizer.broadcaster.submit(transaction, endpoint)
             }
-        }
-    }
-
-    private suspend fun submitCreatedTransaction(
-        synchronizer: SdkSynchronizer,
-        transaction: CreatedTransaction,
-        endpoints: List<LightWalletEndpoint>,
-        index: Int,
-        transactionCount: Int,
-        logTag: String
-    ): TransactionSubmitResult {
-        if (endpoints.isEmpty()) {
-            Twig.error { "$logTag No endpoints available for transaction ${transaction.txIdString()}." }
-            return createGrpcFailure(transaction, "No endpoints available")
-        }
-
-        return if (endpoints.size == 1) {
-            Twig.info {
-                "$logTag Submitting transaction ${index + 1}/$transactionCount to ${endpoints.first().serverString()}."
-            }
-            submitToEndpoint(
-                synchronizer = synchronizer,
-                transaction = transaction,
-                endpoint = endpoints.first(),
-                logTag = logTag
-            )
-        } else {
-            Twig.info {
-                "$logTag Broadcasting transaction ${index + 1}/$transactionCount to ${endpoints.size} endpoints."
-            }
-            broadcastToEndpoints(
-                synchronizer = synchronizer,
-                transaction = transaction,
-                endpoints = endpoints,
-                logTag = logTag
-            )
-        }
-    }
-
-    private suspend fun broadcastToEndpoints(
-        synchronizer: SdkSynchronizer,
-        transaction: CreatedTransaction,
-        endpoints: List<LightWalletEndpoint>,
-        logTag: String
-    ): TransactionSubmitResult {
-        val completion = CompletableDeferred<BroadcastCompletion>()
-        val failureCount = AtomicInteger(0)
-        val failures = Collections.synchronizedList(mutableListOf<TransactionSubmitResult>())
-        val jobs =
-            endpoints.map { endpoint ->
-                broadcastScope
-                    .async {
-                        EndpointSubmission(
-                            endpoint = endpoint,
-                            result =
-                                submitToEndpoint(
-                                    synchronizer = synchronizer,
-                                    transaction = transaction,
-                                    endpoint = endpoint,
-                                    logTag = logTag
-                                )
-                        )
-                    }.also { job ->
-                        job.invokeOnCompletion { throwable ->
-                            if (throwable is CancellationException) return@invokeOnCompletion
-
-                            broadcastScope.launch {
-                                val submission =
-                                    runCatching { job.await() }
-                                        .getOrElse {
-                                            EndpointSubmission(
-                                                endpoint = endpoint,
-                                                result = createGrpcFailure(transaction, it.message)
-                                            )
-                                        }
-
-                                when (val result = submission.result) {
-                                    is TransactionSubmitResult.Success -> {
-                                        completion.complete(
-                                            BroadcastCompletion.Accepted(
-                                                endpoint = submission.endpoint,
-                                                result = result
-                                            )
-                                        )
-                                    }
-
-                                    is TransactionSubmitResult.Failure,
-                                    is TransactionSubmitResult.NotAttempted -> {
-                                        failures += result
-                                        if (failureCount.incrementAndGet() >= endpoints.size) {
-                                            completion.complete(
-                                                BroadcastCompletion.Rejected(
-                                                    result = selectRejectedResult(transaction, failures)
-                                                )
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-        val timeoutJob =
-            broadcastScope.launch {
-                delay(MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS)
-                val completedSubmissions =
-                    jobs.mapNotNull { job ->
-                        if (job.isCompleted && !job.isCancelled) {
-                            runCatching { job.await() }.getOrNull()
-                        } else {
-                            null
-                        }
-                    }
-                val timeoutResult =
-                    selectTimeoutCompletion(
-                        transaction = transaction,
-                        submissions = completedSubmissions
-                    )
-                if (
-                    completion.complete(timeoutResult)
-                ) {
-                    Twig.error { "$logTag Timed out waiting for any endpoint to accept ${transaction.txIdString()}." }
-                    jobs.forEach { it.cancel() }
-                }
-            }
-
-        return try {
-            when (val result = completion.await()) {
-                is BroadcastCompletion.Accepted -> {
-                    Twig.info {
-                        "$logTag Transaction ${transaction.txIdString()} accepted by ${result.endpoint.serverString()}."
-                    }
-                    broadcastScope.launch {
-                        delay(MULTI_SUBMIT_GRACE_PERIOD_MILLIS)
-                        jobs.forEach { it.cancel() }
-                        timeoutJob.cancel()
-                    }
-                    result.result
-                }
-
-                is BroadcastCompletion.Rejected -> {
-                    timeoutJob.cancel()
-                    jobs.forEach { it.cancel() }
-                    Twig.error {
-                        "$logTag Transaction ${transaction.txIdString()} rejected by all ${endpoints.size} endpoint(s)."
-                    }
-                    result.result
-                }
-            }
-        } catch (e: CancellationException) {
-            timeoutJob.cancel()
-            jobs.forEach { it.cancel() }
-            throw e
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun submitToEndpoint(
-        synchronizer: SdkSynchronizer,
-        transaction: CreatedTransaction,
-        endpoint: LightWalletEndpoint,
-        logTag: String
-    ): TransactionSubmitResult =
-        try {
-            val result = synchronizer.broadcaster.submit(transaction, endpoint)
-            when (result) {
-                is TransactionSubmitResult.Success -> {
-                    Twig.info { "$logTag ${endpoint.serverString()} SUCCESS ${transaction.txIdString()}." }
-                }
-
-                is TransactionSubmitResult.Failure -> {
-                    Twig.warn {
-                        "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}: " +
-                            "${result.code} ${result.description}"
-                    }
-                }
-
-                is TransactionSubmitResult.NotAttempted -> {
-                    Twig.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED ${transaction.txIdString()}." }
-                }
-            }
-            result
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Twig.warn(e) { "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}." }
-            createGrpcFailure(transaction, e.message)
-        }
+        ).submitTransactions(
+            transactions = transactions,
+            endpoints = endpoints,
+            logTag = logTag
+        )
 
     private suspend fun getSubmissionEndpoints(): List<LightWalletEndpoint> {
         val selection = serverSelectionProvider.getServerSelection() ?: ServerSelection.automatic()
@@ -604,53 +397,6 @@ class ProposalDataSourceImpl(
             ConnectionMode.MANUAL -> listOf(checkNotNull(selection.endpoint))
         }
     }
-
-    private fun selectRejectedResult(
-        transaction: CreatedTransaction,
-        results: List<TransactionSubmitResult>
-    ): TransactionSubmitResult =
-        results
-            .filterIsInstance<TransactionSubmitResult.Failure>()
-            .lastOrNull { !it.grpcError }
-            ?: results
-                .filterIsInstance<TransactionSubmitResult.Failure>()
-                .lastOrNull()
-            ?: createGrpcFailure(transaction, "All endpoints rejected transaction")
-
-    private fun selectTimeoutCompletion(
-        transaction: CreatedTransaction,
-        submissions: List<EndpointSubmission>
-    ): BroadcastCompletion =
-        submissions
-            .firstNotNullOfOrNull { submission ->
-                (submission.result as? TransactionSubmitResult.Success)?.let {
-                    BroadcastCompletion.Accepted(
-                        endpoint = submission.endpoint,
-                        result = it
-                    )
-                }
-            }
-            ?: submissions
-                .map { it.result }
-                .takeIf { it.isNotEmpty() }
-                ?.let {
-                    BroadcastCompletion.Rejected(
-                        result = selectRejectedResult(transaction, it)
-                    )
-                }
-            ?: BroadcastCompletion.Rejected(
-                result = createGrpcFailure(transaction, "Timed out submitting to endpoints")
-            )
-
-    private fun createGrpcFailure(transaction: CreatedTransaction, description: String?) =
-        TransactionSubmitResult.Failure(
-            txId = transaction.txId,
-            grpcError = true,
-            code = MULTI_SUBMIT_GRPC_FAILURE_CODE,
-            description = description
-        )
-
-    private fun LightWalletEndpoint.serverString() = "$host:$port"
 
     @Suppress("TooGenericExceptionCaught")
     private suspend inline fun <T : Any> getOrThrow(block: (Synchronizer) -> T): T =
@@ -741,22 +487,3 @@ data class ExactOutputSwapTransactionProposal(
 private const val DEFAULT_SHIELDING_THRESHOLD = 100000L
 private const val MULTI_SUBMIT_TAG = "[MultiSubmit]"
 private const val MULTI_SUBMIT_PCZT_TAG = "[MultiSubmit/PCZT]"
-private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
-private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
-private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
-
-private data class EndpointSubmission(
-    val endpoint: LightWalletEndpoint,
-    val result: TransactionSubmitResult
-)
-
-private sealed interface BroadcastCompletion {
-    data class Accepted(
-        val endpoint: LightWalletEndpoint,
-        val result: TransactionSubmitResult.Success
-    ) : BroadcastCompletion
-
-    data class Rejected(
-        val result: TransactionSubmitResult
-    ) : BroadcastCompletion
-}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -284,8 +284,16 @@ class ProposalDataSourceImpl(
         withContext(Dispatchers.IO) {
             val synchronizer = synchronizerProvider.getSynchronizer() as SdkSynchronizer
             val transactions = block(synchronizer)
-            val endpoints = getSubmissionEndpoints()
 
+            if (transactions.isEmpty()) {
+                return@withContext SubmitResult.Failure(
+                    txIds = emptyList(),
+                    code = MULTI_SUBMIT_EMPTY_TRANSACTION_CODE,
+                    description = MULTI_SUBMIT_EMPTY_TRANSACTION_DESCRIPTION
+                )
+            }
+
+            val endpoints = getSubmissionEndpoints()
             Twig.info {
                 "$logTag Created ${transactions.size} transaction(s); submitting to ${endpoints.size} endpoint(s)."
             }
@@ -300,91 +308,7 @@ class ProposalDataSourceImpl(
 
             Twig.debug { "Internal transaction submit results: $submitResults" }
 
-            val successCount =
-                submitResults
-                    .count { it is TransactionSubmitResult.Success }
-            val txIds =
-                submitResults
-                    .map { it.txIdString() }
-            val statuses =
-                submitResults
-                    .map {
-                        when (it) {
-                            is TransactionSubmitResult.Success -> {
-                                "success"
-                            }
-
-                            is TransactionSubmitResult.Failure -> {
-                                if (it.grpcError) {
-                                    it.description.orEmpty()
-                                } else {
-                                    "code: ${it.code} desc: ${it.description}"
-                                }
-                            }
-
-                            is TransactionSubmitResult.NotAttempted -> {
-                                "notAttempted"
-                            }
-                        }
-                    }
-            val resubmittableFailures =
-                submitResults
-                    .mapNotNull {
-                        when (it) {
-                            is TransactionSubmitResult.Failure -> it.grpcError
-                            is TransactionSubmitResult.NotAttempted -> null
-                            is TransactionSubmitResult.Success -> null
-                        }
-                    }
-            val grpcFailureDescription =
-                submitResults
-                    .filterIsInstance<TransactionSubmitResult.Failure>()
-                    .lastOrNull { it.grpcError }
-                    ?.description
-            val grpcFailureReason =
-                if (grpcFailureDescription == MULTI_SUBMIT_TIMEOUT_DESCRIPTION) {
-                    SubmitResult.GrpcFailure.Reason.TIMEOUT
-                } else {
-                    null
-                }
-
-            val (errCode, errDesc) =
-                submitResults
-                    .filterIsInstance<TransactionSubmitResult.Failure>()
-                    .lastOrNull { !it.grpcError }
-                    ?.let { it.code to it.description } ?: (0 to "")
-
-            val result =
-                when (successCount) {
-                    0 -> {
-                        if (resubmittableFailures.all { it }) {
-                            SubmitResult.GrpcFailure(
-                                txIds = txIds,
-                                description = grpcFailureDescription,
-                                reason = grpcFailureReason
-                            )
-                        } else {
-                            SubmitResult.Failure(txIds = txIds, code = errCode, description = errDesc)
-                        }
-                    }
-
-                    txIds.size -> {
-                        SubmitResult.Success(txIds = txIds)
-                    }
-
-                    else -> {
-                        if (resubmittableFailures.all { it }) {
-                            SubmitResult.GrpcFailure(
-                                txIds = txIds,
-                                description = grpcFailureDescription,
-                                reason = grpcFailureReason
-                            )
-                        } else {
-                            SubmitResult.Partial(txIds = txIds, statuses = statuses)
-                        }
-                    }
-                }
-
+            val result = submitResults.toSubmitResult()
             synchronizer.refreshTransactions()
             synchronizer.refreshAllBalances()
             Twig.debug { "Transaction submit result: $result" }
@@ -449,6 +373,84 @@ class ProposalDataSourceImpl(
         }
 }
 
+internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
+    if (isEmpty()) {
+        return SubmitResult.Failure(
+            txIds = emptyList(),
+            code = MULTI_SUBMIT_EMPTY_TRANSACTION_CODE,
+            description = MULTI_SUBMIT_EMPTY_TRANSACTION_DESCRIPTION
+        )
+    }
+
+    val successCount = count { it is TransactionSubmitResult.Success }
+    val txIds = map { it.txIdString() }
+    val statuses =
+        map {
+            when (it) {
+                is TransactionSubmitResult.Success -> {
+                    "success"
+                }
+
+                is TransactionSubmitResult.Failure -> {
+                    if (it.grpcError) {
+                        it.description.orEmpty()
+                    } else {
+                        "code: ${it.code} desc: ${it.description}"
+                    }
+                }
+
+                is TransactionSubmitResult.NotAttempted -> {
+                    "notAttempted"
+                }
+            }
+        }
+    val resubmittableFailures =
+        mapNotNull {
+            when (it) {
+                is TransactionSubmitResult.Failure -> it.grpcError
+                is TransactionSubmitResult.NotAttempted -> null
+                is TransactionSubmitResult.Success -> null
+            }
+        }
+    val grpcFailureDescription =
+        filterIsInstance<TransactionSubmitResult.Failure>()
+            .lastOrNull { it.grpcError }
+            ?.description
+    val grpcFailureReason =
+        if (grpcFailureDescription == MULTI_SUBMIT_TIMEOUT_DESCRIPTION) {
+            SubmitResult.GrpcFailure.Reason.TIMEOUT
+        } else {
+            null
+        }
+
+    val (errCode, errDesc) =
+        filterIsInstance<TransactionSubmitResult.Failure>()
+            .lastOrNull { !it.grpcError }
+            ?.let { it.code to it.description } ?: (0 to "")
+
+    return when (successCount) {
+        0 -> {
+            if (resubmittableFailures.all { it }) {
+                SubmitResult.GrpcFailure(
+                    txIds = txIds,
+                    description = grpcFailureDescription,
+                    reason = grpcFailureReason
+                )
+            } else {
+                SubmitResult.Failure(txIds = txIds, code = errCode, description = errDesc)
+            }
+        }
+
+        txIds.size -> {
+            SubmitResult.Success(txIds = txIds)
+        }
+
+        else -> {
+            SubmitResult.Partial(txIds = txIds, statuses = statuses)
+        }
+    }
+}
+
 sealed interface TransactionProposal {
     val proposal: Proposal
 }
@@ -506,3 +508,5 @@ data class ExactOutputSwapTransactionProposal(
 private const val DEFAULT_SHIELDING_THRESHOLD = 100000L
 private const val MULTI_SUBMIT_TAG = "[MultiSubmit]"
 private const val MULTI_SUBMIT_PCZT_TAG = "[MultiSubmit/PCZT]"
+private const val MULTI_SUBMIT_EMPTY_TRANSACTION_CODE = -1
+private const val MULTI_SUBMIT_EMPTY_TRANSACTION_DESCRIPTION = "No transactions created"

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -384,36 +384,9 @@ internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
 
     val successCount = count { it is TransactionSubmitResult.Success }
     val txIds = map { it.txIdString() }
-    val statuses =
-        map {
-            when (it) {
-                is TransactionSubmitResult.Success -> {
-                    "success"
-                }
-
-                is TransactionSubmitResult.Failure -> {
-                    if (it.grpcError) {
-                        it.description.orEmpty()
-                    } else {
-                        "code: ${it.code} desc: ${it.description}"
-                    }
-                }
-
-                is TransactionSubmitResult.NotAttempted -> {
-                    "notAttempted"
-                }
-            }
-        }
-    val resubmittableFailures =
-        mapNotNull {
-            when (it) {
-                is TransactionSubmitResult.Failure -> it.grpcError
-                is TransactionSubmitResult.NotAttempted -> null
-                is TransactionSubmitResult.Success -> null
-            }
-        }
+    val failures = filterIsInstance<TransactionSubmitResult.Failure>()
     val grpcFailureDescription =
-        filterIsInstance<TransactionSubmitResult.Failure>()
+        failures
             .lastOrNull { it.grpcError }
             ?.description
     val grpcFailureReason =
@@ -424,13 +397,13 @@ internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
         }
 
     val (errCode, errDesc) =
-        filterIsInstance<TransactionSubmitResult.Failure>()
+        failures
             .lastOrNull { !it.grpcError }
             ?.let { it.code to it.description } ?: (0 to "")
 
     return when (successCount) {
         0 -> {
-            if (resubmittableFailures.all { it }) {
+            if (failures.all { it.grpcError }) {
                 SubmitResult.GrpcFailure(
                     txIds = txIds,
                     description = grpcFailureDescription,
@@ -446,10 +419,29 @@ internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
         }
 
         else -> {
-            SubmitResult.Partial(txIds = txIds, statuses = statuses)
+            SubmitResult.Partial(txIds = txIds, statuses = map { it.statusDescription() })
         }
     }
 }
+
+private fun TransactionSubmitResult.statusDescription() =
+    when (this) {
+        is TransactionSubmitResult.Success -> {
+            "success"
+        }
+
+        is TransactionSubmitResult.Failure -> {
+            if (grpcError) {
+                description.orEmpty()
+            } else {
+                "code: $code desc: $description"
+            }
+        }
+
+        is TransactionSubmitResult.NotAttempted -> {
+            "notAttempted"
+        }
+    }
 
 sealed interface TransactionProposal {
     val proposal: Proposal

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.exception.PcztException
 import cash.z.ecc.android.sdk.exception.TransactionEncoderException
 import cash.z.ecc.android.sdk.ext.convertZecToZatoshi
+import cash.z.ecc.android.sdk.model.CreatedTransaction
 import cash.z.ecc.android.sdk.model.Memo
 import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.Proposal
@@ -15,21 +16,33 @@ import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZecSend
 import cash.z.ecc.android.sdk.model.proposeSend
 import cash.z.ecc.android.sdk.type.AddressType
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.common.model.ConnectionMode
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.NetworkDimension
+import co.electriccoin.zcash.ui.common.model.ServerSelection
 import co.electriccoin.zcash.ui.common.model.SubmitResult
 import co.electriccoin.zcash.ui.common.model.SwapQuote
 import co.electriccoin.zcash.ui.common.model.VersionInfo
 import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
+import co.electriccoin.zcash.ui.common.provider.ServerSelectionProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.zecdev.zip321.ZIP321
 import org.zecdev.zip321.parser.ParserContext
 import java.math.BigDecimal
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
 
 interface ProposalDataSource {
     @Throws(
@@ -96,7 +109,11 @@ class TexUnsupportedOnKSException : Exception("TEX addresses are unsupported on 
 @Suppress("TooManyFunctions")
 class ProposalDataSourceImpl(
     private val synchronizerProvider: SynchronizerProvider,
+    private val lightWalletEndpointProvider: LightWalletEndpointProvider,
+    private val serverSelectionProvider: ServerSelectionProvider,
 ) : ProposalDataSource {
+    private val broadcastScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
     override suspend fun createProposal(account: WalletAccount, send: ZecSend): RegularTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
@@ -230,16 +247,16 @@ class ProposalDataSourceImpl(
         }
 
     override suspend fun submitTransaction(pcztWithProofs: Pczt, pcztWithSignatures: Pczt): SubmitResult =
-        submitTransactionInternal {
-            it.createTransactionFromPczt(
+        submitTransactionInternal(MULTI_SUBMIT_PCZT_TAG) {
+            it.broadcaster.createTransactionFromPczt(
                 pcztWithProofs = pcztWithProofs,
                 pcztWithSignatures = pcztWithSignatures,
             )
         }
 
     override suspend fun submitTransaction(proposal: Proposal, usk: UnifiedSpendingKey): SubmitResult =
-        submitTransactionInternal {
-            it.createProposedTransactions(
+        submitTransactionInternal(MULTI_SUBMIT_TAG) {
+            it.broadcaster.createProposedTransactions(
                 proposal = proposal,
                 usk = usk,
             )
@@ -268,11 +285,26 @@ class ProposalDataSourceImpl(
 
     @Suppress("CyclomaticComplexMethod", "TooGenericExceptionCaught")
     private suspend fun submitTransactionInternal(
-        block: suspend (Synchronizer) -> Flow<TransactionSubmitResult>
+        logTag: String,
+        block: suspend (SdkSynchronizer) -> List<CreatedTransaction>
     ): SubmitResult =
         withContext(Dispatchers.IO) {
             val synchronizer = synchronizerProvider.getSynchronizer() as SdkSynchronizer
-            val submitResults = block(synchronizer).toList()
+            val transactions = block(synchronizer)
+            val endpoints = getSubmissionEndpoints()
+
+            Twig.info {
+                "$logTag Created ${transactions.size} transaction(s); submitting to ${endpoints.size} endpoint(s)."
+            }
+
+            val submitResults =
+                submitCreatedTransactions(
+                    synchronizer = synchronizer,
+                    transactions = transactions,
+                    endpoints = endpoints,
+                    logTag = logTag
+                )
+
             Twig.debug { "Internal transaction submit results: $submitResults" }
 
             val successCount =
@@ -346,6 +378,245 @@ class ProposalDataSourceImpl(
             Twig.debug { "Transaction submit result: $result" }
             result
         }
+
+    private suspend fun submitCreatedTransactions(
+        synchronizer: SdkSynchronizer,
+        transactions: List<CreatedTransaction>,
+        endpoints: List<LightWalletEndpoint>,
+        logTag: String
+    ): List<TransactionSubmitResult> {
+        var anySubmissionFailed = false
+
+        return transactions.mapIndexed { index, transaction ->
+            if (anySubmissionFailed) {
+                TransactionSubmitResult.NotAttempted(transaction.txId)
+            } else {
+                val result =
+                    submitCreatedTransaction(
+                        synchronizer = synchronizer,
+                        transaction = transaction,
+                        endpoints = endpoints,
+                        index = index,
+                        transactionCount = transactions.size,
+                        logTag = logTag
+                    )
+
+                if (result !is TransactionSubmitResult.Success) {
+                    anySubmissionFailed = true
+                }
+
+                result
+            }
+        }
+    }
+
+    private suspend fun submitCreatedTransaction(
+        synchronizer: SdkSynchronizer,
+        transaction: CreatedTransaction,
+        endpoints: List<LightWalletEndpoint>,
+        index: Int,
+        transactionCount: Int,
+        logTag: String
+    ): TransactionSubmitResult {
+        if (endpoints.isEmpty()) {
+            Twig.error { "$logTag No endpoints available for transaction ${transaction.txIdString()}." }
+            return createGrpcFailure(transaction, "No endpoints available")
+        }
+
+        return if (endpoints.size == 1) {
+            Twig.info {
+                "$logTag Submitting transaction ${index + 1}/$transactionCount to ${endpoints.first().serverString()}."
+            }
+            submitToEndpoint(
+                synchronizer = synchronizer,
+                transaction = transaction,
+                endpoint = endpoints.first(),
+                logTag = logTag
+            )
+        } else {
+            Twig.info {
+                "$logTag Broadcasting transaction ${index + 1}/$transactionCount to ${endpoints.size} endpoints."
+            }
+            broadcastToEndpoints(
+                synchronizer = synchronizer,
+                transaction = transaction,
+                endpoints = endpoints,
+                logTag = logTag
+            )
+        }
+    }
+
+    private suspend fun broadcastToEndpoints(
+        synchronizer: SdkSynchronizer,
+        transaction: CreatedTransaction,
+        endpoints: List<LightWalletEndpoint>,
+        logTag: String
+    ): TransactionSubmitResult {
+        val completion = CompletableDeferred<BroadcastCompletion>()
+        val failureCount = AtomicInteger(0)
+        val failures = Collections.synchronizedList(mutableListOf<TransactionSubmitResult>())
+        val jobs =
+            endpoints.map { endpoint ->
+                broadcastScope
+                    .async {
+                        EndpointSubmission(
+                            endpoint = endpoint,
+                            result =
+                                submitToEndpoint(
+                                    synchronizer = synchronizer,
+                                    transaction = transaction,
+                                    endpoint = endpoint,
+                                    logTag = logTag
+                                )
+                        )
+                    }.also { job ->
+                        job.invokeOnCompletion { throwable ->
+                            if (throwable is CancellationException) return@invokeOnCompletion
+
+                            broadcastScope.launch {
+                                val submission =
+                                    runCatching { job.await() }
+                                        .getOrElse {
+                                            EndpointSubmission(
+                                                endpoint = endpoint,
+                                                result = createGrpcFailure(transaction, it.message)
+                                            )
+                                        }
+
+                                when (val result = submission.result) {
+                                    is TransactionSubmitResult.Success -> {
+                                        completion.complete(
+                                            BroadcastCompletion.Accepted(
+                                                endpoint = submission.endpoint,
+                                                result = result
+                                            )
+                                        )
+                                    }
+
+                                    is TransactionSubmitResult.Failure,
+                                    is TransactionSubmitResult.NotAttempted -> {
+                                        failures += result
+                                        if (failureCount.incrementAndGet() >= endpoints.size) {
+                                            completion.complete(
+                                                BroadcastCompletion.Rejected(
+                                                    result = selectRejectedResult(transaction, failures)
+                                                )
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+            }
+        val timeoutJob =
+            broadcastScope.launch {
+                delay(MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS)
+                if (
+                    completion.complete(
+                        BroadcastCompletion.Rejected(
+                            result = createGrpcFailure(transaction, "Timed out submitting to endpoints")
+                        )
+                    )
+                ) {
+                    Twig.error { "$logTag Timed out waiting for any endpoint to accept ${transaction.txIdString()}." }
+                    jobs.forEach { it.cancel() }
+                }
+            }
+
+        return try {
+            when (val result = completion.await()) {
+                is BroadcastCompletion.Accepted -> {
+                    Twig.info {
+                        "$logTag Transaction ${transaction.txIdString()} accepted by ${result.endpoint.serverString()}."
+                    }
+                    broadcastScope.launch {
+                        delay(MULTI_SUBMIT_GRACE_PERIOD_MILLIS)
+                        jobs.forEach { it.cancel() }
+                        timeoutJob.cancel()
+                    }
+                    result.result
+                }
+
+                is BroadcastCompletion.Rejected -> {
+                    timeoutJob.cancel()
+                    jobs.forEach { it.cancel() }
+                    Twig.error {
+                        "$logTag Transaction ${transaction.txIdString()} rejected by all ${endpoints.size} endpoint(s)."
+                    }
+                    result.result
+                }
+            }
+        } catch (e: CancellationException) {
+            timeoutJob.cancel()
+            jobs.forEach { it.cancel() }
+            throw e
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun submitToEndpoint(
+        synchronizer: SdkSynchronizer,
+        transaction: CreatedTransaction,
+        endpoint: LightWalletEndpoint,
+        logTag: String
+    ): TransactionSubmitResult =
+        try {
+            val result = synchronizer.broadcaster.submit(transaction, endpoint)
+            when (result) {
+                is TransactionSubmitResult.Success -> {
+                    Twig.info { "$logTag ${endpoint.serverString()} SUCCESS ${transaction.txIdString()}." }
+                }
+
+                is TransactionSubmitResult.Failure -> {
+                    Twig.warn {
+                        "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}: " +
+                            "${result.code} ${result.description}"
+                    }
+                }
+
+                is TransactionSubmitResult.NotAttempted -> {
+                    Twig.warn { "$logTag ${endpoint.serverString()} NOT_ATTEMPTED ${transaction.txIdString()}." }
+                }
+            }
+            result
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Twig.warn(e) { "$logTag ${endpoint.serverString()} FAILED ${transaction.txIdString()}." }
+            createGrpcFailure(transaction, e.message)
+        }
+
+    private suspend fun getSubmissionEndpoints(): List<LightWalletEndpoint> {
+        val selection = serverSelectionProvider.getServerSelection() ?: ServerSelection.automatic()
+
+        return when (selection.mode) {
+            ConnectionMode.AUTOMATIC -> lightWalletEndpointProvider.getEndpoints()
+            ConnectionMode.MANUAL -> listOf(checkNotNull(selection.endpoint))
+        }
+    }
+
+    private fun selectRejectedResult(
+        transaction: CreatedTransaction,
+        results: List<TransactionSubmitResult>
+    ): TransactionSubmitResult =
+        results
+            .filterIsInstance<TransactionSubmitResult.Failure>()
+            .lastOrNull { !it.grpcError }
+            ?: results
+                .filterIsInstance<TransactionSubmitResult.Failure>()
+                .lastOrNull()
+            ?: createGrpcFailure(transaction, "All endpoints rejected transaction")
+
+    private fun createGrpcFailure(transaction: CreatedTransaction, description: String?) =
+        TransactionSubmitResult.Failure(
+            txId = transaction.txId,
+            grpcError = true,
+            code = MULTI_SUBMIT_GRPC_FAILURE_CODE,
+            description = description
+        )
+
+    private fun LightWalletEndpoint.serverString() = "$host:$port"
 
     @Suppress("TooGenericExceptionCaught")
     private suspend inline fun <T : Any> getOrThrow(block: (Synchronizer) -> T): T =
@@ -434,3 +705,24 @@ data class ExactOutputSwapTransactionProposal(
 ) : SwapTransactionProposal
 
 private const val DEFAULT_SHIELDING_THRESHOLD = 100000L
+private const val MULTI_SUBMIT_TAG = "[MultiSubmit]"
+private const val MULTI_SUBMIT_PCZT_TAG = "[MultiSubmit/PCZT]"
+private const val MULTI_SUBMIT_GRACE_PERIOD_MILLIS = 5_000L
+private const val MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS = 30_000L
+private const val MULTI_SUBMIT_GRPC_FAILURE_CODE = -1
+
+private data class EndpointSubmission(
+    val endpoint: LightWalletEndpoint,
+    val result: TransactionSubmitResult
+)
+
+private sealed interface BroadcastCompletion {
+    data class Accepted(
+        val endpoint: LightWalletEndpoint,
+        val result: TransactionSubmitResult.Success
+    ) : BroadcastCompletion
+
+    data class Rejected(
+        val result: TransactionSubmitResult
+    ) : BroadcastCompletion
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -341,6 +341,12 @@ class ProposalDataSourceImpl(
                     .filterIsInstance<TransactionSubmitResult.Failure>()
                     .lastOrNull { it.grpcError }
                     ?.description
+            val grpcFailureReason =
+                if (grpcFailureDescription == MULTI_SUBMIT_TIMEOUT_DESCRIPTION) {
+                    SubmitResult.GrpcFailure.Reason.TIMEOUT
+                } else {
+                    null
+                }
 
             val (errCode, errDesc) =
                 submitResults
@@ -352,7 +358,11 @@ class ProposalDataSourceImpl(
                 when (successCount) {
                     0 -> {
                         if (resubmittableFailures.all { it }) {
-                            SubmitResult.GrpcFailure(txIds = txIds, description = grpcFailureDescription)
+                            SubmitResult.GrpcFailure(
+                                txIds = txIds,
+                                description = grpcFailureDescription,
+                                reason = grpcFailureReason
+                            )
                         } else {
                             SubmitResult.Failure(txIds = txIds, code = errCode, description = errDesc)
                         }
@@ -364,7 +374,11 @@ class ProposalDataSourceImpl(
 
                     else -> {
                         if (resubmittableFailures.all { it }) {
-                            SubmitResult.GrpcFailure(txIds = txIds, description = grpcFailureDescription)
+                            SubmitResult.GrpcFailure(
+                                txIds = txIds,
+                                description = grpcFailureDescription,
+                                reason = grpcFailureReason
+                            )
                         } else {
                             SubmitResult.Partial(txIds = txIds, statuses = statuses)
                         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -385,13 +385,17 @@ internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
     val successCount = count { it is TransactionSubmitResult.Success }
     val txIds = map { it.txIdString() }
     val failures = filterIsInstance<TransactionSubmitResult.Failure>()
-    val grpcFailureDescription =
-        failures
-            .lastOrNull { it.grpcError }
-            ?.description
+    val hasTimeoutFailure =
+        failures.any { it.grpcError && it.description == MULTI_SUBMIT_TIMEOUT_DESCRIPTION }
     val grpcFailureReason =
-        if (grpcFailureDescription == MULTI_SUBMIT_TIMEOUT_DESCRIPTION) {
+        if (hasTimeoutFailure) {
             SubmitResult.GrpcFailure.Reason.TIMEOUT
+        } else {
+            null
+        }
+    val grpcFailureDescription =
+        if (hasTimeoutFailure) {
+            MULTI_SUBMIT_TIMEOUT_DESCRIPTION
         } else {
             null
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -321,13 +321,11 @@ class ProposalDataSourceImpl(
             submit = { transaction, endpoint ->
                 synchronizer.broadcaster.submit(transaction, endpoint)
             }
-        ).use { submitter ->
-            submitter.submitTransactions(
-                transactions = transactions,
-                endpoints = endpoints,
-                logTag = logTag
-            )
-        }
+        ).submitTransactions(
+            transactions = transactions,
+            endpoints = endpoints,
+            logTag = logTag
+        )
 
     private suspend fun getSubmissionEndpoints(): List<LightWalletEndpoint> {
         val selection = serverSelectionProvider.getServerSelection() ?: ServerSelection.automatic()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -385,6 +385,7 @@ internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
     val successCount = count { it is TransactionSubmitResult.Success }
     val txIds = map { it.txIdString() }
     val failures = filterIsInstance<TransactionSubmitResult.Failure>()
+    val hasNotAttempted = any { it is TransactionSubmitResult.NotAttempted }
     val hasTimeoutFailure =
         failures.any { it.grpcError && it.description == MULTI_SUBMIT_TIMEOUT_DESCRIPTION }
     val grpcFailureReason =
@@ -407,12 +408,14 @@ internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
 
     return when (successCount) {
         0 -> {
-            if (failures.all { it.grpcError }) {
+            if (failures.size == size && failures.all { it.grpcError }) {
                 SubmitResult.GrpcFailure(
                     txIds = txIds,
                     description = grpcFailureDescription,
                     reason = grpcFailureReason
                 )
+            } else if (hasNotAttempted && failures.none { !it.grpcError }) {
+                SubmitResult.Partial(txIds = txIds, statuses = map { it.statusDescription() })
             } else {
                 SubmitResult.Failure(txIds = txIds, code = errCode, description = errDesc)
             }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -29,9 +29,7 @@ import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.ServerSelectionProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.withContext
 import org.zecdev.zip321.ZIP321
 import org.zecdev.zip321.parser.ParserContext
@@ -105,8 +103,6 @@ class ProposalDataSourceImpl(
     private val lightWalletEndpointProvider: LightWalletEndpointProvider,
     private val serverSelectionProvider: ServerSelectionProvider,
 ) : ProposalDataSource {
-    private val broadcastScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
     override suspend fun createProposal(account: WalletAccount, send: ZecSend): RegularTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
@@ -322,15 +318,16 @@ class ProposalDataSourceImpl(
         logTag: String
     ): List<TransactionSubmitResult> =
         MultiEndpointTransactionSubmitter(
-            scope = broadcastScope,
             submit = { transaction, endpoint ->
                 synchronizer.broadcaster.submit(transaction, endpoint)
             }
-        ).submitTransactions(
-            transactions = transactions,
-            endpoints = endpoints,
-            logTag = logTag
-        )
+        ).use { submitter ->
+            submitter.submitTransactions(
+                transactions = transactions,
+                endpoints = endpoints,
+                logTag = logTag
+            )
+        }
 
     private suspend fun getSubmissionEndpoints(): List<LightWalletEndpoint> {
         val selection = serverSelectionProvider.getServerSelection() ?: ServerSelection.automatic()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -336,6 +336,11 @@ class ProposalDataSourceImpl(
                             is TransactionSubmitResult.Success -> null
                         }
                     }
+            val grpcFailureDescription =
+                submitResults
+                    .filterIsInstance<TransactionSubmitResult.Failure>()
+                    .lastOrNull { it.grpcError }
+                    ?.description
 
             val (errCode, errDesc) =
                 submitResults
@@ -347,7 +352,7 @@ class ProposalDataSourceImpl(
                 when (successCount) {
                     0 -> {
                         if (resubmittableFailures.all { it }) {
-                            SubmitResult.GrpcFailure(txIds = txIds)
+                            SubmitResult.GrpcFailure(txIds = txIds, description = grpcFailureDescription)
                         } else {
                             SubmitResult.Failure(txIds = txIds, code = errCode, description = errDesc)
                         }
@@ -359,7 +364,7 @@ class ProposalDataSourceImpl(
 
                     else -> {
                         if (resubmittableFailures.all { it }) {
-                            SubmitResult.GrpcFailure(txIds = txIds)
+                            SubmitResult.GrpcFailure(txIds = txIds, description = grpcFailureDescription)
                         } else {
                             SubmitResult.Partial(txIds = txIds, statuses = statuses)
                         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -439,7 +439,11 @@ private fun TransactionSubmitResult.statusDescription() =
 
         is TransactionSubmitResult.Failure -> {
             if (grpcError) {
-                description.orEmpty()
+                if (description == MULTI_SUBMIT_TIMEOUT_DESCRIPTION) {
+                    MULTI_SUBMIT_TIMEOUT_DESCRIPTION
+                } else {
+                    MULTI_SUBMIT_GRPC_FAILURE_STATUS
+                }
             } else {
                 "code: $code desc: $description"
             }
@@ -509,3 +513,4 @@ private const val MULTI_SUBMIT_TAG = "[MultiSubmit]"
 private const val MULTI_SUBMIT_PCZT_TAG = "[MultiSubmit/PCZT]"
 private const val MULTI_SUBMIT_EMPTY_TRANSACTION_CODE = -1
 private const val MULTI_SUBMIT_EMPTY_TRANSACTION_DESCRIPTION = "No transactions created"
+private const val MULTI_SUBMIT_GRPC_FAILURE_STATUS = "grpcFailure"

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -512,12 +512,21 @@ class ProposalDataSourceImpl(
         val timeoutJob =
             broadcastScope.launch {
                 delay(MULTI_SUBMIT_GLOBAL_TIMEOUT_MILLIS)
-                if (
-                    completion.complete(
-                        BroadcastCompletion.Rejected(
-                            result = createGrpcFailure(transaction, "Timed out submitting to endpoints")
-                        )
+                val completedSubmissions =
+                    jobs.mapNotNull { job ->
+                        if (job.isCompleted && !job.isCancelled) {
+                            runCatching { job.await() }.getOrNull()
+                        } else {
+                            null
+                        }
+                    }
+                val timeoutResult =
+                    selectTimeoutCompletion(
+                        transaction = transaction,
+                        submissions = completedSubmissions
                     )
+                if (
+                    completion.complete(timeoutResult)
                 ) {
                     Twig.error { "$logTag Timed out waiting for any endpoint to accept ${transaction.txIdString()}." }
                     jobs.forEach { it.cancel() }
@@ -607,6 +616,31 @@ class ProposalDataSourceImpl(
                 .filterIsInstance<TransactionSubmitResult.Failure>()
                 .lastOrNull()
             ?: createGrpcFailure(transaction, "All endpoints rejected transaction")
+
+    private fun selectTimeoutCompletion(
+        transaction: CreatedTransaction,
+        submissions: List<EndpointSubmission>
+    ): BroadcastCompletion =
+        submissions
+            .firstNotNullOfOrNull { submission ->
+                (submission.result as? TransactionSubmitResult.Success)?.let {
+                    BroadcastCompletion.Accepted(
+                        endpoint = submission.endpoint,
+                        result = it
+                    )
+                }
+            }
+            ?: submissions
+                .map { it.result }
+                .takeIf { it.isNotEmpty() }
+                ?.let {
+                    BroadcastCompletion.Rejected(
+                        result = selectRejectedResult(transaction, it)
+                    )
+                }
+            ?: BroadcastCompletion.Rejected(
+                result = createGrpcFailure(transaction, "Timed out submitting to endpoints")
+            )
 
     private fun createGrpcFailure(transaction: CreatedTransaction, description: String?) =
         TransactionSubmitResult.Failure(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -398,7 +398,7 @@ internal fun List<TransactionSubmitResult>.toSubmitResult(): SubmitResult {
 
     val (errCode, errDesc) =
         failures
-            .lastOrNull { !it.grpcError }
+            .firstOrNull { !it.grpcError }
             ?.let { it.code to it.description } ?: (0 to "")
 
     return when (successCount) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/SubmitResult.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/SubmitResult.kt
@@ -15,8 +15,13 @@ sealed interface SubmitResult {
 
     data class GrpcFailure(
         override val txIds: List<String>,
-        val description: String? = null
-    ) : SubmitResult
+        val description: String? = null,
+        val reason: Reason? = null
+    ) : SubmitResult {
+        enum class Reason {
+            TIMEOUT
+        }
+    }
 
     data class Partial(
         override val txIds: List<String>,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/SubmitResult.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/SubmitResult.kt
@@ -14,7 +14,8 @@ sealed interface SubmitResult {
     ) : NonResubmittableError
 
     data class GrpcFailure(
-        override val txIds: List<String>
+        override val txIds: List<String>,
+        val description: String? = null
     ) : SubmitResult
 
     data class Partial(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
@@ -126,7 +126,8 @@ class SendEmailUseCase(
                     body =
                         buildString {
                             appendLine("Grpc failure")
-                            submitResult.reportDescription()
+                            submitResult
+                                .reportDescription()
                                 ?.takeIf { it.isNotBlank() }
                                 ?.let {
                                     appendLine()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
@@ -126,7 +126,7 @@ class SendEmailUseCase(
                     body =
                         buildString {
                             appendLine("Grpc failure")
-                            submitResult.description
+                            submitResult.reportDescription()
                                 ?.takeIf { it.isNotBlank() }
                                 ?.let {
                                     appendLine()
@@ -137,6 +137,17 @@ class SendEmailUseCase(
                 )
         )
     }
+
+    private fun SubmitResult.GrpcFailure.reportDescription() =
+        when (reason) {
+            SubmitResult.GrpcFailure.Reason.TIMEOUT -> {
+                context.getString(R.string.send_confirmation_pending_timeout_subtitle)
+            }
+
+            null -> {
+                description
+            }
+        }
 
     /**
      * Sends a support email for transaction submission error.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
@@ -123,7 +123,16 @@ class SendEmailUseCase(
             subject = context.getString(R.string.app_name),
             messageBody =
                 EmailUtil.formatMessage(
-                    body = "Grpc failure",
+                    body =
+                        buildString {
+                            appendLine("Grpc failure")
+                            submitResult.description
+                                ?.takeIf { it.isNotBlank() }
+                                ?.let {
+                                    appendLine()
+                                    appendLine(it)
+                                }
+                        },
                     supportInfo = ""
                 )
         )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
@@ -119,6 +119,17 @@ class SendEmailUseCase(
      * Sends a support email for gRPC failure.
      */
     operator fun invoke(submitResult: SubmitResult.GrpcFailure) {
+        val reportDescription =
+            when (submitResult.reason) {
+                SubmitResult.GrpcFailure.Reason.TIMEOUT -> {
+                    context.getString(R.string.send_confirmation_pending_timeout_subtitle)
+                }
+
+                null -> {
+                    submitResult.description
+                }
+            }
+
         sendSupportEmail(
             subject = context.getString(R.string.app_name),
             messageBody =
@@ -126,8 +137,7 @@ class SendEmailUseCase(
                     body =
                         buildString {
                             appendLine("Grpc failure")
-                            submitResult
-                                .reportDescription()
+                            reportDescription
                                 ?.takeIf { it.isNotBlank() }
                                 ?.let {
                                     appendLine()
@@ -138,17 +148,6 @@ class SendEmailUseCase(
                 )
         )
     }
-
-    private fun SubmitResult.GrpcFailure.reportDescription() =
-        when (reason) {
-            SubmitResult.GrpcFailure.Reason.TIMEOUT -> {
-                context.getString(R.string.send_confirmation_pending_timeout_subtitle)
-            }
-
-            null -> {
-                description
-            }
-        }
 
     /**
      * Sends a support email for transaction submission error.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressVM.kt
@@ -266,21 +266,24 @@ class TransactionProgressVM(
                     }
                 },
             subtitle =
-                when (proposal) {
-                    is Zip321TransactionProposal,
-                    is RegularTransactionProposal -> {
-                        stringRes(R.string.send_confirmation_pending_transaction_subtitle)
-                    }
+                result.description
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { stringRes(it).withStyle() }
+                    ?: when (proposal) {
+                        is Zip321TransactionProposal,
+                        is RegularTransactionProposal -> {
+                            stringRes(R.string.send_confirmation_pending_transaction_subtitle)
+                        }
 
-                    is ExactInputSwapTransactionProposal,
-                    is ExactOutputSwapTransactionProposal -> {
-                        stringRes(R.string.send_confirmation_pending_swap_subtitle)
-                    }
+                        is ExactInputSwapTransactionProposal,
+                        is ExactOutputSwapTransactionProposal -> {
+                            stringRes(R.string.send_confirmation_pending_swap_subtitle)
+                        }
 
-                    is ShieldTransactionProposal -> {
-                        stringRes(R.string.send_confirmation_pending_shielding_subtitle)
-                    }
-                }.withStyle(),
+                        is ShieldTransactionProposal -> {
+                            stringRes(R.string.send_confirmation_pending_shielding_subtitle)
+                        }
+                    }.withStyle(),
             middleButton =
                 when (proposal) {
                     is ExactInputSwapTransactionProposal,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressVM.kt
@@ -266,9 +266,7 @@ class TransactionProgressVM(
                     }
                 },
             subtitle =
-                result.description
-                    ?.takeIf { it.isNotBlank() }
-                    ?.let { stringRes(it).withStyle() }
+                result.pendingDescription()
                     ?: when (proposal) {
                         is Zip321TransactionProposal,
                         is RegularTransactionProposal -> {
@@ -343,6 +341,19 @@ class TransactionProgressVM(
             image = imageRes(listOf(R.drawable.ic_fist_punch, R.drawable.ic_face_star).random())
         )
     }
+
+    private fun SubmitResult.GrpcFailure.pendingDescription(): StyledStringResource? =
+        when (reason) {
+            SubmitResult.GrpcFailure.Reason.TIMEOUT -> {
+                stringRes(R.string.send_confirmation_pending_timeout_subtitle).withStyle()
+            }
+
+            null -> {
+                description
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { stringRes(it).withStyle() }
+            }
+        }
 
     private fun createNonResubmittableErrorState(
         proposal: TransactionProposal,

--- a/ui-lib/src/main/res/ui/send_confirmation/values-es/strings.xml
+++ b/ui-lib/src/main/res/ui/send_confirmation/values-es/strings.xml
@@ -73,6 +73,7 @@
     <!-- Pending states -->
     <string name="send_confirmation_pending_transaction_title">Transacción Pendiente</string>
     <string name="send_confirmation_pending_transaction_subtitle">Tu transacción se está procesando.</string>
+    <string name="send_confirmation_pending_timeout_subtitle">Se agotó el tiempo de espera de la respuesta del servidor. Es posible que tu transacción aún se haya transmitido.</string>
     <string name="send_confirmation_pending_swap_title">Swap Pendiente</string>
     <string name="send_confirmation_pending_swap_subtitle">Tu swap se está procesando. Siga el estado en la pantalla de transacción.</string>
     <string name="send_confirmation_pending_payment_title">Pago Pendiente</string>

--- a/ui-lib/src/main/res/ui/send_confirmation/values/strings.xml
+++ b/ui-lib/src/main/res/ui/send_confirmation/values/strings.xml
@@ -78,6 +78,7 @@
     <!-- Pending states -->
     <string name="send_confirmation_pending_transaction_title">Transaction Pending</string>
     <string name="send_confirmation_pending_transaction_subtitle">Your transaction is being processed.</string>
+    <string name="send_confirmation_pending_timeout_subtitle">Timed out waiting for a server response. Your transaction may still have been broadcast.</string>
     <string name="send_confirmation_pending_swap_title">Swap Pending</string>
     <string name="send_confirmation_pending_swap_subtitle">Your swap is being processed. Follow its status on the transaction screen.</string>
     <string name="send_confirmation_pending_payment_title">Payment Pending</string>

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -375,7 +375,7 @@ class MultiEndpointTransactionSubmitterTest {
                         secondTransaction.txIdString(),
                         thirdTransaction.txIdString()
                     ),
-                statuses = listOf("success", "failure -1", "notAttempted")
+                statuses = listOf("success", "grpcFailure", "notAttempted")
             ),
             result
         )
@@ -435,7 +435,32 @@ class MultiEndpointTransactionSubmitterTest {
         assertEquals(
             SubmitResult.Partial(
                 txIds = listOf(firstTransaction.txIdString(), secondTransaction.txIdString()),
-                statuses = listOf("failure -1", "notAttempted")
+                statuses = listOf("grpcFailure", "notAttempted")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun grpcFailurePartialStatusDoesNotExposeDescription() {
+        val firstTransaction = transaction(21)
+        val secondTransaction = transaction(22)
+
+        val result =
+            listOf(
+                TransactionSubmitResult.Failure(
+                    txId = firstTransaction.txId,
+                    grpcError = true,
+                    code = -1,
+                    description = "private.example.com:443 failed"
+                ),
+                TransactionSubmitResult.NotAttempted(secondTransaction.txId)
+            ).toSubmitResult()
+
+        assertEquals(
+            SubmitResult.Partial(
+                txIds = listOf(firstTransaction.txIdString(), secondTransaction.txIdString()),
+                statuses = listOf("grpcFailure", "notAttempted")
             ),
             result
         )

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -67,7 +67,10 @@ class MultiEndpointTransactionSubmitterTest {
 
             val result = assertIs<TransactionSubmitResult.Failure>(results.single())
             assertEquals(true, result.grpcError)
-            assertEquals("Timed out submitting to endpoints", result.description)
+            assertEquals(
+                "Timed out waiting for endpoint response; transaction may still have been broadcast",
+                result.description
+            )
         }
 
     @Test

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -193,7 +193,7 @@ class MultiEndpointTransactionSubmitterTest {
         }
 
     @Test
-    fun timeoutPreservesCompletedEndpointFailure() =
+    fun timeoutWithIncompleteEndpointReportsGrpcFailure() =
         runTest {
             val transaction = transaction(4)
             val submitter =
@@ -219,9 +219,17 @@ class MultiEndpointTransactionSubmitterTest {
                 )
 
             val result = assertIs<TransactionSubmitResult.Failure>(results.single())
-            assertEquals(false, result.grpcError)
-            assertEquals(18, result.code)
-            assertEquals("failed.example.com:443: failure 18", result.description)
+            assertEquals(true, result.grpcError)
+            assertEquals(-1, result.code)
+            assertEquals(MULTI_SUBMIT_TIMEOUT_DESCRIPTION, result.description)
+            assertEquals(
+                SubmitResult.GrpcFailure(
+                    txIds = listOf(transaction.txIdString()),
+                    description = MULTI_SUBMIT_TIMEOUT_DESCRIPTION,
+                    reason = SubmitResult.GrpcFailure.Reason.TIMEOUT
+                ),
+                results.toSubmitResult()
+            )
         }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -1,0 +1,241 @@
+package co.electriccoin.zcash.ui.common.datasource
+
+import cash.z.ecc.android.sdk.model.CreatedTransaction
+import cash.z.ecc.android.sdk.model.FirstClassByteArray
+import cash.z.ecc.android.sdk.model.TransactionSubmitResult
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class MultiEndpointTransactionSubmitterTest {
+    @Test
+    fun manualModeSubmitsOnlyToSelectedEndpoint() =
+        runTest {
+            val endpoint = endpoint("manual.example.com")
+            val submissions = Collections.synchronizedList(mutableListOf<LightWalletEndpoint>())
+            val transaction = transaction(1)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    submit = { _, submittedEndpoint ->
+                        submissions += submittedEndpoint
+                        TransactionSubmitResult.Success(transaction.txId)
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(endpoint),
+                    logTag = LOG_TAG
+                )
+
+            assertEquals(listOf(TransactionSubmitResult.Success(transaction.txId)), results)
+            assertEquals(listOf(endpoint), submissions.toList())
+        }
+
+    @Test
+    fun automaticModeReturnsFirstSuccessfulEndpoint() =
+        runTest {
+            val first = endpoint("first.example.com")
+            val second = endpoint("second.example.com")
+            val third = endpoint("third.example.com")
+            val transaction = transaction(2)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    submit = { _, submittedEndpoint ->
+                        when (submittedEndpoint) {
+                            first -> {
+                                delay(1_000)
+                                failure(transaction, code = 1, grpcError = true)
+                            }
+                            second -> TransactionSubmitResult.Success(transaction.txId)
+                            third -> {
+                                delay(1_000)
+                                TransactionSubmitResult.Success(transaction.txId)
+                            }
+                            else -> error("Unexpected endpoint $submittedEndpoint")
+                        }
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(first, second, third),
+                    logTag = LOG_TAG
+                )
+
+            assertEquals(listOf(TransactionSubmitResult.Success(transaction.txId)), results)
+        }
+
+    @Test
+    fun automaticModeReturnsBestFailureWhenAllEndpointsFailFast() =
+        runTest {
+            val transaction = transaction(3)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    submit = { _, submittedEndpoint ->
+                        when (submittedEndpoint.host) {
+                            "first.example.com" -> failure(transaction, code = 1, grpcError = true)
+                            "second.example.com" -> failure(transaction, code = 18, grpcError = false)
+                            "third.example.com" -> failure(transaction, code = 19, grpcError = true)
+                            else -> error("Unexpected endpoint $submittedEndpoint")
+                        }
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints =
+                        listOf(
+                            endpoint("first.example.com"),
+                            endpoint("second.example.com"),
+                            endpoint("third.example.com")
+                        ),
+                    logTag = LOG_TAG
+                )
+
+            val result = assertIs<TransactionSubmitResult.Failure>(results.single())
+            assertEquals(false, result.grpcError)
+            assertEquals(18, result.code)
+        }
+
+    @Test
+    fun timeoutPreservesCompletedEndpointFailure() =
+        runTest {
+            val transaction = transaction(4)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    globalTimeoutMillis = 100,
+                    submit = { _, submittedEndpoint ->
+                        when (submittedEndpoint.host) {
+                            "failed.example.com" -> failure(transaction, code = 18, grpcError = false)
+                            "hung.example.com" -> awaitCancellation()
+                            else -> error("Unexpected endpoint $submittedEndpoint")
+                        }
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(endpoint("failed.example.com"), endpoint("hung.example.com")),
+                    logTag = LOG_TAG
+                )
+
+            val result = assertIs<TransactionSubmitResult.Failure>(results.single())
+            assertEquals(false, result.grpcError)
+            assertEquals(18, result.code)
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun callerCancellationCancelsEndpointSubmissions() =
+        runTest {
+            val started = CompletableDeferred<Unit>()
+            val cancelledCount = AtomicInteger(0)
+            val startedCount = AtomicInteger(0)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    submit = { _, _ ->
+                        if (startedCount.incrementAndGet() == 2) {
+                            started.complete(Unit)
+                        }
+                        try {
+                            awaitCancellation()
+                        } finally {
+                            cancelledCount.incrementAndGet()
+                        }
+                    }
+                )
+
+            val job =
+                launch {
+                    submitter.submitTransactions(
+                        transactions = listOf(transaction(5)),
+                        endpoints = listOf(endpoint("first.example.com"), endpoint("second.example.com")),
+                        logTag = LOG_TAG
+                    )
+                }
+
+            started.await()
+            job.cancel()
+            job.join()
+            runCurrent()
+
+            assertEquals(2, cancelledCount.get())
+        }
+
+    @Test
+    fun laterTransactionsAreNotAttemptedAfterFirstFailure() =
+        runTest {
+            val firstTransaction = transaction(6)
+            val secondTransaction = transaction(7)
+            val submissions = AtomicInteger(0)
+            val firstFailure = failure(firstTransaction, code = 18, grpcError = false)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    submit = { _, _ ->
+                        submissions.incrementAndGet()
+                        firstFailure
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(firstTransaction, secondTransaction),
+                    endpoints = listOf(endpoint("manual.example.com")),
+                    logTag = LOG_TAG
+                )
+
+            assertEquals(firstFailure, results[0])
+            assertEquals(TransactionSubmitResult.NotAttempted(secondTransaction.txId), results[1])
+            assertEquals(1, submissions.get())
+        }
+
+    private fun transaction(index: Int) =
+        CreatedTransaction(
+            txId = FirstClassByteArray(byteArrayOf(index.toByte())),
+            raw = FirstClassByteArray(byteArrayOf(index.toByte(), index.toByte())),
+            expiryHeight = null
+        )
+
+    private fun failure(
+        transaction: CreatedTransaction,
+        code: Int,
+        grpcError: Boolean
+    ) = TransactionSubmitResult.Failure(
+        txId = transaction.txId,
+        grpcError = grpcError,
+        code = code,
+        description = "failure $code"
+    )
+
+    private fun endpoint(host: String) =
+        LightWalletEndpoint(
+            host = host,
+            port = 443,
+            isSecure = true
+        )
+
+    private companion object {
+        const val LOG_TAG = "[MultiSubmitTest]"
+    }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import java.util.Collections
@@ -111,6 +112,52 @@ class MultiEndpointTransactionSubmitterTest {
                 )
 
             assertEquals(listOf(TransactionSubmitResult.Success(transaction.txId)), results)
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun successfulBroadcastKeepsOtherEndpointsRunningDuringGracePeriod() =
+        runTest {
+            val transaction = transaction(23)
+            val lateEndpointCompleted = CompletableDeferred<Unit>()
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
+                    gracePeriodMillis = 100,
+                    logger = noOpLogger,
+                    submit = { _, submittedEndpoint ->
+                        when (submittedEndpoint.host) {
+                            "fast.example.com" -> {
+                                TransactionSubmitResult.Success(transaction.txId)
+                            }
+
+                            "late.example.com" -> {
+                                delay(50)
+                                lateEndpointCompleted.complete(Unit)
+                                TransactionSubmitResult.Success(transaction.txId)
+                            }
+
+                            else -> {
+                                error("Unexpected endpoint $submittedEndpoint")
+                            }
+                        }
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(endpoint("fast.example.com"), endpoint("late.example.com")),
+                    logTag = LOG_TAG
+                )
+
+            assertEquals(listOf(TransactionSubmitResult.Success(transaction.txId)), results)
+            assertEquals(false, lateEndpointCompleted.isCompleted)
+
+            advanceTimeBy(50)
+            runCurrent()
+
+            assertEquals(true, lateEndpointCompleted.isCompleted)
         }
 
     @Test

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -369,6 +369,26 @@ class MultiEndpointTransactionSubmitterTest {
     }
 
     @Test
+    fun grpcFailureThenNotAttemptedMapsToPartialResult() {
+        val firstTransaction = transaction(17)
+        val secondTransaction = transaction(18)
+
+        val result =
+            listOf(
+                failure(firstTransaction, code = -1, grpcError = true),
+                TransactionSubmitResult.NotAttempted(secondTransaction.txId)
+            ).toSubmitResult()
+
+        assertEquals(
+            SubmitResult.Partial(
+                txIds = listOf(firstTransaction.txIdString(), secondTransaction.txIdString()),
+                statuses = listOf("failure -1", "notAttempted")
+            ),
+            result
+        )
+    }
+
+    @Test
     fun emptyCreatedTransactionsMapToFailureResult() {
         val result = emptyList<TransactionSubmitResult>().toSubmitResult()
 

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.ui.common.model.SubmitResult
+import co.electriccoin.zcash.ui.util.CloseableScopeHolderImpl
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -27,7 +28,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(1)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         submissions += submittedEndpoint
@@ -52,7 +53,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(8)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     globalTimeoutMillis = 100,
                     timeoutDrainMillis = 100,
                     logger = noOpLogger,
@@ -80,7 +81,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(9)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     globalTimeoutMillis = 100,
                     timeoutDrainMillis = 100,
                     logger = noOpLogger,
@@ -121,7 +122,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(2)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         when (submittedEndpoint) {
@@ -162,7 +163,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(3)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         when (submittedEndpoint.host) {
@@ -198,7 +199,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(4)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     globalTimeoutMillis = 100,
                     timeoutDrainMillis = 100,
                     logger = noOpLogger,
@@ -241,7 +242,7 @@ class MultiEndpointTransactionSubmitterTest {
             val startedCount = AtomicInteger(0)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     logger = noOpLogger,
                     submit = { _, _ ->
                         if (startedCount.incrementAndGet() == 2) {
@@ -281,7 +282,7 @@ class MultiEndpointTransactionSubmitterTest {
             val firstFailure = failure(firstTransaction, code = 18, grpcError = false)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     logger = noOpLogger,
                     submit = { _, _ ->
                         submissions.incrementAndGet()
@@ -308,7 +309,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(19)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     logger = logger,
                     submit = { _, _ ->
                         failure(transaction, code = 18, grpcError = false)
@@ -334,7 +335,7 @@ class MultiEndpointTransactionSubmitterTest {
             val transaction = transaction(20)
             val submitter =
                 MultiEndpointTransactionSubmitter(
-                    scope = backgroundScope,
+                    closeableScopeHolder = CloseableScopeHolderImpl(backgroundScope),
                     logger = logger,
                     submit = { _, _ ->
                         error("private.example.com:443 failed")

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -157,7 +157,7 @@ class MultiEndpointTransactionSubmitterTest {
         }
 
     @Test
-    fun automaticModeReturnsBestFailureWhenAllEndpointsFailFast() =
+    fun automaticModeReturnsFirstNonGrpcFailureWhenAllEndpointsFailFast() =
         runTest {
             val transaction = transaction(3)
             val submitter =
@@ -168,7 +168,7 @@ class MultiEndpointTransactionSubmitterTest {
                         when (submittedEndpoint.host) {
                             "first.example.com" -> failure(transaction, code = 1, grpcError = true)
                             "second.example.com" -> failure(transaction, code = 18, grpcError = false)
-                            "third.example.com" -> failure(transaction, code = 19, grpcError = true)
+                            "third.example.com" -> failure(transaction, code = 19, grpcError = false)
                             else -> error("Unexpected endpoint $submittedEndpoint")
                         }
                     }
@@ -315,6 +315,27 @@ class MultiEndpointTransactionSubmitterTest {
                         thirdTransaction.txIdString()
                     ),
                 statuses = listOf("success", "failure -1", "notAttempted")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun nonGrpcFailuresMapToFirstFailureDetail() {
+        val firstTransaction = transaction(13)
+        val secondTransaction = transaction(14)
+
+        val result =
+            listOf(
+                failure(firstTransaction, code = 18, grpcError = false),
+                failure(secondTransaction, code = 19, grpcError = false)
+            ).toSubmitResult()
+
+        assertEquals(
+            SubmitResult.Failure(
+                txIds = listOf(firstTransaction.txIdString(), secondTransaction.txIdString()),
+                code = 18,
+                description = "failure 18"
             ),
             result
         )

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -46,6 +46,30 @@ class MultiEndpointTransactionSubmitterTest {
         }
 
     @Test
+    fun manualModeTimesOutHungSubmission() =
+        runTest {
+            val transaction = transaction(8)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    globalTimeoutMillis = 100,
+                    logger = noOpLogger,
+                    submit = { _, _ -> awaitCancellation() }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(endpoint("manual.example.com")),
+                    logTag = LOG_TAG
+                )
+
+            val result = assertIs<TransactionSubmitResult.Failure>(results.single())
+            assertEquals(true, result.grpcError)
+            assertEquals("Timed out submitting to endpoints", result.description)
+        }
+
+    @Test
     fun automaticModeReturnsFirstSuccessfulEndpoint() =
         runTest {
             val first = endpoint("first.example.com")
@@ -122,6 +146,7 @@ class MultiEndpointTransactionSubmitterTest {
             val result = assertIs<TransactionSubmitResult.Failure>(results.single())
             assertEquals(false, result.grpcError)
             assertEquals(18, result.code)
+            assertEquals("second.example.com:443: failure 18", result.description)
         }
 
     @Test
@@ -152,6 +177,7 @@ class MultiEndpointTransactionSubmitterTest {
             val result = assertIs<TransactionSubmitResult.Failure>(results.single())
             assertEquals(false, result.grpcError)
             assertEquals(18, result.code)
+            assertEquals("failed.example.com:443: failure 18", result.description)
         }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -189,7 +189,7 @@ class MultiEndpointTransactionSubmitterTest {
             val result = assertIs<TransactionSubmitResult.Failure>(results.single())
             assertEquals(false, result.grpcError)
             assertEquals(18, result.code)
-            assertEquals("second.example.com:443: failure 18", result.description)
+            assertEquals("failure 18", result.description)
         }
 
     @Test
@@ -296,9 +296,62 @@ class MultiEndpointTransactionSubmitterTest {
                     logTag = LOG_TAG
                 )
 
-            assertEquals(firstFailure.copy(description = "manual.example.com:443: failure 18"), results[0])
+            assertEquals(firstFailure, results[0])
             assertEquals(TransactionSubmitResult.NotAttempted(secondTransaction.txId), results[1])
             assertEquals(1, submissions.get())
+        }
+
+    @Test
+    fun endpointHostAndPortAreNotLoggedOrAddedToFailureDescription() =
+        runTest {
+            val logger = RecordingLogger()
+            val transaction = transaction(19)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    logger = logger,
+                    submit = { _, _ ->
+                        failure(transaction, code = 18, grpcError = false)
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(endpoint("private.example.com")),
+                    logTag = LOG_TAG
+                )
+
+            val result = assertIs<TransactionSubmitResult.Failure>(results.single())
+            assertEquals("failure 18", result.description)
+            assertEquals(false, logger.messages.any { it.contains("private.example.com") || it.contains(":443") })
+        }
+
+    @Test
+    fun endpointExceptionMessageIsNotLoggedOrReported() =
+        runTest {
+            val logger = RecordingLogger()
+            val transaction = transaction(20)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    logger = logger,
+                    submit = { _, _ ->
+                        error("private.example.com:443 failed")
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(endpoint("private.example.com")),
+                    logTag = LOG_TAG
+                )
+
+            val result = assertIs<TransactionSubmitResult.Failure>(results.single())
+            assertEquals(true, result.grpcError)
+            assertEquals("Endpoint submission failed", result.description)
+            assertEquals(false, logger.messages.any { it.contains("private.example.com") || it.contains(":443") })
         }
 
     @Test
@@ -436,12 +489,23 @@ class MultiEndpointTransactionSubmitterTest {
 
                 override fun warn(message: () -> String) = Unit
 
-                override fun warn(
-                    throwable: Throwable,
-                    message: () -> String
-                ) = Unit
-
                 override fun error(message: () -> String) = Unit
             }
+    }
+}
+
+private class RecordingLogger : MultiEndpointTransactionSubmitterLogger {
+    val messages: MutableList<String> = Collections.synchronizedList(mutableListOf())
+
+    override fun info(message: () -> String) {
+        messages += message()
+    }
+
+    override fun warn(message: () -> String) {
+        messages += message()
+    }
+
+    override fun error(message: () -> String) {
+        messages += message()
     }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -342,6 +342,25 @@ class MultiEndpointTransactionSubmitterTest {
     }
 
     @Test
+    fun nonTimeoutGrpcFailuresMapToDefaultPendingResult() {
+        val firstTransaction = transaction(15)
+        val secondTransaction = transaction(16)
+
+        val result =
+            listOf(
+                failure(firstTransaction, code = -1, grpcError = true),
+                failure(secondTransaction, code = -1, grpcError = true)
+            ).toSubmitResult()
+
+        assertEquals(
+            SubmitResult.GrpcFailure(
+                txIds = listOf(firstTransaction.txIdString(), secondTransaction.txIdString())
+            ),
+            result
+        )
+    }
+
+    @Test
     fun emptyCreatedTransactionsMapToFailureResult() {
         val result = emptyList<TransactionSubmitResult>().toSubmitResult()
 

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.sdk.model.CreatedTransaction
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.ui.common.model.SubmitResult
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -291,6 +292,47 @@ class MultiEndpointTransactionSubmitterTest {
             assertEquals(TransactionSubmitResult.NotAttempted(secondTransaction.txId), results[1])
             assertEquals(1, submissions.get())
         }
+
+    @Test
+    fun acceptedTransactionThenGrpcFailureMapsToPartialResult() {
+        val firstTransaction = transaction(10)
+        val secondTransaction = transaction(11)
+        val thirdTransaction = transaction(12)
+
+        val result =
+            listOf(
+                TransactionSubmitResult.Success(firstTransaction.txId),
+                failure(secondTransaction, code = -1, grpcError = true),
+                TransactionSubmitResult.NotAttempted(thirdTransaction.txId)
+            ).toSubmitResult()
+
+        assertEquals(
+            SubmitResult.Partial(
+                txIds =
+                    listOf(
+                        firstTransaction.txIdString(),
+                        secondTransaction.txIdString(),
+                        thirdTransaction.txIdString()
+                    ),
+                statuses = listOf("success", "failure -1", "notAttempted")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun emptyCreatedTransactionsMapToFailureResult() {
+        val result = emptyList<TransactionSubmitResult>().toSubmitResult()
+
+        assertEquals(
+            SubmitResult.Failure(
+                txIds = emptyList(),
+                code = -1,
+                description = "No transactions created"
+            ),
+            result
+        )
+    }
 
     private fun transaction(index: Int) =
         CreatedTransaction(

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -53,6 +53,7 @@ class MultiEndpointTransactionSubmitterTest {
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
                     globalTimeoutMillis = 100,
+                    timeoutDrainMillis = 100,
                     logger = noOpLogger,
                     submit = { _, _ -> awaitCancellation() }
                 )
@@ -67,6 +68,44 @@ class MultiEndpointTransactionSubmitterTest {
             val result = assertIs<TransactionSubmitResult.Failure>(results.single())
             assertEquals(true, result.grpcError)
             assertEquals("Timed out submitting to endpoints", result.description)
+        }
+
+    @Test
+    fun timeoutDrainPreservesLateEndpointSuccess() =
+        runTest {
+            val transaction = transaction(9)
+            val submitter =
+                MultiEndpointTransactionSubmitter(
+                    scope = backgroundScope,
+                    globalTimeoutMillis = 100,
+                    timeoutDrainMillis = 100,
+                    logger = noOpLogger,
+                    submit = { _, submittedEndpoint ->
+                        when (submittedEndpoint.host) {
+                            "late.example.com" -> {
+                                delay(150)
+                                TransactionSubmitResult.Success(transaction.txId)
+                            }
+
+                            "hung.example.com" -> {
+                                awaitCancellation()
+                            }
+
+                            else -> {
+                                error("Unexpected endpoint $submittedEndpoint")
+                            }
+                        }
+                    }
+                )
+
+            val results =
+                submitter.submitTransactions(
+                    transactions = listOf(transaction),
+                    endpoints = listOf(endpoint("late.example.com"), endpoint("hung.example.com")),
+                    logTag = LOG_TAG
+                )
+
+            assertEquals(listOf(TransactionSubmitResult.Success(transaction.txId)), results)
         }
 
     @Test
@@ -157,6 +196,7 @@ class MultiEndpointTransactionSubmitterTest {
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
                     globalTimeoutMillis = 100,
+                    timeoutDrainMillis = 100,
                     logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         when (submittedEndpoint.host) {
@@ -244,7 +284,7 @@ class MultiEndpointTransactionSubmitterTest {
                     logTag = LOG_TAG
                 )
 
-            assertEquals(firstFailure, results[0])
+            assertEquals(firstFailure.copy(description = "manual.example.com:443: failure 18"), results[0])
             assertEquals(TransactionSubmitResult.NotAttempted(secondTransaction.txId), results[1])
             assertEquals(1, submissions.get())
         }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -27,6 +27,7 @@ class MultiEndpointTransactionSubmitterTest {
             val submitter =
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
+                    logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         submissions += submittedEndpoint
                         TransactionSubmitResult.Success(transaction.txId)
@@ -54,6 +55,7 @@ class MultiEndpointTransactionSubmitterTest {
             val submitter =
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
+                    logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         when (submittedEndpoint) {
                             first -> {
@@ -87,6 +89,7 @@ class MultiEndpointTransactionSubmitterTest {
             val submitter =
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
+                    logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         when (submittedEndpoint.host) {
                             "first.example.com" -> failure(transaction, code = 1, grpcError = true)
@@ -122,6 +125,7 @@ class MultiEndpointTransactionSubmitterTest {
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
                     globalTimeoutMillis = 100,
+                    logger = noOpLogger,
                     submit = { _, submittedEndpoint ->
                         when (submittedEndpoint.host) {
                             "failed.example.com" -> failure(transaction, code = 18, grpcError = false)
@@ -153,6 +157,7 @@ class MultiEndpointTransactionSubmitterTest {
             val submitter =
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
+                    logger = noOpLogger,
                     submit = { _, _ ->
                         if (startedCount.incrementAndGet() == 2) {
                             started.complete(Unit)
@@ -192,6 +197,7 @@ class MultiEndpointTransactionSubmitterTest {
             val submitter =
                 MultiEndpointTransactionSubmitter(
                     scope = backgroundScope,
+                    logger = noOpLogger,
                     submit = { _, _ ->
                         submissions.incrementAndGet()
                         firstFailure
@@ -237,5 +243,19 @@ class MultiEndpointTransactionSubmitterTest {
 
     private companion object {
         const val LOG_TAG = "[MultiSubmitTest]"
+
+        val noOpLogger =
+            object : MultiEndpointTransactionSubmitterLogger {
+                override fun info(message: () -> String) = Unit
+
+                override fun warn(message: () -> String) = Unit
+
+                override fun warn(
+                    throwable: Throwable,
+                    message: () -> String
+                ) = Unit
+
+                override fun error(message: () -> String) = Unit
+            }
     }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/MultiEndpointTransactionSubmitterTest.kt
@@ -62,12 +62,19 @@ class MultiEndpointTransactionSubmitterTest {
                                 delay(1_000)
                                 failure(transaction, code = 1, grpcError = true)
                             }
-                            second -> TransactionSubmitResult.Success(transaction.txId)
+
+                            second -> {
+                                TransactionSubmitResult.Success(transaction.txId)
+                            }
+
                             third -> {
                                 delay(1_000)
                                 TransactionSubmitResult.Success(transaction.txId)
                             }
-                            else -> error("Unexpected endpoint $submittedEndpoint")
+
+                            else -> {
+                                error("Unexpected endpoint $submittedEndpoint")
+                            }
                         }
                     }
                 )


### PR DESCRIPTION
Closes: #2216

## Summary

- Replaces proposal submission internals with a create-then-submit multi-endpoint broadcaster.
- Manual mode submits each created transaction to the selected endpoint. Automatic mode fans out each created transaction to all known endpoints.
- The first successful endpoint wins, remaining endpoint calls get a short grace period, and the endpoint group has a timeout plus drain window before reporting timeout.
- If no endpoint responds before timeout, the result stays pending with timeout-specific copy because the transaction may still have been broadcast.
- First non-gRPC rejection details are preserved, non-timeout gRPC pending results use the default pending copy, partial multi-transaction submissions route to support/error state, and regular sends, ZIP321, shielding, swaps, and Keystone submissions all use the same path.

## Dependency Note

This still depends on the unreleased Android SDK broadcaster API. Local validation uses the SDK included build instead of Maven Central until the released SDK tag is available. Before merge, replace the local SDK dependency path with the released tag and repeat final validation.

## Testing

- End-to-end manual validation covered the app flow with the SDK broadcaster API and the automatic/manual server-mode branch.
- `git diff --check`
- `./gradlew :ui-lib:compileZcashmainnetFossDebugUnitTestKotlin`
- `./gradlew -PJACOCO_VERSION=0.8.14 :ui-lib:testZcashmainnetFossDebugUnitTest --tests co.electriccoin.zcash.ui.common.datasource.MultiEndpointTransactionSubmitterTest --rerun-tasks`
- `./gradlew detektAll`
- `./gradlew ktlint` currently fails locally only on inherited base-branch formatting in `MockSynchronizer.kt`. The PR-scoped files are clean.

Current Android CI failures are inherited from the base branch and expected until the SDK tag and base cleanup land.
