### PR TITLE
Fix voting submission progress regression

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
@@ -489,6 +489,26 @@ class SubmitVotesUseCase(
                             ?: error("Unknown proposal id $proposalId for round $roundId")
                     val progressBase = proposalIndex + 1
 
+                    fun emitSubmittingProgress(
+                        bundleIndex: Int,
+                        bundleProgress: Double
+                    ) {
+                        onProgress(
+                            VotingSubmissionProgress.Submitting(
+                                current = progressBase,
+                                total = totalChoices,
+                                progress =
+                                    calculateSubmittingBundleProgress(
+                                        proposalIndex = proposalIndex,
+                                        bundleIndex = bundleIndex,
+                                        bundleCount = bundleCount,
+                                        totalChoices = totalChoices,
+                                        bundleProgress = bundleProgress
+                                    )
+                            )
+                        )
+                    }
+
                     val submittedBundles =
                         submittedBundleIndicesByProposal
                             .getOrPut(proposalId) { mutableSetOf() }
@@ -528,15 +548,7 @@ class SubmitVotesUseCase(
                             return@repeat
                         }
 
-                        val completedBundles = proposalIndex * bundleCount + bundleIndex + 1
-                        val bundleTotal = totalChoices * bundleCount.coerceAtLeast(1)
-                        onProgress(
-                            VotingSubmissionProgress.Submitting(
-                                current = progressBase,
-                                total = totalChoices,
-                                progress = completedBundles.toFloat() / bundleTotal
-                            )
-                        )
+                        emitSubmittingProgress(bundleIndex, bundleProgress = 0.0)
 
                         val cachedVoteTxHash =
                             votingCryptoClient.getVoteTxHash(
@@ -628,6 +640,7 @@ class SubmitVotesUseCase(
                                     )
                                 }
                                 submittedBundles += bundleIndex
+                                emitSubmittingProgress(bundleIndex, bundleProgress = 1.0)
                                 return@repeat
                             }
                             Log.i(
@@ -693,18 +706,9 @@ class SubmitVotesUseCase(
                                     accountIndex = accountIndex,
                                     singleShare = singleShare,
                                     proofProgress = { proofProgress ->
-                                        onProgress(
-                                            VotingSubmissionProgress.Submitting(
-                                                current = progressBase,
-                                                total = totalChoices,
-                                                progress =
-                                                    (
-                                                        (
-                                                            proposalIndex * bundleCount + bundleIndex +
-                                                                proofProgress.coerceIn(0.0, 1.0)
-                                                        ) / bundleTotal
-                                                    ).toFloat()
-                                            )
+                                        emitSubmittingProgress(
+                                            bundleIndex = bundleIndex,
+                                            bundleProgress = proofProgress
                                         )
                                     }
                                 )
@@ -826,6 +830,7 @@ class SubmitVotesUseCase(
                             )
                         }
                         submittedBundles += bundleIndex
+                        emitSubmittingProgress(bundleIndex, bundleProgress = 1.0)
                     }
 
                     markProposalSubmissionComplete(accountUuidString, roundId, proposalId)
@@ -1194,4 +1199,25 @@ class SubmitVotesUseCase(
         const val SHARE_DELEGATION_ATTEMPTS = 3
         const val SHARE_DELEGATION_RETRY_MS = 2_000L
     }
+}
+
+internal fun calculateSubmittingBundleProgress(
+    proposalIndex: Int,
+    bundleIndex: Int,
+    bundleCount: Int,
+    totalChoices: Int,
+    bundleProgress: Double
+): Float {
+    require(proposalIndex >= 0) { "proposalIndex must be non-negative" }
+    require(bundleIndex >= 0) { "bundleIndex must be non-negative" }
+    require(bundleCount > 0) { "bundleCount must be positive" }
+    require(totalChoices > 0) { "totalChoices must be positive" }
+
+    val completedBundles =
+        proposalIndex * bundleCount +
+            bundleIndex +
+            bundleProgress.coerceIn(0.0, 1.0)
+    val bundleTotal = totalChoices * bundleCount
+
+    return (completedBundles / bundleTotal).toFloat().coerceIn(0f, 1f)
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseProgressTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseProgressTest.kt
@@ -1,0 +1,101 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SubmitVotesUseCaseProgressTest {
+    @Test
+    fun submittingProgressDoesNotAdvanceBundleBeforeWorkCompletes() {
+        assertEquals(
+            0f,
+            calculateSubmittingBundleProgress(
+                proposalIndex = 0,
+                bundleIndex = 0,
+                bundleCount = 2,
+                totalChoices = 1,
+                bundleProgress = 0.0
+            )
+        )
+
+        assertEquals(
+            0.5f,
+            calculateSubmittingBundleProgress(
+                proposalIndex = 0,
+                bundleIndex = 0,
+                bundleCount = 2,
+                totalChoices = 1,
+                bundleProgress = 1.0
+            )
+        )
+    }
+
+    @Test
+    fun submittingProgressIsMonotonicAcrossBundleProofAndCompletion() {
+        val progress =
+            listOf(
+                calculateSubmittingBundleProgress(
+                    proposalIndex = 0,
+                    bundleIndex = 0,
+                    bundleCount = 2,
+                    totalChoices = 1,
+                    bundleProgress = 0.0
+                ),
+                calculateSubmittingBundleProgress(
+                    proposalIndex = 0,
+                    bundleIndex = 0,
+                    bundleCount = 2,
+                    totalChoices = 1,
+                    bundleProgress = 0.35
+                ),
+                calculateSubmittingBundleProgress(
+                    proposalIndex = 0,
+                    bundleIndex = 0,
+                    bundleCount = 2,
+                    totalChoices = 1,
+                    bundleProgress = 1.0
+                ),
+                calculateSubmittingBundleProgress(
+                    proposalIndex = 0,
+                    bundleIndex = 1,
+                    bundleCount = 2,
+                    totalChoices = 1,
+                    bundleProgress = 0.0
+                ),
+                calculateSubmittingBundleProgress(
+                    proposalIndex = 0,
+                    bundleIndex = 1,
+                    bundleCount = 2,
+                    totalChoices = 1,
+                    bundleProgress = 1.0
+                )
+            )
+
+        assertEquals(1f, progress.last())
+        assertTrue(progress.zipWithNext().all { (previous, next) -> previous <= next })
+    }
+
+    @Test
+    fun submittingProgressAccountsForMultipleProposalsAndBundles() {
+        assertEquals(
+            0.625f,
+            calculateSubmittingBundleProgress(
+                proposalIndex = 2,
+                bundleIndex = 1,
+                bundleCount = 2,
+                totalChoices = 4,
+                bundleProgress = 0.0
+            )
+        )
+        assertEquals(
+            0.75f,
+            calculateSubmittingBundleProgress(
+                proposalIndex = 2,
+                bundleIndex = 1,
+                bundleCount = 2,
+                totalChoices = 4,
+                bundleProgress = 1.0
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Keep vote submission progress monotonic by starting each bundle at its current position and only marking it complete after successful cached or new submission handling.
- Extract the submitting bundle progress math into a focused helper covered by unit tests.

## Test plan
- `ANDROID_HOME=/Users/roman/Library/Android/sdk ./gradlew :ui-lib:testZcashtestnetFossDebugUnitTest --tests co.electriccoin.zcash.ui.common.usecase.SubmitVotesUseCaseProgressTest`