### PR TITLE
[#1477] Add showBackground to design-lib previews

### DIFF
--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Balance.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Balance.kt
@@ -135,7 +135,7 @@ object StyledBalanceDefaults {
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun StyledBalancePreview() =
     ZcashTheme(forceDarkMode = false) {
@@ -150,7 +150,7 @@ private fun StyledBalancePreview() =
         }
     }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun HiddenStyledBalancePreview() =
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Checkbox.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Checkbox.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun LabeledCheckboxPreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -41,7 +41,7 @@ private fun LabeledCheckboxPreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun LabeledCheckboxDarkPreview() {
     ZcashTheme(forceDarkMode = true) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Chip.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Chip.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.spackle.model.Index
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ComposableChipPreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -28,7 +28,7 @@ private fun ComposableChipPreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ComposableChipIndexedPreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -38,7 +38,7 @@ private fun ComposableChipIndexedPreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ComposableLongChipPreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -51,7 +51,7 @@ private fun ComposableLongChipPreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ComposableChipOnSurfacePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -61,7 +61,7 @@ private fun ComposableChipOnSurfacePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ComposableChipOnSurfaceDarkPreview() {
     ZcashTheme(forceDarkMode = true) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Column.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Column.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
-@Preview("Column with blank background")
+@Preview("Column with blank background", showBackground = true)
 @Composable
 private fun BlankBgColumnComposablePreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/CommonComponents.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/CommonComponents.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import co.electriccoin.zcash.ui.design.R
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopScreenLogoRegularComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -28,7 +28,7 @@ private fun TopScreenLogoRegularComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopScreenLogoRegularDarkComposablePreview() {
     ZcashTheme(forceDarkMode = true) {
@@ -41,7 +41,7 @@ private fun TopScreenLogoRegularDarkComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopScreenLogoLongComposablePreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Dialog.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Dialog.kt
@@ -22,7 +22,7 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun LightAlertDialogComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -38,7 +38,7 @@ private fun LightAlertDialogComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun NoButtonAlertDialogComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -52,7 +52,7 @@ private fun NoButtonAlertDialogComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun DarkAlertDialogComposablePreview() {
     ZcashTheme(forceDarkMode = true) {
@@ -167,7 +167,7 @@ fun AppAlertDialog(
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun NavigationButtonPreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -178,7 +178,7 @@ private fun NavigationButtonPreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun NavigationButtonDarkPreview() {
     ZcashTheme(forceDarkMode = true) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Progress.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Progress.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun CircularScreenProgressIndicatorComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -75,7 +75,7 @@ fun CircularSmallProgressIndicator(
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun LinearProgressIndicatorComposablePreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Scaffold.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Scaffold.kt
@@ -12,7 +12,7 @@ import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.util.orDark
 
-@Preview("Scaffold with blank background")
+@Preview("Scaffold with blank background", showBackground = true)
 @Composable
 private fun BlankBgScaffoldComposablePreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Surface.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Surface.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
-@Preview("Blank background")
+@Preview("Blank background", showBackground = true)
 @Composable
 private fun BlankSurfacePreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Text.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Text.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ReferenceComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -297,7 +297,7 @@ fun Reference(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun NavigationTabTextPreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/TopAppBar.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/TopAppBar.kt
@@ -52,7 +52,7 @@ import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.internal.SecondaryTypography
 import co.electriccoin.zcash.ui.design.theme.internal.TopAppBarColors
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarTextComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -71,7 +71,7 @@ private fun TopAppBarTextComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarTextDarkComposablePreview() {
     ZcashTheme(forceDarkMode = true) {
@@ -90,7 +90,7 @@ private fun TopAppBarTextDarkComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarTextRestoringComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -110,7 +110,7 @@ private fun TopAppBarTextRestoringComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarTextRestoringLongComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -130,7 +130,7 @@ private fun TopAppBarTextRestoringLongComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarLogoComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -149,7 +149,7 @@ private fun TopAppBarLogoComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarLogoRestoringComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -169,7 +169,7 @@ private fun TopAppBarLogoRestoringComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarLogoRestoringDarkComposablePreview() {
     ZcashTheme(forceDarkMode = true) {
@@ -189,7 +189,7 @@ private fun TopAppBarLogoRestoringDarkComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarRegularMenuComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -207,7 +207,7 @@ private fun TopAppBarRegularMenuComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarOneVisibleActionMenuComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -231,7 +231,7 @@ private fun TopAppBarOneVisibleActionMenuComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarHamburgerMenuComposablePreview() {
     ZcashTheme(forceDarkMode = false) {
@@ -255,7 +255,7 @@ private fun TopAppBarHamburgerMenuComposablePreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TopAppBarHamburgerPlusActionComposablePreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiLinearProgressIndicator.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiLinearProgressIndicator.kt
@@ -31,7 +31,7 @@ fun ZashiLinearProgressIndicator(
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ZashiLinearProgressIndicatorPreview() {
     ZcashTheme(forceDarkMode = false) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiNumberTextField.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiNumberTextField.kt
@@ -321,7 +321,7 @@ object ZashiNumberTextFieldParser {
 }
 
 @Composable
-@Preview
+@Preview(showBackground = true)
 private fun Preview() =
     ZcashTheme {
         BlankSurface {


### PR DESCRIPTION
Closes #1477

Adds `showBackground = true` to every standalone `@Preview` annotation in `ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/` that did not already have it, so the Android Studio preview panel renders a surface behind each composable instead of a transparent checkerboard. Thirty-seven annotations are updated across thirteen files, all mechanical, with no functional or runtime impact.

The multi-preview meta-annotations in `newcomponent/PreviewScreens.kt` are untouched because their nested `@Preview` entries already declare `showBackground = true`.

I deliberately did not set the `backgroundColor` argument shown in the issue example. The hardcoded hex `0xFF231F20` is the dark-mode brand surface and would render incorrectly behind previews that wrap their content in `ZcashTheme(forceDarkMode = false)`. Leaving `backgroundColor` unset lets the system supply the correct light or dark surface based on the wrapping theme.