### PR TITLE
Fix voted poll back navigation

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionVM.kt
@@ -28,6 +28,7 @@ import co.electriccoin.zcash.ui.design.component.ButtonStyle
 import co.electriccoin.zcash.ui.design.component.ZashiConfirmationState
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.screen.voting.coinholderpolling.VoteCoinholderPollingArgs
 import co.electriccoin.zcash.ui.screen.voting.proposallist.VoteProposalListArgs
 import co.electriccoin.zcash.ui.screen.voting.proposallist.VoteProposalListMode
 import co.electriccoin.zcash.ui.screen.voting.signkeystone.SignKeystoneVotingArgs
@@ -473,7 +474,8 @@ class VoteConfirmSubmissionVM(
             if (persistedChoices.isNotEmpty()) {
                 votingSessionStore.restoreDraftVotes(accountUuid, args.roundIdHex, persistedChoices)
             }
-            navigationRouter.replace(
+            navigationRouter.replaceAll(
+                VoteCoinholderPollingArgs,
                 VoteProposalListArgs(
                     roundId = args.roundIdHex,
                     mode = VoteProposalListMode.VOTED

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposallist/VoteProposalListVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposallist/VoteProposalListVM.kt
@@ -468,7 +468,7 @@ class VoteProposalListVM(
 
     private fun onBack() {
         when (args.mode) {
-            VoteProposalListMode.VOTED -> navigationRouter.backTo(VoteCoinholderPollingArgs::class)
+            VoteProposalListMode.VOTED -> navigationRouter.replaceAll(VoteCoinholderPollingArgs)
             else -> navigationRouter.back()
         }
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/results/VoteResultsVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/results/VoteResultsVM.kt
@@ -230,9 +230,9 @@ class VoteResultsVM(
         }
     }
 
-    private fun onDone() = navigationRouter.backTo(VoteCoinholderPollingArgs::class)
+    private fun onDone() = navigationRouter.replaceAll(VoteCoinholderPollingArgs)
 
-    fun onBack() = navigationRouter.backTo(VoteCoinholderPollingArgs::class)
+    fun onBack() = navigationRouter.replaceAll(VoteCoinholderPollingArgs)
 }
 
 private fun Long.toZec(): Double = this / 100_000_000.0

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/tallying/VoteTallyingVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/tallying/VoteTallyingVM.kt
@@ -76,7 +76,7 @@ class VoteTallyingVM(
         )
     }
 
-    private fun onBack() = navigationRouter.backTo(VoteCoinholderPollingArgs::class)
+    private fun onBack() = navigationRouter.replaceAll(VoteCoinholderPollingArgs)
 
     private companion object {
         const val POLL_INTERVAL_MS = 5_000L


### PR DESCRIPTION
## Summary
- Rebuild the post-submit stack with the polling page under the voted page.
- Route voted, tallying, and results back/done actions to polling even when that route is missing from history.

## Test plan
- ReadLints on touched voting view models.
- ANDROID_HOME=/Users/roman/Library/Android/sdk ./gradlew :ui-lib:compileZcashmainnetInternalDebugKotlin