### PR TITLE
Skip Ktor timeouts for Tor HTTP clients

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
@@ -16,6 +16,8 @@ import io.ktor.serialization.kotlinx.json.json
 
 interface HttpClientProvider {
     suspend fun create(): HttpClient
+
+    suspend fun supportsKtorTimeouts(): Boolean = true
 }
 
 class HttpClientProviderImpl(
@@ -25,17 +27,19 @@ class HttpClientProviderImpl(
     override suspend fun create(): HttpClient =
         if (isTorEnabledStorageProvider.get() == true) createTor() else createDirect()
 
+    override suspend fun supportsKtorTimeouts(): Boolean = isTorEnabledStorageProvider.get() != true
+
     private suspend fun createTor() =
         synchronizerProvider
             .getSynchronizer()
             .getTorHttpClient {
-                configureHttpClient()
+                configureHttpClient(installTimeouts = false)
             }
 
     @Suppress("MagicNumber")
     private fun createDirect() =
         HttpClient(OkHttp) {
-            configureHttpClient()
+            configureHttpClient(installTimeouts = true)
             install(HttpRequestRetry) {
                 maxRetries = MAX_RETRIES
                 retryIf { request, response ->
@@ -49,12 +53,16 @@ class HttpClientProviderImpl(
             }
         }
 
-    private fun <T : HttpClientEngineConfig> HttpClientConfig<T>.configureHttpClient() {
+    private fun <T : HttpClientEngineConfig> HttpClientConfig<T>.configureHttpClient(
+        installTimeouts: Boolean
+    ) {
         install(ContentNegotiation) { json() }
-        install(HttpTimeout) {
-            requestTimeoutMillis = DEFAULT_REQUEST_TIMEOUT_MILLIS
-            socketTimeoutMillis = DEFAULT_REQUEST_TIMEOUT_MILLIS
-            connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS
+        if (installTimeouts) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = DEFAULT_REQUEST_TIMEOUT_MILLIS
+                socketTimeoutMillis = DEFAULT_REQUEST_TIMEOUT_MILLIS
+                connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS
+            }
         }
         install(Logging) {
             logger = KtorLogger()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -237,9 +237,9 @@ class KtorVotingApiProvider(
         shares: List<SharePayload>,
         roundIdHex: String
     ): List<DelegatedShareInfo> =
-        execute {
+        executeWithKtorTimeoutSupport delegateShares@{ supportsKtorTimeouts ->
             if (shares.isEmpty()) {
-                return@execute emptyList()
+                return@delegateShares emptyList()
             }
 
             val config = getResolvedConfig().serviceConfig
@@ -260,7 +260,8 @@ class KtorVotingApiProvider(
                     val healthyServers = serverHealthTracker.healthyServers(serverUrls)
                     val quorum = max(1, (healthyServers.size + 1) / 2)
                     val targets = healthyServers.shuffled().take(quorum)
-                    val acceptedByServers = postShareToTargets(targets, body).toMutableList()
+                    val acceptedByServers =
+                        postShareToTargets(targets, body, supportsKtorTimeouts).toMutableList()
                     if (acceptedByServers.isEmpty()) {
                         val fallbackTargets =
                             serverHealthTracker
@@ -268,7 +269,7 @@ class KtorVotingApiProvider(
                                 .filterNot { serverUrl -> serverUrl in targets }
                                 .shuffled()
                         for (fallbackTarget in fallbackTargets) {
-                            if (postShare(fallbackTarget, body)) {
+                            if (postShare(fallbackTarget, body, supportsKtorTimeouts)) {
                                 acceptedByServers += fallbackTarget
                                 break
                             }
@@ -295,7 +296,7 @@ class KtorVotingApiProvider(
         roundIdHex: String,
         nullifierHex: String
     ): ShareConfirmationResult =
-        execute {
+        executeWithKtorTimeoutSupport { supportsKtorTimeouts ->
             val normalizedHelperBaseUrl = helperBaseUrl.trimEnd('/')
             try {
                 val responseJson =
@@ -304,11 +305,7 @@ class KtorVotingApiProvider(
                     ) {
                         header("Accept", "application/json")
                         header("X-Helper-Token", "voting-helper")
-                        timeout {
-                            requestTimeoutMillis = HELPER_REQUEST_TIMEOUT_MILLIS
-                            socketTimeoutMillis = HELPER_SOCKET_TIMEOUT_MILLIS
-                            connectTimeoutMillis = HELPER_CONNECT_TIMEOUT_MILLIS
-                        }
+                        helperRequestTimeout(supportsKtorTimeouts)
                     }.bodyAsText()
                 serverHealthTracker.recordSuccess(normalizedHelperBaseUrl)
                 when (JSONObject(responseJson).optString("status")) {
@@ -327,11 +324,11 @@ class KtorVotingApiProvider(
         candidateUrls: List<String>,
         excludeUrls: List<String>
     ): List<String> =
-        execute {
+        executeWithKtorTimeoutSupport resubmitShare@{ supportsKtorTimeouts ->
             val allServers = candidateUrls.normalizeServerUrls()
             val excludedServers = excludeUrls.normalizeServerUrls().toSet()
             if (allServers.isEmpty()) {
-                return@execute emptyList()
+                return@resubmitShare emptyList()
             }
             serverHealthTracker.remember(allServers)
 
@@ -341,27 +338,27 @@ class KtorVotingApiProvider(
 
             if (candidateServers.isEmpty()) {
                 for (serverUrl in healthyServers.shuffled()) {
-                    if (postShare(serverUrl, body)) {
-                        return@execute listOf(serverUrl)
+                    if (postShare(serverUrl, body, supportsKtorTimeouts)) {
+                        return@resubmitShare listOf(serverUrl)
                     }
                 }
-                return@execute emptyList()
+                return@resubmitShare emptyList()
             }
 
             val shuffledCandidates = candidateServers.shuffled()
             val quorum = max(1, (shuffledCandidates.size + 1) / 2)
             val primaryTargets = shuffledCandidates.take(quorum)
-            val acceptedByPrimary = postShareToTargets(primaryTargets, body)
+            val acceptedByPrimary = postShareToTargets(primaryTargets, body, supportsKtorTimeouts)
             if (acceptedByPrimary.isNotEmpty()) {
-                return@execute acceptedByPrimary
+                return@resubmitShare acceptedByPrimary
             }
 
             val fallbackServers =
                 shuffledCandidates.drop(quorum) +
                     healthyServers.filter { serverUrl -> serverUrl in excludedServers }.shuffled()
             for (serverUrl in fallbackServers) {
-                if (postShare(serverUrl, body)) {
-                    return@execute listOf(serverUrl)
+                if (postShare(serverUrl, body, supportsKtorTimeouts)) {
+                    return@resubmitShare listOf(serverUrl)
                 }
             }
             emptyList()
@@ -535,19 +532,28 @@ class KtorVotingApiProvider(
     private suspend inline fun <T> execute(
         crossinline block: suspend HttpClient.() -> T
     ): T =
+        executeWithKtorTimeoutSupport { block() }
+
+    private suspend inline fun <T> executeWithKtorTimeoutSupport(
+        crossinline block: suspend HttpClient.(Boolean) -> T
+    ): T =
         withContext(Dispatchers.IO) {
-            httpClientProvider.create().use { block(it) }
+            val supportsKtorTimeouts = httpClientProvider.supportsKtorTimeouts()
+            httpClientProvider.create().use { httpClient ->
+                block(httpClient, supportsKtorTimeouts)
+            }
         }
 
     private suspend fun HttpClient.postShareToTargets(
         targetUrls: List<String>,
-        body: String
+        body: String,
+        supportsKtorTimeouts: Boolean
     ): List<String> =
         coroutineScope {
             targetUrls
                 .map { targetUrl ->
                     async {
-                        if (postShare(targetUrl, body)) {
+                        if (postShare(targetUrl, body, supportsKtorTimeouts)) {
                             targetUrl
                         } else {
                             null
@@ -559,16 +565,13 @@ class KtorVotingApiProvider(
 
     private suspend fun HttpClient.postShare(
         serverUrl: String,
-        body: String
+        body: String,
+        supportsKtorTimeouts: Boolean
     ): Boolean =
         try {
             post("$serverUrl/shielded-vote/v1/shares") {
                 setBody(TextContent(body, ContentType.Application.Json))
-                timeout {
-                    requestTimeoutMillis = HELPER_REQUEST_TIMEOUT_MILLIS
-                    socketTimeoutMillis = HELPER_SOCKET_TIMEOUT_MILLIS
-                    connectTimeoutMillis = HELPER_CONNECT_TIMEOUT_MILLIS
-                }
+                helperRequestTimeout(supportsKtorTimeouts)
             }
             serverHealthTracker.recordSuccess(serverUrl)
             true
@@ -692,6 +695,16 @@ private data class ResolvedVotingConfig(
 private fun HttpRequestBuilder.noCache() {
     header("Cache-Control", "no-cache")
     header("Pragma", "no-cache")
+}
+
+private fun HttpRequestBuilder.helperRequestTimeout(supportsKtorTimeouts: Boolean) {
+    if (supportsKtorTimeouts) {
+        timeout {
+            requestTimeoutMillis = HELPER_REQUEST_TIMEOUT_MILLIS
+            socketTimeoutMillis = HELPER_SOCKET_TIMEOUT_MILLIS
+            connectTimeoutMillis = HELPER_CONNECT_TIMEOUT_MILLIS
+        }
+    }
 }
 
 private const val HELPER_REQUEST_TIMEOUT_MILLIS = 5_000L

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
@@ -11,6 +11,7 @@ import co.electriccoin.zcash.ui.common.repository.VotingCustomChainConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeoutCapability
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
@@ -21,6 +22,7 @@ import java.lang.reflect.Proxy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class KtorVotingApiProviderTest {
     @Test
@@ -47,21 +49,79 @@ class KtorVotingApiProviderTest {
             assertEquals(listOf("/static-voting-config.json", "/dynamic-voting-config.json"), requests)
         }
 
-    private fun newProvider(requests: MutableList<String>) =
+    @Test
+    fun fetchShareStatusUsesHelperTimeoutWhenSupported() =
+        runBlocking {
+            val requests = mutableListOf<String>()
+            val requestTimeoutCapabilities = mutableListOf<Boolean>()
+            val provider =
+                newProvider(
+                    requests = requests,
+                    supportsKtorTimeouts = true,
+                    requestTimeoutCapabilities = requestTimeoutCapabilities
+                )
+
+            runCatching {
+                provider.fetchShareStatus(
+                    helperBaseUrl = "https://example.com",
+                    roundIdHex = "round-id",
+                    nullifierHex = "nullifier"
+                )
+            }
+
+            assertEquals(listOf("/shielded-vote/v1/share-status/round-id/nullifier"), requests)
+            assertEquals(listOf(true), requestTimeoutCapabilities)
+        }
+
+    @Test
+    fun fetchShareStatusSkipsHelperTimeoutWhenUnsupported() =
+        runBlocking {
+            val requests = mutableListOf<String>()
+            val requestTimeoutCapabilities = mutableListOf<Boolean>()
+            val provider =
+                newProvider(
+                    requests = requests,
+                    supportsKtorTimeouts = false,
+                    requestTimeoutCapabilities = requestTimeoutCapabilities
+                )
+
+            runCatching {
+                provider.fetchShareStatus(
+                    helperBaseUrl = "https://example.com",
+                    roundIdHex = "round-id",
+                    nullifierHex = "nullifier"
+                )
+            }
+
+            assertEquals(listOf("/shielded-vote/v1/share-status/round-id/nullifier"), requests)
+            assertEquals(listOf(false), requestTimeoutCapabilities)
+            assertFalse(requestTimeoutCapabilities.single())
+        }
+
+    private fun newProvider(
+        requests: MutableList<String>,
+        supportsKtorTimeouts: Boolean = true,
+        requestTimeoutCapabilities: MutableList<Boolean> = mutableListOf()
+    ) =
         KtorVotingApiProvider(
-            httpClientProvider = TestHttpClientProvider(requests),
+            httpClientProvider = TestHttpClientProvider(requests, supportsKtorTimeouts, requestTimeoutCapabilities),
             configurationRepository = TestConfigurationRepository(),
             votingChainConfigRepository = TestVotingChainConfigRepository(),
             votingCryptoClient = unusedVotingCryptoClient()
         )
 
     private class TestHttpClientProvider(
-        private val requests: MutableList<String>
+        private val requests: MutableList<String>,
+        private val supportsKtorTimeouts: Boolean,
+        private val requestTimeoutCapabilities: MutableList<Boolean>
     ) : HttpClientProvider {
+        override suspend fun supportsKtorTimeouts(): Boolean = supportsKtorTimeouts
+
         override suspend fun create(): HttpClient =
             HttpClient(
                 MockEngine { request ->
                     requests += request.url.encodedPath
+                    requestTimeoutCapabilities += (request.getCapabilityOrNull(HttpTimeoutCapability) != null)
                     when (request.url.encodedPath) {
                         "/static-voting-config.json" -> {
                             respond(
@@ -75,6 +135,14 @@ class KtorVotingApiProviderTest {
                             respond(
                                 content = "temporary dynamic config failure",
                                 status = HttpStatusCode.InternalServerError
+                            )
+                        }
+
+                        "/shielded-vote/v1/share-status/round-id/nullifier" -> {
+                            respond(
+                                content = """{"status":"confirmed"}""",
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json")
                             )
                         }
 


### PR DESCRIPTION
Skips Ktor timeout capabilities when the shared HTTP client is backed by the SDK Tor engine, which does not support them. Direct OkHttp clients keep the existing client and helper request timeouts, and voting helper requests now gate their per-request timeout configuration the same way.

Validation: `:ui-lib:compileZcashmainnetFossDebugKotlin` and `:ui-lib:testZcashmainnetFossDebugUnitTest --tests co.electriccoin.zcash.ui.common.provider.KtorVotingApiProviderTest` with the pinned SDK checkout.
