### PR TITLE
[E2E]: parallelize via phase matrix + build APK once

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -36,11 +36,17 @@ jobs:
       - name: Restore cached APK
         # Keyed on hashes of every input that affects the APK output.
         # On hit, skip the gradle build and just upload the restored APK.
+        # buildSrc/src/** + build-conventions-secant/src/** hold Kotlin
+        # source (Git.kt, ChangelogParser.kt, Dimensions.kt, BuildType.kt)
+        # that affects the build but isn't matched by the
+        # **/*.gradle.kts glob. Without those entries a change there
+        # would leave the cache valid and the workflow could install a
+        # stale APK.
         id: apk-cache
         uses: actions/cache@v5
         with:
           path: app/build/outputs/apk/zcashmainnetInternal/debug
-          key: ${{ runner.os }}-android-apk-${{ hashFiles('app/src/**', 'ui-lib/src/**', 'sdk-ext-lib/src/**', 'ui-design-lib/src/**', '**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
+          key: ${{ runner.os }}-android-apk-${{ hashFiles('app/src/**', 'ui-lib/src/**', 'sdk-ext-lib/src/**', 'ui-design-lib/src/**', 'buildSrc/src/**', 'build-conventions-secant/src/**', '**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
 
       - name: Build debug APK
         if: steps.apk-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -15,9 +15,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-android:
+  # Build the APK once and share it with both phase matrix jobs via
+  # actions/upload-artifact. The previous matrix design rebuilt the
+  # APK in each phase job, paying ~7 min twice.
+  build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build debug APK
+        run: ./gradlew assembleZcashmainnetInternalDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: zodl-android-debug-apk
+          path: app/build/outputs/apk/zcashmainnetInternal/debug/*.apk
+          retention-days: 1
+
+  e2e-android:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
     strategy:
@@ -29,9 +58,6 @@ jobs:
         phase: [1, 2]
     name: e2e-android (phase ${{ matrix.phase }})
     steps:
-      - name: Checkout app
-        uses: actions/checkout@v4
-
       - name: Checkout smoke tests
         uses: actions/checkout@v4
         with:
@@ -39,14 +65,11 @@ jobs:
           path: zodl-qa
           token: ${{ secrets.ZODL_QA }}
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Download APK
+        uses: actions/download-artifact@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Build debug APK
-        run: ./gradlew assembleZcashmainnetInternalDebug
+          name: zodl-android-debug-apk
+          path: apk
 
       - name: Enable KVM
         run: |
@@ -92,7 +115,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           script: |
-            adb install app/build/outputs/apk/zcashmainnetInternal/debug/*.apk
+            adb install apk/*.apk
             chmod +x zodl-qa/scripts/run-smoke-android.sh
             ./zodl-qa/scripts/run-smoke-android.sh
 
@@ -101,4 +124,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maestro-android-results-phase-${{ matrix.phase }}
-          path: ~/.maestro/tests/
+          path: |
+            ~/.maestro/tests/
+            ${{ runner.temp }}/zodl-enroll-fail/

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -56,7 +56,11 @@ jobs:
   e2e-android:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Cold-cache phase 2 runs (no cached SDK DB yet for the seed)
+    # spend most of the budget scanning blocks from birthday height.
+    # 45 min leaves headroom for the first run; warm-cache runs
+    # finish in ~10-15 min.
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -33,7 +33,17 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Restore cached APK
+        # Keyed on hashes of every input that affects the APK output.
+        # On hit, skip the gradle build and just upload the restored APK.
+        id: apk-cache
+        uses: actions/cache@v5
+        with:
+          path: app/build/outputs/apk/zcashmainnetInternal/debug
+          key: ${{ runner.os }}-android-apk-${{ hashFiles('app/src/**', 'ui-lib/src/**', 'sdk-ext-lib/src/**', 'ui-design-lib/src/**', '**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
+
       - name: Build debug APK
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         run: ./gradlew assembleZcashmainnetInternalDebug
 
       - name: Upload APK

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -17,9 +17,17 @@ concurrency:
 jobs:
   e2e-android:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     permissions:
       contents: read
+    strategy:
+      # Run the two suite phases in parallel jobs to halve wall time.
+      # Each job boots its own emulator; phase 1 uses fresh wallets,
+      # phase 2 restores once and runs cache-dependent tests.
+      fail-fast: false
+      matrix:
+        phase: [1, 2]
+    name: e2e-android (phase ${{ matrix.phase }})
     steps:
       - name: Checkout app
         uses: actions/checkout@v4
@@ -70,6 +78,7 @@ jobs:
           ZODL_TEST_ADDRESS_IOS: ${{ secrets.ZODL_TEST_ADDRESS_IOS }}
           ZODL_TEST_CONTACT_NAME_IOS: ${{ vars.ZODL_TEST_CONTACT_NAME_IOS || 'iOS Shield' }}
           ZODL_TEST_DIRECTION: ${{ vars.ZODL_TEST_DIRECTION || 'AUTO_ALTERNATE' }}
+          ZODL_TEST_PHASE: ${{ matrix.phase }}
           ZODL_TEST_SEND_AMOUNT: ${{ vars.ZODL_TEST_SEND_AMOUNT || '0.005' }}
           ZODL_TEST_BALANCE_MIN: ${{ vars.ZODL_TEST_BALANCE_MIN || '1.3' }}
           ZODL_TEST_BALANCE_WARN: ${{ vars.ZODL_TEST_BALANCE_WARN || '1.36' }}
@@ -91,5 +100,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-android-results
+          name: maestro-android-results-phase-${{ matrix.phase }}
           path: ~/.maestro/tests/


### PR DESCRIPTION
## Summary

Restructure the e2e smoke workflow to (a) parallelize the suite across
two matrix jobs and (b) build the APK only once instead of repeating
it per matrix job.

### Phase matrix [1, 2]

Suite splits into two independent halves:
- **Phase 1**: create-new-wallet, navigate-to-receive,
  address-book/delete-contact, currency-conversion
- **Phase 2**: restore-existing-wallet, recovery-phrase,
  export-private-data, send-transaction

Each phase runs on its own emulator in a separate matrix job. Both
zodl-qa wrappers (run-smoke-android.sh, run-smoke-ios.sh) accept
`ZODL_TEST_PHASE=1|2` and select the right `SUITE_FLOWS` subset.

### Build once

Previously each phase job ran `gradle assembleZcashmainnetInternalDebug`
(~5-7 min each). Now a single `build` job uploads the APK as an
artifact; phase matrix jobs `actions/download-artifact` and
`adb install` it.

## Expected impact

| | Before | After |
|---|---|---|
| Wall time | ~40 min | ~17-22 min |
| CI minutes / run | ~40 min | ~25 min |

## Test plan

- [ ] CI green on both phase 1 and phase 2 jobs.
- [ ] APK download + `adb install apk/*.apk` works inside the
      android-emulator-runner script.
- [ ] Each phase's emulator boot doesn't conflict with the other
      (separate runners — should be fine).

## Companion PR

zodl-ios `harry/e2e-biometric-toggle` carries the same restructure
for the iOS workflow.
