### PR TITLE
Release 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 ### Changed:
 - Voting round responses now require explicit option indices from vote servers.
 
+## [3.5.0 (1729)] - 2026-05-27
+
+### Added:
+- Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets.
+
 ## [3.4.1 (1698)] - 2026-05-19
 
 ### Changed:

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.5.0 (1729)] - 2026-05-27
+
+### Added:
+- Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets.
+
 ## [3.4.1 (1698)] - 2026-05-19
 
 ### Changed:

--- a/docs/whatsNew/WHATS_NEW_ES.md
+++ b/docs/whatsNew/WHATS_NEW_ES.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.5.0 (1729)] - 2026-05-27
+
+### Añadido:
+- Coinholder Polling te permite votar en la gobernanza de Zcash de forma privada, directamente desde tus billeteras Zodl y Keystone.
+
 ## [3.4.1 (1698)] - 2026-05-19
 
 ### Cambiado:

--- a/fastlane/metadata/android/en-US/changelogs/1729.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1729.txt
@@ -1,0 +1,2 @@
+Added:
+- Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets.

--- a/fastlane/metadata/android/es/changelogs/1729.txt
+++ b/fastlane/metadata/android/es/changelogs/1729.txt
@@ -1,0 +1,2 @@
+Añadido:
+- Coinholder Polling te permite votar en la gobernanza de Zcash de forma privada, directamente desde tus billeteras Zodl y Keystone.


### PR DESCRIPTION
Closes #2263

## Changes

## [3.5.0 (1729)] - 2026-05-27

### Added:
- Coinholder Polling lets you vote on Zcash governance privately, right from your Zodl and Keystone wallets.

## [3.4.1 (1698)] - 2026-05-19

### Changed:
- We updated the copy on the shielding status widget.