### PR TITLE
Add testTag IDs for maestro e2e

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -53,13 +53,39 @@ jobs:
 
       - name: Run smoke tests
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          # Wallet config consumed by scripts/run-smoke-android.sh — the
+          # wrapper sources .env locally, but on CI we read each value
+          # from GitHub Secrets / repo variables instead. The wrapper
+          # resolves ZODL_TEST_DIRECTION (AUTO_ALTERNATE flips a state
+          # file each run so sender/receiver rotate), pre-splits the
+          # chosen seed into ZODL_WORD_1..24, and passes everything to
+          # Maestro via --env=KEY=VAL.
+          ZODL_TEST_SEED_ANDROID: ${{ secrets.ZODL_TEST_SEED_ANDROID }}
+          ZODL_TEST_BIRTHDAY_ANDROID: ${{ secrets.ZODL_TEST_BIRTHDAY_ANDROID }}
+          ZODL_TEST_ADDRESS_ANDROID: ${{ secrets.ZODL_TEST_ADDRESS_ANDROID }}
+          ZODL_TEST_CONTACT_NAME_ANDROID: ${{ vars.ZODL_TEST_CONTACT_NAME_ANDROID || 'Android Shield' }}
+          ZODL_TEST_SEED_IOS: ${{ secrets.ZODL_TEST_SEED_IOS }}
+          ZODL_TEST_BIRTHDAY_IOS: ${{ secrets.ZODL_TEST_BIRTHDAY_IOS }}
+          ZODL_TEST_ADDRESS_IOS: ${{ secrets.ZODL_TEST_ADDRESS_IOS }}
+          ZODL_TEST_CONTACT_NAME_IOS: ${{ vars.ZODL_TEST_CONTACT_NAME_IOS || 'iOS Shield' }}
+          ZODL_TEST_DIRECTION: ${{ vars.ZODL_TEST_DIRECTION || 'AUTO_ALTERNATE' }}
+          ZODL_TEST_SEND_AMOUNT: ${{ vars.ZODL_TEST_SEND_AMOUNT || '0.005' }}
+          ZODL_TEST_BALANCE_MIN: ${{ vars.ZODL_TEST_BALANCE_MIN || '1.3' }}
+          ZODL_TEST_BALANCE_WARN: ${{ vars.ZODL_TEST_BALANCE_WARN || '1.36' }}
+          ZODL_TEST_CROSSPAY_TARGET_ADDRESS: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_ADDRESS || '0xf90bd7c30fd538efde8729ea61fdf20920ed3171' }}
+          ZODL_TEST_CROSSPAY_TARGET_NAME: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_NAME || 'USDC Base' }}
+          ZODL_TEST_CROSSPAY_CHAIN: ${{ vars.ZODL_TEST_CROSSPAY_CHAIN || 'BASE' }}
+          ZODL_TEST_CROSSPAY_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_AMOUNT || '0.5' }}
+          ZODL_TEST_STATE_DIR: ${{ github.workspace }}/.zodl-qa-state
         with:
           api-level: 34
           arch: x86_64
           profile: pixel_6
           script: |
             adb install app/build/outputs/apk/zcashmainnetInternal/debug/*.apk
-            maestro test zodl-qa/maestro/smoke/ --include-tags="android"
+            chmod +x zodl-qa/scripts/run-smoke-android.sh
+            ./zodl-qa/scripts/run-smoke-android.sh
 
       - name: Upload test results
         if: always()

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenDialog.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
@@ -51,10 +52,17 @@ private fun Dialog(
     AlertDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
-            ZashiButton(state = positive)
+            ZashiButton(
+                state = positive,
+                modifier = Modifier.testTag(ZashiScreenDialogTag.CONFIRM)
+            )
         },
         dismissButton = {
-            ZashiButton(state = negative, defaultPrimaryColors = ZashiButtonDefaults.secondaryColors())
+            ZashiButton(
+                state = negative,
+                modifier = Modifier.testTag(ZashiScreenDialogTag.DISMISS),
+                defaultPrimaryColors = ZashiButtonDefaults.secondaryColors()
+            )
         },
         title = {
             Text(
@@ -86,3 +94,8 @@ data class DialogState(
     val title: StringResource,
     val message: StringResource,
 )
+
+object ZashiScreenDialogTag {
+    const val CONFIRM = "DIALOG_CONFIRM"
+    const val DISMISS = "DIALOG_DISMISS"
+}

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenDialog.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenDialog.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
 package co.electriccoin.zcash.ui.design.component
 
 import android.view.WindowManager
@@ -7,7 +9,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
@@ -52,15 +56,25 @@ private fun Dialog(
     AlertDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
+            // AlertDialog renders in a separate Compose Popup window.
+            // The activity-level testTagsAsResourceId doesn't reach here,
+            // so we re-enable it inline so the testTag surfaces to
+            // Maestro / uiautomator as a resource-id.
             ZashiButton(
                 state = positive,
-                modifier = Modifier.testTag(ZashiScreenDialogTag.CONFIRM)
+                modifier = Modifier.semantics {
+                    testTagsAsResourceId = true
+                    testTag = ZashiScreenDialogTag.CONFIRM
+                }
             )
         },
         dismissButton = {
             ZashiButton(
                 state = negative,
-                modifier = Modifier.testTag(ZashiScreenDialogTag.DISMISS),
+                modifier = Modifier.semantics {
+                    testTagsAsResourceId = true
+                    testTag = ZashiScreenDialogTag.DISMISS
+                },
                 defaultPrimaryColors = ZashiButtonDefaults.secondaryColors()
             )
         },

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenDialog.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenDialog.kt
@@ -62,19 +62,21 @@ private fun Dialog(
             // Maestro / uiautomator as a resource-id.
             ZashiButton(
                 state = positive,
-                modifier = Modifier.semantics {
-                    testTagsAsResourceId = true
-                    testTag = ZashiScreenDialogTag.CONFIRM
-                }
+                modifier =
+                    Modifier.semantics {
+                        testTagsAsResourceId = true
+                        testTag = ZashiScreenDialogTag.CONFIRM
+                    }
             )
         },
         dismissButton = {
             ZashiButton(
                 state = negative,
-                modifier = Modifier.semantics {
-                    testTagsAsResourceId = true
-                    testTag = ZashiScreenDialogTag.DISMISS
-                },
+                modifier =
+                    Modifier.semantics {
+                        testTagsAsResourceId = true
+                        testTag = ZashiScreenDialogTag.DISMISS
+                    },
                 defaultPrimaryColors = ZashiButtonDefaults.secondaryColors()
             )
         },

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiTopAppBarNavigation.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiTopAppBarNavigation.kt
@@ -99,7 +99,7 @@ fun ZashiTopAppBarNavigation(
         IconButton(
             onClick = onBack,
             enabled = enabled,
-            modifier = Modifier.testTag(NAVIGATION_BACK_TAG)
+            modifier = Modifier.testTag(ZashiTopAppBarNavigationTag.BACK)
         ) {
             Icon(
                 painter = painterResource(drawableRes),
@@ -110,4 +110,6 @@ fun ZashiTopAppBarNavigation(
     }
 }
 
-const val NAVIGATION_BACK_TAG = "NAVIGATION_BACK"
+object ZashiTopAppBarNavigationTag {
+    const val BACK = "NAVIGATION_BACK"
+}

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiTopAppBarNavigation.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiTopAppBarNavigation.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -95,7 +96,11 @@ fun ZashiTopAppBarNavigation(
         modifier = modifier,
     ) {
         Spacer(modifier = Modifier.width(16.dp))
-        IconButton(onClick = onBack, enabled = enabled) {
+        IconButton(
+            onClick = onBack,
+            enabled = enabled,
+            modifier = Modifier.testTag(NAVIGATION_BACK_TAG)
+        ) {
             Icon(
                 painter = painterResource(drawableRes),
                 contentDescription = backContentDescriptionText,
@@ -104,3 +109,5 @@ fun ZashiTopAppBarNavigation(
         }
     }
 }
+
+const val NAVIGATION_BACK_TAG = "NAVIGATION_BACK"

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
@@ -1,4 +1,5 @@
 @file:Suppress("DEPRECATION")
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 
 package co.electriccoin.zcash.ui
 
@@ -16,6 +17,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
@@ -158,6 +161,10 @@ class MainActivity : FragmentActivity() {
                             .fillMaxWidth()
                             .fillMaxHeight()
                             .imePadding()
+                            // Maestro reads Compose testTags as resource-ids only
+                            // when this flag is on at the root. File-level
+                            // @OptIn(ExperimentalComposeUiApi::class) opts into the API.
+                            .semantics { testTagsAsResourceId = true }
                     ) {
                         BindCompLocalProvider {
                             MainContent()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/appbar/ZashiTopAppBarWithAccountSelection.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/appbar/ZashiTopAppBarWithAccountSelection.kt
@@ -55,7 +55,7 @@ fun ZashiTopAppBarWithAccountSelection(
                 }
                 ZashiIconButton(
                     state.moreButton,
-                    modifier = Modifier.size(40.dp).testTag("HOME_MORE")
+                    modifier = Modifier.size(40.dp).testTag(ZashiTopAppBarWithAccountSelectionTag.MORE)
                 )
                 Spacer(Modifier.width(20.dp))
             },
@@ -133,6 +133,10 @@ data class AccountSwitchState(
     val onAccountTypeClick: (() -> Unit)?,
     val accountType: AccountType,
 )
+
+object ZashiTopAppBarWithAccountSelectionTag {
+    const val MORE = "HOME_MORE"
+}
 
 @PreviewScreens
 @Composable

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/appbar/ZashiTopAppBarWithAccountSelection.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/appbar/ZashiTopAppBarWithAccountSelection.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -52,7 +53,10 @@ fun ZashiTopAppBarWithAccountSelection(
                     ZashiIconButton(state.balanceVisibilityButton, modifier = Modifier.size(40.dp))
                     Spacer(Modifier.width(4.dp))
                 }
-                ZashiIconButton(state.moreButton, modifier = Modifier.size(40.dp))
+                ZashiIconButton(
+                    state.moreButton,
+                    modifier = Modifier.size(40.dp).testTag("HOME_MORE")
+                )
                 Spacer(Modifier.width(20.dp))
             },
             navigationAction = {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookPopup.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookPopup.kt
@@ -69,23 +69,25 @@ private fun Tooltip(
             // window — re-enable testTagsAsResourceId inline so testTags
             // surface as resource-ids inside the popup.
             TextButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .semantics {
-                        testTagsAsResourceId = true
-                        testTag = AddressBookTag.MANUAL_ENTRY
-                    },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            testTagsAsResourceId = true
+                            testTag = AddressBookTag.MANUAL_ENTRY
+                        },
                 state = state.manualButton,
                 res = R.drawable.ic_add_contact_manual,
                 onDismissRequest = onDismissRequest
             )
             TextButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .semantics {
-                        testTagsAsResourceId = true
-                        testTag = AddressBookTag.SCAN_ENTRY
-                    },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            testTagsAsResourceId = true
+                            testTag = AddressBookTag.SCAN_ENTRY
+                        },
                 state = state.scanButton,
                 res = R.drawable.ic_add_contact_qr,
                 onDismissRequest = onDismissRequest

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookPopup.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookPopup.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -61,13 +62,17 @@ private fun Tooltip(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             TextButton(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(AddressBookTag.MANUAL_ENTRY),
                 state = state.manualButton,
                 res = R.drawable.ic_add_contact_manual,
                 onDismissRequest = onDismissRequest
             )
             TextButton(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(AddressBookTag.SCAN_ENTRY),
                 state = state.scanButton,
                 res = R.drawable.ic_add_contact_qr,
                 onDismissRequest = onDismissRequest

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookPopup.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookPopup.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
 package co.electriccoin.zcash.ui.screen.addressbook
 
 import androidx.annotation.DrawableRes
@@ -16,8 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.R
@@ -61,10 +65,16 @@ private fun Tooltip(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            // Material3 TooltipBox renders in a separate Compose Popup
+            // window — re-enable testTagsAsResourceId inline so testTags
+            // surface as resource-ids inside the popup.
             TextButton(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag(AddressBookTag.MANUAL_ENTRY),
+                    .semantics {
+                        testTagsAsResourceId = true
+                        testTag = AddressBookTag.MANUAL_ENTRY
+                    },
                 state = state.manualButton,
                 res = R.drawable.ic_add_contact_manual,
                 onDismissRequest = onDismissRequest
@@ -72,7 +82,10 @@ private fun Tooltip(
             TextButton(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag(AddressBookTag.SCAN_ENTRY),
+                    .semantics {
+                        testTagsAsResourceId = true
+                        testTag = AddressBookTag.SCAN_ENTRY
+                    },
                 state = state.scanButton,
                 res = R.drawable.ic_add_contact_qr,
                 onDismissRequest = onDismissRequest

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookTag.kt
@@ -2,4 +2,7 @@ package co.electriccoin.zcash.ui.screen.addressbook
 
 object AddressBookTag {
     const val TOP_APP_BAR = "top_app_bar"
+    const val ADD_CONTACT = "ADDRESS_BOOK_ADD_CONTACT"
+    const val MANUAL_ENTRY = "ADDRESS_BOOK_MANUAL_ENTRY"
+    const val SCAN_ENTRY = "ADDRESS_BOOK_SCAN_ENTRY"
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookView.kt
@@ -292,7 +292,9 @@ private fun AddContactButton(
         state = state,
     ) {
         ZashiButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(AddressBookTag.ADD_CONTACT),
             state =
                 ButtonState(
                     onClick = {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/AddressBookView.kt
@@ -292,9 +292,10 @@ private fun AddContactButton(
         state = state,
     ) {
         ZashiButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag(AddressBookTag.ADD_CONTACT),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .testTag(AddressBookTag.ADD_CONTACT),
             state =
                 ButtonState(
                     onClick = {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactTag.kt
@@ -2,6 +2,8 @@ package co.electriccoin.zcash.ui.screen.contact
 
 object ABContactTag {
     const val TOP_APP_BAR = "top_app_bar"
+    const val WALLET_ADDRESS_FIELD = "ADDRESS_BOOK_WALLET_ADDRESS_FIELD"
+    const val CONTACT_NAME_FIELD = "ADDRESS_BOOK_CONTACT_NAME_FIELD"
     const val CHAIN_SELECTOR = "ADDRESS_BOOK_CHAIN_SELECTOR"
     const val SAVE_BUTTON = "ADDRESS_BOOK_SAVE"
     const val DELETE_BUTTON = "ADDRESS_BOOK_DELETE"

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactTag.kt
@@ -2,4 +2,7 @@ package co.electriccoin.zcash.ui.screen.contact
 
 object ABContactTag {
     const val TOP_APP_BAR = "top_app_bar"
+    const val CHAIN_SELECTOR = "ADDRESS_BOOK_CHAIN_SELECTOR"
+    const val SAVE_BUTTON = "ADDRESS_BOOK_SAVE"
+    const val DELETE_BUTTON = "ADDRESS_BOOK_DELETE"
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactView.kt
@@ -29,6 +29,7 @@ import co.electriccoin.zcash.ui.design.component.PickerState
 import co.electriccoin.zcash.ui.design.component.Spacer
 import co.electriccoin.zcash.ui.design.component.TextFieldState
 import co.electriccoin.zcash.ui.design.component.ZashiAddressTextField
+import co.electriccoin.zcash.ui.design.component.ZashiTextFieldDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiButton
 import co.electriccoin.zcash.ui.design.component.ZashiButtonDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiIconButton
@@ -96,6 +97,10 @@ private fun ContactViewInternal(
                 Modifier
                     .fillMaxWidth()
                     .focusRequester(addressFocusRequester),
+            innerModifier =
+                ZashiTextFieldDefaults
+                    .innerModifier
+                    .testTag(ABContactTag.WALLET_ADDRESS_FIELD),
             state = state.walletAddress,
             placeholder = {
                 Text(
@@ -122,6 +127,10 @@ private fun ContactViewInternal(
                 Modifier
                     .fillMaxWidth()
                     .focusRequester(nameFocusRequester),
+            innerModifier =
+                ZashiTextFieldDefaults
+                    .innerModifier
+                    .testTag(ABContactTag.CONTACT_NAME_FIELD),
             state = state.contactName,
             keyboardOptions =
                 KeyboardOptions(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactView.kt
@@ -146,19 +146,22 @@ private fun ContactViewInternal(
                 color = ZashiColors.Inputs.Filled.label
             )
             Spacer(6.dp)
-            ZashiPicker(state = state.chain)
+            ZashiPicker(
+                state = state.chain,
+                modifier = Modifier.testTag(ABContactTag.CHAIN_SELECTOR)
+            )
         }
         Spacer(1f)
         Spacer(24.dp)
         ZashiButton(
             state = state.positiveButton,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth().testTag(ABContactTag.SAVE_BUTTON)
         )
 
         state.negativeButton?.let {
             ZashiButton(
                 state = it,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag(ABContactTag.DELETE_BUTTON),
                 defaultPrimaryColors = ZashiButtonDefaults.destructive1Colors()
             )
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/contact/ABContactView.kt
@@ -29,13 +29,13 @@ import co.electriccoin.zcash.ui.design.component.PickerState
 import co.electriccoin.zcash.ui.design.component.Spacer
 import co.electriccoin.zcash.ui.design.component.TextFieldState
 import co.electriccoin.zcash.ui.design.component.ZashiAddressTextField
-import co.electriccoin.zcash.ui.design.component.ZashiTextFieldDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiButton
 import co.electriccoin.zcash.ui.design.component.ZashiButtonDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiIconButton
 import co.electriccoin.zcash.ui.design.component.ZashiPicker
 import co.electriccoin.zcash.ui.design.component.ZashiSmallTopAppBar
 import co.electriccoin.zcash.ui.design.component.ZashiTextField
+import co.electriccoin.zcash.ui.design.component.ZashiTextFieldDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiTopAppBarBackNavigation
 import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeTags.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeTags.kt
@@ -3,4 +3,6 @@ package co.electriccoin.zcash.ui.screen.home
 object HomeTags {
     const val SEND = "SEND"
     const val RECEIVE = "RECEIVE"
+    const val PAY = "HOME_PAY"
+    const val SWAP = "HOME_SWAP"
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeView.kt
@@ -184,14 +184,16 @@ private fun NavButtons(
             modifier =
                 Modifier
                     .minHeight106Percent()
-                    .weight(1f),
+                    .weight(1f)
+                    .testTag(HomeTags.PAY),
             state = state.thirdButton,
         )
         ZashiBigIconButton(
             modifier =
                 Modifier
                     .minHeight106Percent()
-                    .weight(1f),
+                    .weight(1f)
+                    .testTag(HomeTags.SWAP),
             state = state.fourthButton,
         )
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/onboarding/view/OnboardingTags.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/onboarding/view/OnboardingTags.kt
@@ -1,0 +1,6 @@
+package co.electriccoin.zcash.ui.screen.onboarding.view
+
+object OnboardingTags {
+    const val CREATE_NEW_WALLET = "ONBOARDING_CREATE_WALLET"
+    const val RESTORE_EXISTING_WALLET = "ONBOARDING_RESTORE_WALLET"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/onboarding/view/OnboardingView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/onboarding/view/OnboardingView.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -142,7 +143,7 @@ private fun OnboardingMainContent(
         )
 
         ZashiButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag(OnboardingTags.RESTORE_EXISTING_WALLET),
             text = stringResource(R.string.onboarding_import_existing_wallet),
             onClick = onImportWallet,
             colors = ZashiButtonDefaults.tertiaryColors()
@@ -153,7 +154,7 @@ private fun OnboardingMainContent(
         ZashiButton(
             onClick = onCreateWallet,
             text = stringResource(R.string.onboarding_create_new_wallet),
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag(OnboardingTags.CREATE_NEW_WALLET),
             hapticFeedbackType = HapticFeedbackType.Confirm
         )
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayTag.kt
@@ -1,0 +1,13 @@
+package co.electriccoin.zcash.ui.screen.pay
+
+/**
+ * These are only used for automated testing.
+ */
+object PayTag {
+    const val PAY_ASSET_CARD = "PAY_ASSET_CARD"
+    const val PAY_ADDRESS_BOOK_BUTTON = "PAY_ADDRESS_BOOK_BUTTON"
+    const val PAY_SCAN_BUTTON = "PAY_SCAN_BUTTON"
+    const val PAY_AMOUNT_TOKEN_FIELD = "PAY_AMOUNT_TOKEN_FIELD"
+    const val PAY_AMOUNT_FIAT_FIELD = "PAY_AMOUNT_FIAT_FIELD"
+    const val PAY_REVIEW_BUTTON = "PAY_REVIEW_BUTTON"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayView.kt
@@ -111,7 +111,7 @@ internal fun PayView(
                 color = ZashiColors.Text.textPrimary
             )
             Spacer(12.dp)
-            ZashiAssetCard(state.asset)
+            ZashiAssetCard(state.asset, modifier = Modifier.testTag(PayTag.PAY_ASSET_CARD))
             Spacer(28.dp)
             AddressTextField(
                 state = state
@@ -154,7 +154,9 @@ internal fun PayView(
             }
             if (state.primaryButton != null) {
                 ZashiButton(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(PayTag.PAY_REVIEW_BUTTON),
                     state = state.primaryButton
                 )
             }
@@ -208,7 +210,9 @@ private fun AmountTextFields(state: PayState) {
         val isAmountFocused by amountInteractionSource.collectIsFocusedAsState()
 
         ZashiNumberTextField(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .testTag(PayTag.PAY_AMOUNT_TOKEN_FIELD),
             state = state.amount,
             interactionSource = amountInteractionSource,
             placeholder =
@@ -240,7 +244,9 @@ private fun AmountTextFields(state: PayState) {
         Spacer(12.dp)
 
         ZashiNumberTextField(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .testTag(PayTag.PAY_AMOUNT_FIAT_FIELD),
             state = state.amountFiat,
             placeholder = {
                 ZashiNumberTextFieldDefaults.Placeholder(
@@ -368,12 +374,16 @@ private fun AddressTextField(
                 verticalAlignment = Alignment.Top
             ) {
                 ZashiImageButton(
-                    modifier = Modifier.size(36.dp),
+                    modifier = Modifier
+                        .size(36.dp)
+                        .testTag(PayTag.PAY_ADDRESS_BOOK_BUTTON),
                     state = state.abButton
                 )
                 Spacer(4.dp)
                 ZashiImageButton(
-                    modifier = Modifier.size(36.dp),
+                    modifier = Modifier
+                        .size(36.dp)
+                        .testTag(PayTag.PAY_SCAN_BUTTON),
                     state = state.qrButton
                 )
             }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayView.kt
@@ -154,9 +154,10 @@ internal fun PayView(
             }
             if (state.primaryButton != null) {
                 ZashiButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag(PayTag.PAY_REVIEW_BUTTON),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .testTag(PayTag.PAY_REVIEW_BUTTON),
                     state = state.primaryButton
                 )
             }
@@ -210,9 +211,10 @@ private fun AmountTextFields(state: PayState) {
         val isAmountFocused by amountInteractionSource.collectIsFocusedAsState()
 
         ZashiNumberTextField(
-            modifier = Modifier
-                .weight(1f)
-                .testTag(PayTag.PAY_AMOUNT_TOKEN_FIELD),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .testTag(PayTag.PAY_AMOUNT_TOKEN_FIELD),
             state = state.amount,
             interactionSource = amountInteractionSource,
             placeholder =
@@ -244,9 +246,10 @@ private fun AmountTextFields(state: PayState) {
         Spacer(12.dp)
 
         ZashiNumberTextField(
-            modifier = Modifier
-                .weight(1f)
-                .testTag(PayTag.PAY_AMOUNT_FIAT_FIELD),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .testTag(PayTag.PAY_AMOUNT_FIAT_FIELD),
             state = state.amountFiat,
             placeholder = {
                 ZashiNumberTextFieldDefaults.Placeholder(
@@ -374,16 +377,18 @@ private fun AddressTextField(
                 verticalAlignment = Alignment.Top
             ) {
                 ZashiImageButton(
-                    modifier = Modifier
-                        .size(36.dp)
-                        .testTag(PayTag.PAY_ADDRESS_BOOK_BUTTON),
+                    modifier =
+                        Modifier
+                            .size(36.dp)
+                            .testTag(PayTag.PAY_ADDRESS_BOOK_BUTTON),
                     state = state.abButton
                 )
                 Spacer(4.dp)
                 ZashiImageButton(
-                    modifier = Modifier
-                        .size(36.dp)
-                        .testTag(PayTag.PAY_SCAN_BUTTON),
+                    modifier =
+                        Modifier
+                            .size(36.dp)
+                            .testTag(PayTag.PAY_SCAN_BUTTON),
                     state = state.qrButton
                 )
             }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/reviewtransaction/ReviewTransactionTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/reviewtransaction/ReviewTransactionTag.kt
@@ -1,0 +1,8 @@
+package co.electriccoin.zcash.ui.screen.reviewtransaction
+
+/**
+ * These are only used for automated testing.
+ */
+object ReviewTransactionTag {
+    const val REVIEW_TX_PRIMARY_BUTTON = "REVIEW_TX_PRIMARY_BUTTON"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/reviewtransaction/ReviewTransactionView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/reviewtransaction/ReviewTransactionView.kt
@@ -442,6 +442,7 @@ private fun BottomBar(state: ReviewTransactionState) {
                 Modifier
                     .padding(horizontal = 24.dp)
                     .fillMaxWidth()
+                    .testTag(ReviewTransactionTag.REVIEW_TX_PRIMARY_BUTTON)
         )
     }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendTag.kt
@@ -6,4 +6,6 @@ package co.electriccoin.zcash.ui.screen.send
 object SendTag {
     const val SEND_FORM_BUTTON = "send_form_button"
     const val SEND_AMOUNT_FIELD = "SEND_AMOUNT_FIELD"
+    const val SEND_ADDRESS_BOOK_BUTTON = "SEND_ADDRESS_BOOK_BUTTON"
+    const val SEND_SCAN_BUTTON = "SEND_SCAN_BUTTON"
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
@@ -466,12 +466,13 @@ fun SendFormAddressTextField(
                         ) {
                             Image(
                                 modifier =
-                                    Modifier.clickable(
-                                        onClick = sendAddressBookState.onButtonClick,
-                                        role = Role.Button,
-                                        indication = ripple(radius = 4.dp),
-                                        interactionSource = remember { MutableInteractionSource() }
-                                    ),
+                                    Modifier
+                                        .clickable(
+                                            onClick = sendAddressBookState.onButtonClick,
+                                            role = Role.Button,
+                                            indication = ripple(radius = 4.dp),
+                                            interactionSource = remember { MutableInteractionSource() }
+                                        ).testTag(SendTag.SEND_ADDRESS_BOOK_BUTTON),
                                 painter = painterResource(sendAddressBookState.mode.icon),
                                 contentDescription = stringResource(R.string.send_address_book_content_description),
                             )
@@ -480,12 +481,13 @@ fun SendFormAddressTextField(
 
                             Image(
                                 modifier =
-                                    Modifier.clickable(
-                                        onClick = onQrScannerOpen,
-                                        role = Role.Button,
-                                        indication = ripple(radius = 4.dp),
-                                        interactionSource = remember { MutableInteractionSource() }
-                                    ),
+                                    Modifier
+                                        .clickable(
+                                            onClick = onQrScannerOpen,
+                                            role = Role.Button,
+                                            indication = ripple(radius = 4.dp),
+                                            interactionSource = remember { MutableInteractionSource() }
+                                        ).testTag(SendTag.SEND_SCAN_BUTTON),
                                 painter = painterResource(R.drawable.qr_code_icon),
                                 contentDescription = stringResource(R.string.send_scan_content_description),
                             )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressTag.kt
@@ -1,0 +1,12 @@
+package co.electriccoin.zcash.ui.screen.transactionprogress
+
+/**
+ * These are only used for automated testing.
+ */
+object TransactionProgressTag {
+    /** Primary CTA on the progress screen — typically "Close" on success. */
+    const val TX_PROGRESS_PRIMARY_BUTTON = "TX_PROGRESS_PRIMARY_BUTTON"
+
+    /** Secondary CTA on the progress screen — e.g. "Try Again" on failure. */
+    const val TX_PROGRESS_SECONDARY_BUTTON = "TX_PROGRESS_SECONDARY_BUTTON"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionprogress/TransactionProgressView.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -108,6 +109,7 @@ private fun BottomBar(state: TransactionProgressState) {
                     Modifier
                         .fillMaxWidth()
                         .padding(horizontal = ZashiDimensions.Spacing.spacing2xl)
+                        .testTag(TransactionProgressTag.TX_PROGRESS_SECONDARY_BUTTON)
             )
         }
         if (state.primaryButton != null) {
@@ -116,7 +118,8 @@ private fun BottomBar(state: TransactionProgressState) {
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = ZashiDimensions.Spacing.spacing2xl),
+                        .padding(horizontal = ZashiDimensions.Spacing.spacing2xl)
+                        .testTag(TransactionProgressTag.TX_PROGRESS_PRIMARY_BUTTON),
             )
         }
     }


### PR DESCRIPTION
Enable testTagsAsResourceId at root so Compose testTags surface as resource-ids to Maestro / uiautomator. Add HOME_MORE on the home dots menu, and CHAIN_SELECTOR / SAVE / DELETE in the address-book contact form. Constants live in HomeTags / ABContactTag for compile-safety.