### PR TITLE
Fix CHP voting skip flow regressions

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/voting/Proposal.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/voting/Proposal.kt
@@ -23,10 +23,3 @@ fun Proposal.abstainOptionId(): Int =
 
 internal fun Proposal.isSyntheticAbstainChoice(choiceId: Int): Boolean =
     options.none(VoteOption::isAbstainOption) && choiceId == abstainOptionId()
-
-fun Proposal.optionsWithAbstain(): List<VoteOption> =
-    if (options.any(VoteOption::isAbstainOption)) {
-        options
-    } else {
-        options + VoteOption(id = abstainOptionId(), label = "Abstain")
-    }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposaldetail/VoteProposalDetailVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposaldetail/VoteProposalDetailVM.kt
@@ -195,7 +195,12 @@ class VoteProposalDetailVM(
             )
         } else {
             val unansweredCount = proposals.count { !drafts.containsKey(it.id) }
-            unansweredSheet.value = buildUnansweredSheet(unansweredCount, accountUuid, round)
+            unansweredSheet.value =
+                if (drafts.isEmpty()) {
+                    buildNoChoicesSheet()
+                } else {
+                    buildUnansweredSheet(unansweredCount, accountUuid, round)
+                }
         }
     }
 
@@ -292,6 +297,16 @@ class VoteProposalDetailVM(
         onSecondary = { unansweredSheet.value = null },
         onBack = { unansweredSheet.value = null },
     )
+
+    private fun buildNoChoicesSheet() =
+        ZashiConfirmationState.error(
+            title = stringRes(R.string.vote_proposal_detail_unanswered_title),
+            message = stringRes(R.string.vote_proposal_detail_no_choices_message),
+            primaryText = stringRes(R.string.vote_dismiss),
+            secondaryText = null,
+            onPrimary = { unansweredSheet.value = null },
+            onBack = { unansweredSheet.value = null },
+        )
 
     private fun buildUnverifiedPollWarningSheet(round: VotingRound) =
         ZashiConfirmationState(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposaldetail/VoteProposalDetailVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposaldetail/VoteProposalDetailVM.kt
@@ -12,7 +12,6 @@ import co.electriccoin.zcash.ui.common.model.voting.Proposal
 import co.electriccoin.zcash.ui.common.model.voting.SessionStatus
 import co.electriccoin.zcash.ui.common.model.voting.VotingRound
 import co.electriccoin.zcash.ui.common.model.voting.displayColor
-import co.electriccoin.zcash.ui.common.model.voting.optionsWithAbstain
 import co.electriccoin.zcash.ui.common.repository.ConfigurationRepository
 import co.electriccoin.zcash.ui.common.repository.VotingApiRepository
 import co.electriccoin.zcash.ui.common.repository.VotingChainConfigRepository
@@ -135,7 +134,7 @@ class VoteProposalDetailVM(
         accountUuid: String,
         isReadOnly: Boolean
     ): List<VoteVoteOptionRowState> {
-        val options = proposal.optionsWithAbstain()
+        val options = proposal.options
 
         return options.map { option ->
             VoteVoteOptionRowState(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposallist/VoteProposalListVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposallist/VoteProposalListVM.kt
@@ -415,6 +415,9 @@ class VoteProposalListVM(
         }
 
         if (mode == VoteProposalListMode.REVIEW) {
+            if (drafts.isEmpty()) {
+                return null
+            }
             return ButtonState(
                 text = stringRes(R.string.vote_proposal_list_confirm_submit),
                 style = ButtonStyle.PRIMARY,

--- a/ui-lib/src/main/res/ui/voting/values/strings.xml
+++ b/ui-lib/src/main/res/ui/voting/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="vote_proposal_detail_unanswered_title">Unanswered Questions</string>
     <string name="vote_proposal_detail_unanswered_message_singular">You have not responded to 1 question. Confirm to skip this question or go back to respond.</string>
     <string name="vote_proposal_detail_unanswered_message_plural">You have not responded to %1$d questions. Confirm to skip these questions or go back to respond.</string>
+    <string name="vote_proposal_detail_no_choices_message">Select at least one answer before reviewing and submitting your vote.</string>
     <string name="vote_proposal_detail_unanswered_go_back">Go back</string>
     <string name="vote_proposal_list_review_title">Review and submit vote</string>
     <string name="vote_proposal_list_review_subtitle">Tap on the question to edit any of your answers. After you review your answers, tap on Confirm &amp; Submit.</string>


### PR DESCRIPTION
## Summary

- render only configured proposal options so polls without Abstain do not show an extra answer
- block the all-skipped zero-choice path before users reach a disabled confirmation CTA

Fixes #2246

## Testing

- ./gradlew :ui-lib:testZcashmainnetFossDebugUnitTest --tests co.electriccoin.zcash.ui.common.repository.VotingSessionStoreTest --tests co.electriccoin.zcash.ui.common.model.voting.ProposalTest