### PR TITLE
Replace popup menu with chevron on custom data source rows

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigView.kt
@@ -1,7 +1,6 @@
 package co.electriccoin.zcash.ui.screen.voting.chainconfig
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -26,8 +25,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -35,15 +32,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
@@ -166,7 +159,6 @@ private fun Intro() {
 @Composable
 private fun ChainItem(state: VoteChainConfigItemState) {
     val isSelected = state.radioButtonState.isChecked
-    var menuExpanded by remember { mutableStateOf(false) }
 
     Surface(
         modifier =
@@ -256,50 +248,17 @@ private fun ChainItem(state: VoteChainConfigItemState) {
                 )
             }
 
-            if (state.editButton != null || state.deleteButton != null) {
-                Box {
-                    IconButton(
-                        onClick = { menuExpanded = true },
-                        modifier = Modifier.size(40.dp)
-                    ) {
-                        DotsHorizontalIcon()
-                    }
-                    DropdownMenu(
-                        expanded = menuExpanded,
-                        onDismissRequest = { menuExpanded = false }
-                    ) {
-                        state.editButton?.let { editButton ->
-                            DropdownMenuItem(
-                                enabled = editButton.isEnabled,
-                                text = {
-                                    Text(
-                                        text = editButton.text.getValue(),
-                                        style = ZashiTypography.textSm
-                                    )
-                                },
-                                onClick = {
-                                    menuExpanded = false
-                                    editButton.onClick()
-                                }
-                            )
-                        }
-                        state.deleteButton?.let { deleteButton ->
-                            DropdownMenuItem(
-                                enabled = deleteButton.isEnabled,
-                                text = {
-                                    Text(
-                                        text = deleteButton.text.getValue(),
-                                        style = ZashiTypography.textSm,
-                                        color = ZashiColors.Utility.ErrorRed.utilityError700
-                                    )
-                                },
-                                onClick = {
-                                    menuExpanded = false
-                                    deleteButton.onClick()
-                                }
-                            )
-                        }
-                    }
+            state.editButton?.let { editButton ->
+                IconButton(
+                    onClick = editButton.onClick,
+                    enabled = editButton.isEnabled,
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right),
+                        contentDescription = editButton.text.getValue(),
+                        tint = ZashiColors.Text.textPrimary
+                    )
                 }
             }
         }
@@ -333,21 +292,6 @@ private fun RadioIndicator(
                         .background(ZashiColors.Surfaces.bgPrimary, CircleShape)
             )
         }
-    }
-}
-
-@Composable
-private fun DotsHorizontalIcon(modifier: Modifier = Modifier) {
-    val dotColor = ZashiColors.Text.textPrimary
-
-    Canvas(modifier = modifier.size(20.dp)) {
-        val radius = 1.7.dp.toPx()
-        val centerY = size.height / 2f
-        val centerX = size.width / 2f
-        val gap = 6.dp.toPx()
-        drawCircle(color = dotColor, radius = radius, center = Offset(centerX - gap, centerY))
-        drawCircle(color = dotColor, radius = radius, center = Offset(centerX, centerY))
-        drawCircle(color = dotColor, radius = radius, center = Offset(centerX + gap, centerY))
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the `⋯` dropdown menu on each custom data-source row in `VoteChainConfigView` with a chevron-right icon.
- Tapping the chevron opens the existing Edit bottom sheet directly; Delete remains inside that sheet (no behaviour change for Delete).
- Removes the now-unused `DotsHorizontalIcon` composable, `menuExpanded` state, and 6 dead imports.

The dots menu was visually out of place with the rest of the app. The chevron matches the affordance used elsewhere (proposal list, poll description, etc.) and aligns with the Figma reference linked in the discussion.

<img width="3024" height="4032" alt="IMG_5268" src="https://github.com/user-attachments/assets/7ab18ce0-fbaa-4e97-9c5c-9e7bb681be92" />

