### PR TITLE
Tolerate voting rounds without titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 ### Changed:
 - Voting round responses now require explicit option indices from vote servers.
 
+### Fixed:
+- Coinholder polling can now load when a vote server returns a round without a title.
+
 ## [3.3.1 (1643)] - 2026-04-10
 
 ### Fixed:

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/voting/ChainDto.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/voting/ChainDto.kt
@@ -35,7 +35,7 @@ data class ChainTxDto(
 @JsonIgnoreUnknownKeys
 data class ChainRoundDto(
     @SerialName("vote_round_id") val voteRoundId: String,
-    @SerialName("title") val title: String,
+    @SerialName("title") val title: String = "",
     @SerialName("description") val description: String = "",
     @SerialName("snapshot_height") val snapshotHeight: Long,
     @SerialName("snapshot_blockhash") val snapshotBlockhash: String = "",

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/voting/ChainDtoTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/voting/ChainDtoTest.kt
@@ -1,10 +1,46 @@
 package co.electriccoin.zcash.ui.common.model.voting
 
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class ChainDtoTest {
+    @Test
+    fun chainRoundsDecodeWhenRoundTitleIsMissing() {
+        val response =
+            Json.decodeFromString<ChainRoundsResponse>(
+                """
+                {
+                  "rounds": [
+                    {
+                      "vote_round_id": "${"00".repeat(32)}",
+                      "snapshot_height": 100,
+                      "vote_end_time": 200,
+                      "proposals": [
+                        {
+                          "id": 1,
+                          "title": "Proposal 1",
+                          "options": [
+                            { "label": "No", "index": 0 },
+                            { "label": "Yes", "index": 1 }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """.trimIndent()
+            )
+
+        val round = assertNotNull(response.rounds?.single())
+        assertEquals("", round.title)
+        assertEquals("", round.description)
+        assertEquals("Proposal 1", round.toVotingRound().proposals.single().title)
+    }
+
     @Test
     fun chainRoundSourcesProposalIdentityFromChainResponse() {
         val round =


### PR DESCRIPTION
## Summary

Allow chain round DTOs to decode when a vote server returns a round without a top-level title. The title already behaves like optional display metadata in the polling UI, and missing values should not make the entire rounds response fail to load.

## Validation

- Ran `./gradlew :ui-lib:testZcashtestnetInternalDebugUnitTest --tests co.electriccoin.zcash.ui.common.model.voting.ChainDtoTest -PSDK_INCLUDED_BUILD_PATH=/Users/czar/.codex/worktrees/zodl-android-main-sdk1961/zcash-android-wallet-sdk --stacktrace`
- Verified locally that Coinholder Polling loads stage rounds after the parser tolerance change.
