### PR TITLE
[TEST]: added more Maestro TagIDs

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -76,7 +76,8 @@ jobs:
           ZODL_TEST_CROSSPAY_TARGET_ADDRESS: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_ADDRESS || '0xf90bd7c30fd538efde8729ea61fdf20920ed3171' }}
           ZODL_TEST_CROSSPAY_TARGET_NAME: ${{ vars.ZODL_TEST_CROSSPAY_TARGET_NAME || 'USDC Base' }}
           ZODL_TEST_CROSSPAY_CHAIN: ${{ vars.ZODL_TEST_CROSSPAY_CHAIN || 'BASE' }}
-          ZODL_TEST_CROSSPAY_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_AMOUNT || '0.5' }}
+          ZODL_TEST_CROSSPAY_USDC_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_USDC_AMOUNT || '0.5' }}
+          ZODL_TEST_SWAP_ZEC_AMOUNT: ${{ vars.ZODL_TEST_SWAP_ZEC_AMOUNT || '0.005' }}
           ZODL_TEST_STATE_DIR: ${{ github.workspace }}/.zodl-qa-state
         with:
           api-level: 34

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapTag.kt
@@ -1,0 +1,13 @@
+package co.electriccoin.zcash.ui.screen.swap
+
+/**
+ * These are only used for automated testing.
+ */
+object SwapTag {
+    const val SWAP_ASSET_CARD = "SWAP_ASSET_CARD"
+    const val SWAP_ADDRESS_BOOK_BUTTON = "SWAP_ADDRESS_BOOK_BUTTON"
+    const val SWAP_SCAN_BUTTON = "SWAP_SCAN_BUTTON"
+    const val SWAP_AMOUNT_FIELD = "SWAP_AMOUNT_FIELD"
+    const val SWAP_CHANGE_MODE_BUTTON = "SWAP_CHANGE_MODE_BUTTON"
+    const val SWAP_REVIEW_BUTTON = "SWAP_REVIEW_BUTTON"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapView.kt
@@ -146,7 +146,10 @@ internal fun SwapView(
             }
             if (state.primaryButton != null) {
                 ZashiButton(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .testTag(SwapTag.SWAP_REVIEW_BUTTON),
                     state = state.primaryButton
                 )
             }
@@ -225,7 +228,10 @@ private fun SlippageSeparator(
             color = ZashiColors.Utility.Gray.utilityGray100
         )
 
-        ZashiImageButton(state.changeModeButton)
+        ZashiImageButton(
+            state = state.changeModeButton,
+            modifier = Modifier.testTag(SwapTag.SWAP_CHANGE_MODE_BUTTON)
+        )
 
         ZashiHorizontalDivider(
             modifier = Modifier.weight(1f),
@@ -362,12 +368,18 @@ private fun ColumnScope.AddressTextField(state: SwapState) {
                 verticalAlignment = Alignment.Top
             ) {
                 ZashiImageButton(
-                    modifier = Modifier.size(36.dp),
+                    modifier =
+                        Modifier
+                            .size(36.dp)
+                            .testTag(SwapTag.SWAP_ADDRESS_BOOK_BUTTON),
                     state = state.addressBookButton
                 )
                 Spacer(4.dp)
                 ZashiImageButton(
-                    modifier = Modifier.size(36.dp),
+                    modifier =
+                        Modifier
+                            .size(36.dp)
+                            .testTag(SwapTag.SWAP_SCAN_BUTTON),
                     state = state.qrScannerButton
                 )
             }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/ui/SwapAmountTextField.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/ui/SwapAmountTextField.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -48,6 +49,7 @@ import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.imageRes
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.design.util.stringResByDynamicCurrencyNumber
+import co.electriccoin.zcash.ui.screen.swap.SwapTag
 
 @Composable
 internal fun SwapAmountTextField(
@@ -117,7 +119,8 @@ private fun SwapTextFieldCard(
                     modifier = Modifier.weight(.425f)
                 ) {
                     ZashiAssetCard(
-                        state = state.token
+                        state = state.token,
+                        modifier = Modifier.testTag(SwapTag.SWAP_ASSET_CARD)
                     )
                 }
                 Spacer(modifier = Modifier.weight(.025f))
@@ -127,7 +130,8 @@ private fun SwapTextFieldCard(
                     modifier =
                         Modifier
                             .weight(.55f)
-                            .focusRequester(focusRequester),
+                            .focusRequester(focusRequester)
+                            .testTag(SwapTag.SWAP_AMOUNT_FIELD),
                     textStyle =
                         ZashiTypography.header4.copy(
                             fontWeight = FontWeight.SemiBold,


### PR DESCRIPTION
## Summary

Part 2 of the Maestro tag IDs work — adds the testTag IDs needed for
the swap-transaction smoke flow, plus a CI env var rename to match
the renamed crosspay variable and the new swap variable.

Stacks on #<p1-PR-number> (`harry/maestro-tag-ids`).

### What's added

New `SwapTag` object at
`ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapTag.kt`:

| testTag | Element |
|---|---|
| `SWAP_ASSET_CARD` | FROM-token asset chip (opens SELECT TOKEN sheet) |
| `SWAP_ADDRESS_BOOK_BUTTON` | "person +" icon next to recipient |
| `SWAP_SCAN_BUTTON` | QR scan icon |
| `SWAP_AMOUNT_FIELD` | ZashiNumberTextField for the amount |
| `SWAP_CHANGE_MODE_BUTTON` | "switch sides" button (flips ZEC ↔ token) |
| `SWAP_REVIEW_BUTTON` | bottom "Review" CTA |

Applied across `SwapView.kt` (4 sites) and `SwapAmountTextField.kt` (2
sites — `ZashiAssetCard` + `ZashiNumberTextField`).

Surfaces to Maestro via the existing `semantics { testTagsAsResourceId
= true }` at the root composable.

### CI env vars

In `.github/workflows/e2e-smoke.yml`:
- `ZODL_TEST_CROSSPAY_AMOUNT` → `ZODL_TEST_CROSSPAY_USDC_AMOUNT`
- New `ZODL_TEST_SWAP_ZEC_AMOUNT`

