### PR TITLE
Fix main CI failures

### DIFF
--- a/sdk-ext-lib/src/main/java/cash/z/ecc/sdk/extension/CurrencyFormatterExt.kt
+++ b/sdk-ext-lib/src/main/java/cash/z/ecc/sdk/extension/CurrencyFormatterExt.kt
@@ -1,6 +1,8 @@
 package cash.z.ecc.sdk.extension
 
 import android.os.Build
+import cash.z.ecc.android.sdk.ext.convertZatoshiToZec
+import cash.z.ecc.android.sdk.model.Zatoshi
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
@@ -17,6 +19,13 @@ fun zatoshiFormatter(locale: Locale): DecimalFormat =
         maximumFractionDigits = ZATOSHI_MAXIMUM_FRACTION_DIGITS,
         minimumFractionDigits = ZATOSHI_MINIMUM_FRACTION_DIGITS
     )
+
+fun Zatoshi.toZecString(locale: Locale): String =
+    currencyFormatter(
+        locale = locale,
+        maximumFractionDigits = ZATOSHI_MAXIMUM_FRACTION_DIGITS,
+        minimumFractionDigits = ZATOSHI_MAXIMUM_FRACTION_DIGITS
+    ).format(convertZatoshiToZec(scale = ZATOSHI_MAXIMUM_FRACTION_DIGITS))
 
 fun currencyFormatter(
     locale: Locale,

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
@@ -219,10 +219,6 @@ internal class MockSynchronizer : CloseableSynchronizer {
         error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
     }
 
-    override suspend fun rewindToHeight(height: BlockHeight) {
-        error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
-    }
-
     override suspend fun validateAddress(address: String): AddressType = AddressType.Unified
 
     override suspend fun validateConsensusBranch(): ConsensusMatchType {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -186,7 +186,6 @@ class AccountDataSourceImpl(
                                 seedFingerprint = seedFingerprint.hexToByteArray(),
                                 zip32AccountIndex = Zip32AccountIndex.new(index)
                             ),
-                        birthday = birthday,
                     ),
                 )
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ConfirmResyncUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ConfirmResyncUseCase.kt
@@ -17,7 +17,7 @@ class ConfirmResyncUseCase(
 ) {
     suspend operator fun invoke(blockHeight: BlockHeight) {
         val synchronizer = synchronizerProvider.getSynchronizer()
-        synchronizer.rewindToHeight(blockHeight)
+        synchronizer.rewindToNearestHeight(blockHeight)
         walletRestoringStateProvider.store(WalletRestoringState.RESYNCING)
         synchronizerProvider.resetSynchronizer()
         isKeepScreenOnDuringRestoreProvider.clear()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateFlexaTransactionUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateFlexaTransactionUseCase.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZecSend
 import cash.z.ecc.android.sdk.model.fromZecString
+import cash.z.ecc.android.sdk.model.toKotlinLocale
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.datasource.TransactionProposalNotCreatedException
@@ -95,7 +96,7 @@ class CreateFlexaTransactionUseCase(
                     null -> WalletAddress.Unified.new(recipientAddressState.address)
                 },
             amount =
-                Zatoshi.fromZecString(transaction.amount, locale)
+                Zatoshi.fromZecString(context, transaction.amount, locale.toKotlinLocale())
                     ?: throw NullPointerException("TX amount is null"),
             memo = Memo(""),
             proposal = null

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/height/KeystoneHeightVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/height/KeystoneHeightVM.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.screen.connectkeystone.height
 
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.lifecycle.ViewModel
-import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.android.sdk.model.BlockHeight
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
@@ -74,7 +73,7 @@ class KeystoneHeightVM(
         createAccountLce.execute {
             createKeystoneAccount(
                 accounts,
-                account ?: throw InitializeException.NoAccountLoaded,
+                account ?: throw IllegalStateException("No account loaded"),
                 BlockHeight.new(height),
             )
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/neworactive/KeystoneNewOrActiveVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/neworactive/KeystoneNewOrActiveVM.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.screen.connectkeystone.neworactive
 
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.lifecycle.ViewModel
-import cash.z.ecc.android.sdk.exception.InitializeException
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.LceState
@@ -55,7 +54,7 @@ class KeystoneNewOrActiveVM(
 
     private fun onNewDeviceClick() =
         createAccountLce.execute {
-            val account = accounts.accounts.firstOrNull() ?: throw InitializeException.NoAccountLoaded
+            val account = accounts.accounts.firstOrNull() ?: throw IllegalStateException("No account loaded")
             createKeystoneAccount(accounts, account, birthday = null)
         }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.ZecSend
-import cash.z.ecc.android.sdk.model.toZecString
 import cash.z.ecc.android.sdk.type.AddressType
+import cash.z.ecc.sdk.extension.toZecString
 import co.electriccoin.zcash.di.koinActivityViewModel
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.appbar.ZashiTopAppBarVM

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
@@ -328,7 +328,7 @@ fun SendButton(
                 // SDK side validations
                 val zecSendValidation =
                     ZecSendExt.new(
-                        locale = locale,
+                        context = context,
                         destinationString = recipientAddressState.address,
                         zecString = amountState.value.getString(context),
                         // Take memo for a valid non-transparent receiver only


### PR DESCRIPTION
## Summary
- Pin Jacoco back to the latest published release so coverage-enabled Android test setup can resolve its agent artifact.
- Restore local formatter helpers used by the UI while the current SDK release does not expose the newer formatter APIs.
- Remove the redundant non-null assertion that fails Kotlin test compilation under `-Werror`.

## Validation
- `git diff --check`
- `./gradlew -PSDK_INCLUDED_BUILD_PATH= :ui-design-lib:compileReleaseKotlin --no-daemon`
- `./gradlew -PSDK_INCLUDED_BUILD_PATH= :spackle-lib:compileTestKotlinJvm --no-daemon`
- `./gradlew -PSDK_INCLUDED_BUILD_PATH= -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true :sdk-ext-lib:generateDebugAndroidTestJacocoPropertiesFile --refresh-dependencies --no-daemon`
