### PR TITLE
Show Keystone authorization failures

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
@@ -334,26 +334,28 @@ class SubmitVotesUseCase(
 
                             rustRoundState = votingCryptoClient.getRoundState(dbHandle, roundId)
                             if (rustRoundState?.proofGenerated != true) {
-                                votingCryptoClient.buildAndProveDelegation(
-                                    dbHandle = dbHandle,
-                                    roundId = roundId,
-                                    bundleIndex = bundleIndex,
-                                    pirServerUrl = pirServerUrl,
-                                    networkId = networkId,
-                                    notesJson = allNotesJson,
-                                    hotkeyRawAddress = hotkeyRawAddress,
-                                    proofProgress = { progress ->
-                                        onProgress(
-                                            VotingSubmissionProgress.Authorizing(
-                                                progress =
-                                                    (
-                                                        (bundleIndex + progress.coerceIn(0.0, 1.0)) /
-                                                            bundleCount.coerceAtLeast(1)
-                                                    ).toFloat()
+                                runVotingAuthorizationStep(isKeystone) {
+                                    votingCryptoClient.buildAndProveDelegation(
+                                        dbHandle = dbHandle,
+                                        roundId = roundId,
+                                        bundleIndex = bundleIndex,
+                                        pirServerUrl = pirServerUrl,
+                                        networkId = networkId,
+                                        notesJson = allNotesJson,
+                                        hotkeyRawAddress = hotkeyRawAddress,
+                                        proofProgress = { progress ->
+                                            onProgress(
+                                                VotingSubmissionProgress.Authorizing(
+                                                    progress =
+                                                        (
+                                                            (bundleIndex + progress.coerceIn(0.0, 1.0)) /
+                                                                bundleCount.coerceAtLeast(1)
+                                                        ).toFloat()
+                                                )
                                             )
-                                        )
-                                    }
-                                )
+                                        }
+                                    )
+                                }
                             }
                         }
                         votingRecoveryRepository.setPhase(
@@ -362,48 +364,50 @@ class SubmitVotesUseCase(
                             phase = VotingRecoveryPhase.DELEGATION_PROVED
                         )
 
-                        val submission =
-                            if (isKeystone) {
-                                val keystoneSignature =
-                                    recovery.keystoneBundleSignatures[bundleIndex]
-                                        ?: error("Keystone signature is missing for voting bundle $bundleIndex")
-                                votingCryptoClient.getDelegationSubmissionWithKeystoneSignature(
-                                    dbHandle = dbHandle,
-                                    roundId = roundId,
-                                    bundleIndex = bundleIndex,
-                                    keystoneSig = keystoneSignature.decodeSpendAuthSig(),
-                                    keystoneSighash = keystoneSignature.decodeSighash()
-                                )
-                            } else {
-                                votingCryptoClient.getDelegationSubmission(
-                                    dbHandle = dbHandle,
-                                    roundId = roundId,
-                                    bundleIndex = bundleIndex,
-                                    senderSeed = requireNotNull(senderSeed),
-                                    networkId = networkId,
-                                    accountIndex = accountIndex
-                                )
-                            }
-                        if (isKeystone) {
-                            val keystoneSignature =
-                                recovery.keystoneBundleSignatures[bundleIndex]
-                                    ?: error("Keystone signature is missing for voting bundle $bundleIndex")
-                            require(submission.spendAuthSig.contentEquals(keystoneSignature.decodeSpendAuthSig())) {
-                                "Delegation signature mismatch for Keystone voting bundle $bundleIndex"
-                            }
-                            require(submission.sighash.contentEquals(keystoneSignature.decodeSighash())) {
-                                "Delegation sighash mismatch for Keystone voting bundle $bundleIndex"
-                            }
-                            keystoneSignature.decodeRk()?.let { expectedRk ->
-                                require(submission.rk.contentEquals(expectedRk)) {
-                                    "Delegation rk mismatch for Keystone voting bundle $bundleIndex"
-                                }
-                            }
-                        }
                         val txResult =
-                            votingApiProvider
-                                .submitDelegation(submission.toDelegationRegistration())
-                                .requireAccepted("Delegation transaction was rejected")
+                            runVotingAuthorizationStep(isKeystone) {
+                                val submission =
+                                    if (isKeystone) {
+                                        val keystoneSignature =
+                                            recovery.keystoneBundleSignatures[bundleIndex]
+                                                ?: error("Keystone signature is missing for voting bundle $bundleIndex")
+                                        votingCryptoClient.getDelegationSubmissionWithKeystoneSignature(
+                                            dbHandle = dbHandle,
+                                            roundId = roundId,
+                                            bundleIndex = bundleIndex,
+                                            keystoneSig = keystoneSignature.decodeSpendAuthSig(),
+                                            keystoneSighash = keystoneSignature.decodeSighash()
+                                        )
+                                    } else {
+                                        votingCryptoClient.getDelegationSubmission(
+                                            dbHandle = dbHandle,
+                                            roundId = roundId,
+                                            bundleIndex = bundleIndex,
+                                            senderSeed = requireNotNull(senderSeed),
+                                            networkId = networkId,
+                                            accountIndex = accountIndex
+                                        )
+                                    }
+                                if (isKeystone) {
+                                    val keystoneSignature =
+                                        recovery.keystoneBundleSignatures[bundleIndex]
+                                            ?: error("Keystone signature is missing for voting bundle $bundleIndex")
+                                    require(submission.spendAuthSig.contentEquals(keystoneSignature.decodeSpendAuthSig())) {
+                                        "Delegation signature mismatch for Keystone voting bundle $bundleIndex"
+                                    }
+                                    require(submission.sighash.contentEquals(keystoneSignature.decodeSighash())) {
+                                        "Delegation sighash mismatch for Keystone voting bundle $bundleIndex"
+                                    }
+                                    keystoneSignature.decodeRk()?.let { expectedRk ->
+                                        require(submission.rk.contentEquals(expectedRk)) {
+                                            "Delegation rk mismatch for Keystone voting bundle $bundleIndex"
+                                        }
+                                    }
+                                }
+                                votingApiProvider
+                                    .submitDelegation(submission.toDelegationRegistration())
+                                    .requireAccepted("Delegation transaction was rejected")
+                            }
                         votingCryptoClient.storeDelegationTxHash(
                             dbHandle = dbHandle,
                             roundId = roundId,
@@ -412,18 +416,24 @@ class SubmitVotesUseCase(
                         )
 
                         val confirmation =
-                            awaitTxConfirmation(txResult.txHash)
-                                ?: throw VotingSubmissionRecoverableException(
-                                    VotingErrors.TxConfirmationTimedOut(txResult.txHash)
-                                )
-                        confirmation.requireAccepted("Delegation transaction failed")
+                            runVotingAuthorizationStep(isKeystone) {
+                                awaitTxConfirmation(txResult.txHash)
+                                    ?: throw VotingSubmissionRecoverableException(
+                                        VotingErrors.TxConfirmationTimedOut(txResult.txHash)
+                                    )
+                            }
+                        runVotingAuthorizationStep(isKeystone) {
+                            confirmation.requireAccepted("Delegation transaction failed")
+                        }
 
                         val vanPosition =
-                            confirmation
-                                .event("delegate_vote")
-                                ?.attribute("leaf_index")
-                                ?.toIntOrNull()
-                                ?: error("Missing delegate_vote leaf_index for bundle $bundleIndex")
+                            runVotingAuthorizationStep(isKeystone) {
+                                confirmation
+                                    .event("delegate_vote")
+                                    ?.attribute("leaf_index")
+                                    ?.toIntOrNull()
+                                    ?: error("Missing delegate_vote leaf_index for bundle $bundleIndex")
+                            }
                         traceVotingStep(
                             roundId = roundId,
                             step = "storeDelegationVanPosition",
@@ -1138,6 +1148,18 @@ class SubmitVotesUseCase(
         return nowEpochSeconds + Random.nextLong(until = window)
     }
 
+    private suspend fun <T> runVotingAuthorizationStep(
+        isKeystone: Boolean,
+        block: suspend () -> T
+    ): T =
+        try {
+            block()
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            throw exception.asVotingAuthorizationExceptionIfNeeded(isKeystone)
+        }
+
     private fun ZcashNetwork.toVotingNetworkId() =
         if (isMainnet()) 1 else 0
 
@@ -1200,6 +1222,14 @@ class SubmitVotesUseCase(
         const val SHARE_DELEGATION_RETRY_MS = 2_000L
     }
 }
+
+internal fun Exception.asVotingAuthorizationExceptionIfNeeded(isKeystone: Boolean): Exception =
+    when {
+        this is VotingSubmissionRecoverableException -> this
+        this is VotingAuthorizationException -> this
+        isKeystone -> VotingAuthorizationException(this)
+        else -> this
+    }
 
 internal fun calculateSubmittingBundleProgress(
     proposalIndex: Int,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionVM.kt
@@ -11,7 +11,6 @@ import co.electriccoin.zcash.ui.common.model.LceState
 import co.electriccoin.zcash.ui.common.model.stateIn
 import co.electriccoin.zcash.ui.common.model.voting.VotingRound
 import co.electriccoin.zcash.ui.common.model.voting.VotingSubmissionProgress
-import co.electriccoin.zcash.ui.common.provider.VotingCryptoClient
 import co.electriccoin.zcash.ui.common.repository.VotingApiRepository
 import co.electriccoin.zcash.ui.common.repository.VotingRecoveryPhase
 import co.electriccoin.zcash.ui.common.repository.VotingRecoveryRepository
@@ -54,15 +53,12 @@ class VoteConfirmSubmissionVM(
     prepareVotingRound: PrepareVotingRoundUseCase,
     private val authorizeVotingSubmission: AuthorizeVotingSubmissionUseCase,
     private val submitVotes: SubmitVotesUseCase,
-    private val votingCryptoClient: VotingCryptoClient,
     private val navigationRouter: NavigationRouter,
 ) : ViewModel() {
     private val statusFlow = MutableStateFlow<VoteSubmissionStatus>(VoteSubmissionStatus.Idle)
     private val isFailureSheetVisible = MutableStateFlow(false)
     private val activeSubmissionIncludesAuthorizationProgress = MutableStateFlow<Boolean?>(null)
 
-    // Loaded once per VM; ballot divisor is a static SDK constant.
-    private val ballotDivisorZatoshi = MutableStateFlow<Long?>(null)
     private val draftChoices =
         runCatching { args.choicesJson.toDraftChoices() }
             .getOrElse { throwable ->
@@ -110,19 +106,6 @@ class VoteConfirmSubmissionVM(
                 Log.e(
                     "VoteConfirmSubmission",
                     "Failed to prepare voting round ${args.roundIdHex}",
-                    throwable
-                )
-            }
-        }
-        viewModelScope.launch {
-            runCatching {
-                votingCryptoClient.ballotDivisorZatoshi()
-            }.onSuccess { divisor ->
-                ballotDivisorZatoshi.value = divisor
-            }.onFailure { throwable ->
-                Log.w(
-                    "VoteConfirmSubmission",
-                    "Failed to fetch ballot divisor for ${args.roundIdHex}",
                     throwable
                 )
             }
@@ -200,9 +183,8 @@ class VoteConfirmSubmissionVM(
             votingApiRepository.snapshot,
             recovery,
             isKeystoneAccount,
-            submissionUiState,
-            ballotDivisorZatoshi,
-        ) { apiSnapshot, recovery, isKeystone, submissionUiState, ballotDivisor ->
+            submissionUiState
+        ) { apiSnapshot, recovery, isKeystone, submissionUiState ->
             apiSnapshot.rounds
                 .firstOrNull { round -> round.id == args.roundIdHex }
                 ?.let { round ->
@@ -212,8 +194,7 @@ class VoteConfirmSubmissionVM(
                         isKeystone = isKeystone,
                         status = submissionUiState.status,
                         showFailureSheet = submissionUiState.isFailureSheetVisible,
-                        activeIncludesAuthorizationProgress = submissionUiState.activeIncludesAuthorizationProgress,
-                        ballotDivisorZatoshi = ballotDivisor
+                        activeIncludesAuthorizationProgress = submissionUiState.activeIncludesAuthorizationProgress
                     )
                 }
         }.map { content ->
@@ -233,7 +214,6 @@ class VoteConfirmSubmissionVM(
         status: VoteSubmissionStatus,
         showFailureSheet: Boolean,
         activeIncludesAuthorizationProgress: Boolean?,
-        ballotDivisorZatoshi: Long?,
     ): VoteConfirmSubmissionState {
         val isPrepared = recovery?.eligibleWeight != null && recovery.hotkeyAddress != null
         val keystoneSignedBundles = recovery?.keystoneBundleSignatures?.size ?: 0
@@ -290,8 +270,6 @@ class VoteConfirmSubmissionVM(
                     status = status,
                     isVisible = showFailureSheet,
                     canRetry = isPrepared && draftChoices.isNotEmpty(),
-                    eligibleWeightZatoshi = recovery?.eligibleWeight,
-                    ballotDivisorZatoshi = ballotDivisorZatoshi,
                     retryAction =
                         if (isKeystone && keystoneSignedBundles < preparedBundleCount) {
                             ::onStartKeystoneSigning
@@ -515,8 +493,6 @@ class VoteConfirmSubmissionVM(
         status: VoteSubmissionStatus,
         isVisible: Boolean,
         canRetry: Boolean,
-        eligibleWeightZatoshi: Long?,
-        ballotDivisorZatoshi: Long?,
         retryAction: () -> Unit,
     ): ZashiConfirmationState? {
         if (!isVisible || !status.isFailure()) {
@@ -524,7 +500,7 @@ class VoteConfirmSubmissionVM(
         }
         return ZashiConfirmationState.error(
             title = failureTitle(status),
-            message = failureMessage(status, eligibleWeightZatoshi, ballotDivisorZatoshi),
+            message = failureMessage(status),
             primaryText = stringRes(if (canRetry) R.string.vote_retry else R.string.vote_dismiss),
             secondaryText = stringRes(R.string.vote_dismiss),
             primaryStyle = ButtonStyle.PRIMARY,
@@ -547,25 +523,14 @@ class VoteConfirmSubmissionVM(
             else -> stringRes(R.string.vote_error_something_went_wrong)
         }
 
-    private fun failureMessage(
-        status: VoteSubmissionStatus,
-        eligibleWeightZatoshi: Long?,
-        ballotDivisorZatoshi: Long?,
-    ) =
+    private fun failureMessage(status: VoteSubmissionStatus) =
         when (status) {
             is VoteSubmissionStatus.LocalAuthFailed -> {
                 status.error.toErrorMessageOrDefault(stringRes(R.string.vote_confirm_error_authentication))
             }
 
-            // Mirrors iOS's `delegationProofFailed` reducer: surface the snapshot
-            // weight against the ballot divisor when the SDK refuses delegation
-            // because the user's weight does not yield a single ballot.
             is VoteSubmissionStatus.ProtocolAuthFailed -> {
-                status.error.toErrorMessageOrDefault(
-                    default = stringRes(R.string.vote_confirm_error_auth),
-                    eligibleWeightZatoshi = eligibleWeightZatoshi,
-                    ballotDivisorZatoshi = ballotDivisorZatoshi
-                )
+                stringRes(R.string.vote_error_authorization_failed_message)
             }
 
             is VoteSubmissionStatus.SubmissionFailed -> {
@@ -639,21 +604,6 @@ private fun String?.toErrorMessageOrDefault(default: StringResource): StringReso
         default
     } else {
         VotingErrorMapper.toUserFriendlyMessage(this)
-    }
-
-private fun String?.toErrorMessageOrDefault(
-    default: StringResource,
-    eligibleWeightZatoshi: Long?,
-    ballotDivisorZatoshi: Long?,
-): StringResource =
-    if (isNullOrBlank()) {
-        default
-    } else {
-        VotingErrorMapper.toUserFriendlyMessage(
-            rawMessage = this,
-            eligibleWeightZatoshi = eligibleWeightZatoshi,
-            ballotDivisorZatoshi = ballotDivisorZatoshi
-        )
     }
 
 private fun String.toDraftChoices(): Map<Int, Int> {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionView.kt
@@ -218,7 +218,7 @@ private fun headerSubtitle(state: VoteConfirmSubmissionState): StringResource =
         }
 
         is VoteSubmissionStatus.ProtocolAuthFailed -> {
-            status.error.toMessageOrDefault(stringRes(R.string.vote_confirm_error_auth))
+            stringRes(R.string.vote_error_authorization_failed_message)
         }
 
         is VoteSubmissionStatus.SubmissionFailed -> {

--- a/ui-lib/src/main/res/ui/voting/values/strings.xml
+++ b/ui-lib/src/main/res/ui/voting/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="vote_error_insufficient_funds_message">You don\'t have enough ZEC to cover the transaction fee. Add funds to your wallet and try again.</string>
     <string name="vote_error_go_back">Go Back</string>
     <string name="vote_error_authorization_failed_title">Authorization Failed</string>
-    <string name="vote_error_authorization_failed_message">The authorization transaction failed. Check your connection and try again.</string>
+    <string name="vote_error_authorization_failed_message">We couldn\'t authorize your vote. Check your connection and try again.</string>
 
     <string name="vote_poll_ended_title">Poll Has Ended</string>
     <string name="vote_poll_ended_message">The voting period closed.\nYour responses cannot be submitted.</string>

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseProgressTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseProgressTest.kt
@@ -1,10 +1,42 @@
 package co.electriccoin.zcash.ui.common.usecase
 
+import co.electriccoin.zcash.ui.common.model.voting.VotingErrors
+import co.electriccoin.zcash.ui.common.model.voting.VotingSubmissionRecoverableException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SubmitVotesUseCaseProgressTest {
+    @Test
+    fun keystoneAuthorizationClassifierWrapsGenericFailures() {
+        val cause = IllegalStateException("Delegation transaction failed")
+
+        val classified = cause.asVotingAuthorizationExceptionIfNeeded(isKeystone = true)
+
+        assertTrue(classified is VotingAuthorizationException)
+        assertSame(cause, classified.cause)
+        assertEquals("Delegation transaction failed", classified.message)
+    }
+
+    @Test
+    fun authorizationClassifierPreservesNonKeystoneFailures() {
+        val cause = IllegalStateException("Delegation transaction failed")
+
+        val classified = cause.asVotingAuthorizationExceptionIfNeeded(isKeystone = false)
+
+        assertSame(cause, classified)
+    }
+
+    @Test
+    fun authorizationClassifierPreservesRecoverableFailures() {
+        val recoverable = VotingSubmissionRecoverableException(VotingErrors.MissingVotingServerUrl)
+
+        val classified = recoverable.asVotingAuthorizationExceptionIfNeeded(isKeystone = true)
+
+        assertSame(recoverable, classified)
+    }
+
     @Test
     fun submittingProgressDoesNotAdvanceBundleBeforeWorkCompletes() {
         assertEquals(


### PR DESCRIPTION
## Summary
- Wrap Keystone delegation authorization failures as `VotingAuthorizationException` so the confirmation UI leaves the loading state and shows the authorization failure state.
- Use the Figma authorization failure copy for both the confirmation screen and failure sheet instead of surfacing raw delegation errors.
- Add focused coverage for Keystone vs non-Keystone error classification.

## Test plan
- `ANDROID_HOME="/Users/roman/Library/Android/sdk" ./gradlew :ui-lib:testZcashtestnetInternalDebugUnitTest --tests "co.electriccoin.zcash.ui.common.usecase.SubmitVotesUseCaseProgressTest"`
- IDE lints on edited files