### PR TITLE
[E2E]:  bump emulator to API 35 to match local dev AVD

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -125,11 +125,15 @@ jobs:
           ZODL_TEST_CROSSPAY_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_AMOUNT || '0.5' }}
           ZODL_TEST_STATE_DIR: ${{ github.workspace }}/.zodl-qa-state
         with:
-          # Match the local dev AVD (Pixel_9 / API 35) so we test the
-          # same Android version on CI as devs run against locally.
+          # API 35 matches the local dev AVD (Pixel_9 / API 35). The
+          # device profile stays `pixel_6` — the GH runner's bundled
+          # avdmanager doesn't ship a `pixel_9` device definition (only
+          # Android Studio does), and the device profile is just
+          # screen size + density anyway; what we actually care about
+          # is the Android version.
           api-level: 35
           arch: x86_64
-          profile: pixel_9
+          profile: pixel_6
           script: |
             adb install apk/*.apk
             chmod +x zodl-qa/scripts/run-smoke-android.sh

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -125,9 +125,11 @@ jobs:
           ZODL_TEST_CROSSPAY_AMOUNT: ${{ vars.ZODL_TEST_CROSSPAY_AMOUNT || '0.5' }}
           ZODL_TEST_STATE_DIR: ${{ github.workspace }}/.zodl-qa-state
         with:
-          api-level: 34
+          # Match the local dev AVD (Pixel_9 / API 35) so we test the
+          # same Android version on CI as devs run against locally.
+          api-level: 35
           arch: x86_64
-          profile: pixel_6
+          profile: pixel_9
           script: |
             adb install apk/*.apk
             chmod +x zodl-qa/scripts/run-smoke-android.sh


### PR DESCRIPTION
Stacked on top of #2297 (parallelize PR), now merged.

## What

Bump the CI Android emulator to **API 35** so it matches what devs actually run locally (`~/.android/avd/Pixel_9.avd` is API 35). Device profile stays `pixel_6` — the GH runner's bundled `avdmanager` doesn't ship a `pixel_9` device definition (only Android Studio's separate device pack does), and the device profile is just screen size + density anyway. What we actually care about for test fidelity is the Android version.

## Why

CI was running on API 34 + Pixel 6, devs run API 35 + Pixel 9. Cross-version skew has bitten us a couple times during this week's e2e churn (API 35 has different `ConfirmLockPassword` timing, different keyboard contacts permission flow on bare AOSP, etc.). Aligning CI removes that whole category of "works locally, fails CI" surprises.

## What changed

Just the workflow YAML's `with:` block:
```yaml
api-level: 35
arch: x86_64
profile: pixel_6
```

No wrapper / no test code changes — wrapper-side fingerprint enrollment is already coord-based (percent-of-screen) so it works the same across both device profiles, and the AOSP-keyboard contacts pre-grant is also stable across API versions.

## Out of scope (now)

This branch previously also carried a "persist wallet direction across CI runs via GH repo variable" commit. We dropped that approach — instead each platform's wrapper now hardcodes its own direction (Android: `ANDROID_TO_IOS`, iOS: `IOS_TO_ANDROID`), each platform tests its own native send code path against its own seed. That's the realistic config. The wrapper change is in `zodl-qa` main; nothing in this repo depends on it.

## Test plan
- [ ] CI green on this branch
- [ ] Phase 2 emulator boots on API 35