### PR TITLE
feature/Add E2E smoke test CI workflow

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           api-level: 34
           arch: x86_64
-          profile: Pixel 6
+          profile: pixel_6
           script: |
             adb install app/build/outputs/apk/zcashtestnetStore/debug/*.apk
             maestro test zodl-qa/maestro/smoke/ \

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -59,8 +59,7 @@ jobs:
           profile: pixel_6
           script: |
             adb install app/build/outputs/apk/zcashtestnetStore/debug/*.apk
-            maestro test zodl-qa/maestro/smoke/ \
-              --include-tags="android"
+            maestro test zodl-qa/maestro/smoke/ --include-tags="android"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,70 @@
+name: E2E Smoke Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-android:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@v4
+
+      - name: Checkout smoke tests
+        uses: actions/checkout@v4
+        with:
+          repository: zodl-inc/zodl-qa
+          path: zodl-qa
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build debug APK
+        run: ./gradlew assembleZcashtestnetStoreDebug
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Run smoke tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: Pixel 6
+          script: |
+            adb install app/build/outputs/apk/zcashtestnetStore/debug/*.apk
+            maestro test zodl-qa/maestro/smoke/ \
+              --include-tags="android"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-android-results
+          path: ~/.maestro/tests/

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Build debug APK
-        run: ./gradlew assembleZcashtestnetStoreDebug
+        run: ./gradlew assembleZcashmainnetInternalDebug
 
       - name: Enable KVM
         run: |
@@ -58,7 +58,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           script: |
-            adb install app/build/outputs/apk/zcashtestnetStore/debug/*.apk
+            adb install app/build/outputs/apk/zcashmainnetInternal/debug/*.apk
             maestro test zodl-qa/maestro/smoke/ --include-tags="android"
 
       - name: Upload test results

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: zodl-inc/zodl-qa
           path: zodl-qa
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.ZODL_QA }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- Adds `e2e-smoke.yml` GitHub Actions workflow that runs on every PR
- Checks out `zodl-qa` repo for Maestro test files
- Builds debug APK, boots Android emulator, runs smoke suite
- Uploads test screenshots as artifacts on pass or fail
