### PR TITLE
[#323] Add content descriptions for Pay and Swap address book and QR scanner buttons

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
@@ -62,12 +62,14 @@ internal class ExactOutputVMMapper {
             abButton =
                 IconButtonState(
                     icon = R.drawable.send_address_book,
+                    contentDescription = stringRes(R.string.send_address_book_content_description),
                     onClick = onAddressBookClick,
                     isEnabled = !state.isRequestingQuote
                 ),
             qrButton =
                 IconButtonState(
                     icon = R.drawable.qr_code_icon,
+                    contentDescription = stringRes(R.string.send_scan_content_description),
                     onClick = onQrCodeScannerClick,
                     isEnabled = !state.isRequestingQuote
                 ),

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
@@ -99,12 +99,14 @@ internal class SwapVMMapper {
             qrScannerButton =
                 IconButtonState(
                     icon = R.drawable.qr_code_icon,
+                    contentDescription = stringRes(R.string.send_scan_content_description),
                     onClick = onQrCodeScannerClick,
                     isEnabled = !state.isRequestingQuote
                 ),
             addressBookButton =
                 IconButtonState(
                     icon = R.drawable.send_address_book,
+                    contentDescription = stringRes(R.string.send_address_book_content_description),
                     onClick = onAddressBookClick,
                     isEnabled = !state.isRequestingQuote
                 ),


### PR DESCRIPTION
Part of #323

Adds missing `contentDescription` values to the address book and QR scanner icon buttons on the Pay (ExactOutput) and Swap screens. These four buttons are icon-only with no adjacent text label, so without a description TalkBack users have no way to know what they do.

Both reuse the existing `send_address_book_content_description` and `send_scan_content_description` strings already defined in `ui-lib`, with Spanish translations in place. No new string resources are added.

The info and swap-direction toggle buttons on these same screens are also unlabeled, but addressing them requires new string resources and translations, so they are deferred to a follow up PR to keep this change small.