### PR TITLE
[#1816] Replace resourceConfigurations with androidResources.localeFilters

### DIFF
--- a/build-conventions-secant/src/main/kotlin/secant.android-build-conventions.gradle.kts
+++ b/build-conventions-secant/src/main/kotlin/secant.android-build-conventions.gradle.kts
@@ -13,12 +13,6 @@ pluginManager.withPlugin("com.android.application") {
             minSdk = project.property("ANDROID_MIN_SDK_VERSION").toString().toInt()
             targetSdk = project.property("ANDROID_TARGET_SDK_VERSION").toString().toInt()
 
-            // en_XA and ar_XB are pseudolocales for debugging.
-            // The rest of the locales provides an explicit list of the languages to keep in the
-            // final app.  Doing this will strip out additional locales from libraries like
-            // Google Play Services and Firebase, which add unnecessary bloat.
-            resourceConfigurations.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
-
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
             testInstrumentationRunnerArguments["useTestStorageService"] = "true"
@@ -27,26 +21,31 @@ pluginManager.withPlugin("com.android.application") {
             }
         }
     }
+    project.the<com.android.build.api.dsl.ApplicationExtension>().apply {
+        // en_XA and ar_XB are pseudolocales for debugging.
+        // The rest of the locales provides an explicit list of the languages to keep in the
+        // final app.  Doing this will strip out additional locales from libraries like
+        // Google Play Services and Firebase, which add unnecessary bloat.
+        @Suppress("UnstableApiUsage")
+        androidResources {
+            localeFilters += listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB")
+        }
+    }
 }
 
 pluginManager.withPlugin("com.android.library") {
     project.the<com.android.build.gradle.LibraryExtension>().apply {
         configureBaseExtension()
 
+        // Locale stripping is configured on the application module via androidResources.localeFilters.
+        // The replacement API is only available on ApplicationAndroidResources, so libraries inherit
+        // the final filter at packaging time and don't need to declare their own.
         defaultConfig {
             minSdk = project.property("ANDROID_MIN_SDK_VERSION").toString().toInt()
             // This is deprecated but we don't have a replacement for the instrumentation APKs yet
             // TODO [#1815]: Gradle targetSdk deprecated #1815
             // TODO [#1815]: https://github.com/Electric-Coin-Company/zashi-android/issues/1815
             targetSdk = project.property("ANDROID_TARGET_SDK_VERSION").toString().toInt()
-
-            // The last two are for support of pseudolocales in debug builds.
-            // If we add other localizations, they should be included in this list.
-            // By explicitly setting supported locales, we strip out unused localizations from third party
-            // libraries (e.g. play services)
-            // TODO [#1816]: Gradle resourceConfigurations deprecation #1816
-            // TODO [#1816]: https://github.com/Electric-Coin-Company/zashi-android/issues/1816
-            resourceConfigurations.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
 
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             consumerProguardFiles("proguard-consumer.txt")
@@ -66,17 +65,11 @@ pluginManager.withPlugin("com.android.test") {
     project.the<com.android.build.gradle.TestExtension>().apply {
         configureBaseExtension()
 
+        // No locale stripping here either. The test APKs target :app and don't ship locale
+        // resources of their own, and localeFilters isn't available on TestAndroidResources.
         defaultConfig {
             minSdk = project.property("ANDROID_MIN_SDK_VERSION").toString().toInt()
             targetSdk = project.property("ANDROID_TARGET_SDK_VERSION").toString().toInt()
-
-            // The last two are for support of pseudolocales in debug builds.
-            // If we add other localizations, they should be included in this list.
-            // By explicitly setting supported locales, we strip out unused localizations from third party
-            // libraries (e.g. play services)
-            // TODO [#1816]: Gradle resourceConfigurations deprecation #1816
-            // TODO [#1816]: https://github.com/Electric-Coin-Company/zashi-android/issues/1816
-            resourceConfigurations.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
 
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/build-conventions-secant/src/main/kotlin/secant.android-build-conventions.gradle.kts
+++ b/build-conventions-secant/src/main/kotlin/secant.android-build-conventions.gradle.kts
@@ -22,13 +22,15 @@ pluginManager.withPlugin("com.android.application") {
         }
     }
     project.the<com.android.build.api.dsl.ApplicationExtension>().apply {
-        // en_XA and ar_XB are pseudolocales for debugging.
+        // en-rXA and ar-rXB are pseudolocales for debugging.
         // The rest of the locales provides an explicit list of the languages to keep in the
         // final app.  Doing this will strip out additional locales from libraries like
         // Google Play Services and Firebase, which add unnecessary bloat.
+        // localeFilters validates every entry and rejects the "en_XA" form that
+        // resourceConfigurations accepted, so the pseudolocales use the "-r" region qualifier.
         @Suppress("UnstableApiUsage")
         androidResources {
-            localeFilters += listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB")
+            localeFilters += listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en-rXA", "ar-rXB")
         }
     }
 }
@@ -37,9 +39,9 @@ pluginManager.withPlugin("com.android.library") {
     project.the<com.android.build.gradle.LibraryExtension>().apply {
         configureBaseExtension()
 
-        // Locale stripping is configured on the application module via androidResources.localeFilters.
-        // The replacement API is only available on ApplicationAndroidResources, so libraries inherit
-        // the final filter at packaging time and don't need to declare their own.
+        // No locale stripping here. localeFilters is only available on ApplicationAndroidResources,
+        // and the application module's filter already applies to the resources merged in from
+        // libraries at packaging time.
         defaultConfig {
             minSdk = project.property("ANDROID_MIN_SDK_VERSION").toString().toInt()
             // This is deprecated but we don't have a replacement for the instrumentation APKs yet


### PR DESCRIPTION
Closes #1816

`resourceConfigurations` is deprecated in AGP 8. This replaces it with `androidResources.localeFilters`.

```diff
-resourceConfigurations.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
+localeFilters += listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en-rXA", "ar-rXB")
```

### Why two of the tags changed spelling

The pseudolocales went from `en_XA` / `ar_XB` to `en-rXA` / `ar-rXB`. This isn't cosmetic: `localeFilters` validates its entries and `resourceConfigurations` didn't, so the underscore form now fails the build outright.

```
> Task :app:processZcashtestnetFossDebugResources FAILED
  > The locale in localeFilters "en_XA" is invalid.
```

> [!WARNING]
> Please don't "modernize" these to BCP-47 (`en-US`, `en-XA`). AGP hands the list to `aapt2 -c`, which only takes Android resource qualifiers and rejects BCP-47 with `invalid config 'en-US' for -c option`. The `-r` region form is the only spelling that satisfies both. That's also why `en-rUS` / `en-rGB` / `en-rAU` are untouched.

### Why library and test modules just drop the call

`localeFilters` only exists on `ApplicationAndroidResources`, so library and test variants can't set it. They don't need to: the app module's filter applies to everything merged into the APK, including resources from libraries. Library modules here aren't published as AARs and the `com.android.test` modules target `:app`, so nothing is lost.

The `@Suppress("UnstableApiUsage")` matches what `managedDevices` already does in the same file.

### Verification

Built the APK twice from the same tree, once with the old API and once with the new one, then diffed `aapt2 dump configurations` on both. **Identical, 43 configurations each**: `en-rAU`, `en-rGB`, `es` and the `en-rXA` / `ar-rXB` pseudolocales all kept, third party locales still stripped. So this is a like-for-like swap, not just something that compiles.

`:app:assembleZcashtestnetFossDebug` passes, as does `processZcashtestnetFossDebugResources` on `:ui-integration-test` and `:ui-screenshot-test` (the modules the call was removed from).
