### PR TITLE
Release 3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [3.5.2 (1742)] - 2026-06-04
+
+### Changed:
+- Updated compatibility with the latest Zcash network changes. This update is required to ensure continued wallet functionality.
+- We updated the default server.
+
 ### Changed:
 - Voting round responses now require explicit option indices from vote servers.
 

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -12,6 +12,12 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.5.2 (1742)] - 2026-06-04
+
+### Changed:
+- Updated compatibility with the latest Zcash network changes. This update is required to ensure continued wallet functionality.
+- We updated the default server.
+
 ## [3.5.1 (1741)] - 2026-06-02
 
 ### Changed:

--- a/docs/whatsNew/WHATS_NEW_ES.md
+++ b/docs/whatsNew/WHATS_NEW_ES.md
@@ -12,6 +12,12 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.5.2 (1742)] - 2026-06-04
+
+### Cambiado:
+- Compatibilidad actualizada con los últimos cambios de la red Zcash. Esta actualización es necesaria para garantizar el correcto funcionamiento de la billetera.
+- Actualizamos el servidor predeterminado.
+
 ## [3.5.1 (1741)] - 2026-06-02
 
 ### Cambiado:

--- a/fastlane/metadata/android/en-US/changelogs/1742.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1742.txt
@@ -1,0 +1,3 @@
+Changed:
+- Updated compatibility with the latest Zcash network changes. This update is required to ensure continued wallet functionality.
+- We updated the default server.

--- a/fastlane/metadata/android/es/changelogs/1742.txt
+++ b/fastlane/metadata/android/es/changelogs/1742.txt
@@ -1,0 +1,3 @@
+Cambiado:
+- Compatibilidad actualizada con los últimos cambios de la red Zcash. Esta actualización es necesaria para garantizar el correcto funcionamiento de la billetera.
+- Actualizamos el servidor predeterminado.

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ NDK_DEBUG_SYMBOL_LEVEL=symbol_table
 # VERSION_CODE is effectively ignored. VERSION_NAME is suffixed with the version code.
 # If not using automated Google Play deployment, then these serve as the actual version numbers.
 ZCASH_VERSION_CODE=1
-ZCASH_VERSION_NAME=3.5.1
+ZCASH_VERSION_NAME=3.5.2
 
 # Set these fields, as you need them (e.g. with values "Zcash X" and "co.electriccoin.zcash.x")
 # to distinguish a different release build that can be installed alongside the official version


### PR DESCRIPTION
Closes #2289

## Changes

### Changed:
- Updated compatibility with the latest Zcash network changes. This update is required to ensure continued wallet functionality.
- We updated the default server.