### PR TITLE
Update bundled voting static config checksum

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/voting/StaticVotingConfig.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/voting/StaticVotingConfig.kt
@@ -55,8 +55,8 @@ data class StaticVotingConfig(
 
         const val BUNDLED_PINNED_SOURCE =
             "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/" +
-                "d19edb058081d72aba8a955a57607eabf815e5df/static-voting-config.json" +
-                "?checksum=sha256:f56224c6552178e64f9cc75e8ee2a663130c46172b2470fc02efdf94c522f2ac"
+                "5ed8d623e4150d383a4dac05dd6bfbdd126a5408/prod/static-voting-config.json" +
+                "?checksum=sha256:5a6bc0dce85a8ee8d6585d2a180e62f145abcfee7768c15b88de47c9a01a5738"
 
         fun decodeAndVerify(data: ByteArray, expectedSHA256: ByteArray?): StaticVotingConfig {
             if (expectedSHA256 != null) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/configuration/ConfigurationEntries.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/configuration/ConfigurationEntries.kt
@@ -7,5 +7,4 @@ import co.electriccoin.zcash.configuration.model.entry.StringConfigurationEntry
 object ConfigurationEntries {
     val IS_FLEXA_AVAILABLE = BooleanConfigurationEntry(ConfigKey("is_flexa_available"), true)
     val VOTING_CONFIG_URL = StringConfigurationEntry(ConfigKey("voting_config_url"), "")
-    val VOTING_SERVER_URL = StringConfigurationEntry(ConfigKey("voting_server_url"), "")
 }


### PR DESCRIPTION
## Summary

- Update `StaticVotingConfig.BUNDLED_PINNED_SOURCE` checksum to `sha256:5a6bc0dce85a8ee8d6585d2a180e62f145abcfee7768c15b88de47c9a01a5738`.
- Remove unused `VOTING_SERVER_URL` configuration entry (dead code from the pre-attestation voting bootstrap path).

## iOS

https://github.com/zodl-inc/zodl-ios/pull/1759