### PR TITLE
ci(create-release): fire release workflow for prerelease-branch tags

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -33,10 +33,14 @@ name: Create Release from tag
 # CASCADE CAVEAT: releases created with the default `GITHUB_TOKEN` do NOT
 # trigger other workflows (GitHub's anti-recursion rule), so `release.yaml`
 # (on: release published) will NOT auto-fire from this workflow's release.
-# To make the build+publish chain run automatically, set a `RELEASE_PAT`
-# repo secret (a fine-grained PAT or GitHub App token with `contents: write`)
-# and this workflow will use it; otherwise it falls back to GITHUB_TOKEN and
-# an operator must (re)publish the release manually to kick off release.yaml.
+# To make the build+publish chain run automatically, this workflow mints a
+# short-lived GitHub App installation token (preferred over a long-lived PAT
+# in a PUBLIC repo) and creates the release with it. Wiring:
+#   * repo variable  RELEASE_BOT_APP_ID    — the App's numeric id (not secret)
+#   * repo secret     RELEASE_BOT_APP_KEY  — the App's PEM private key
+# The App needs only `contents: write` on this single repo. If the variable
+# is unset, the workflow falls back to GITHUB_TOKEN and an operator must
+# (re)publish the release manually to kick off release.yaml.
 
 on:
   push:
@@ -118,6 +122,17 @@ jobs:
             echo "__BODY_EOF__"
           } >> "$GITHUB_OUTPUT"
 
+      # Mint a short-lived App installation token so the published release
+      # cascades into release.yaml. Skipped when RELEASE_BOT_APP_ID is unset;
+      # the create step then falls back to GITHUB_TOKEN (no cascade).
+      - name: Mint App token
+        id: app_token
+        if: ${{ vars.RELEASE_BOT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -127,6 +142,6 @@ jobs:
           draft: false
           prerelease: false
         env:
-          # Prefer a PAT/App token so the published release cascades into
-          # release.yaml; fall back to GITHUB_TOKEN (no cascade — see header).
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          # App token (cascades into release.yaml) when available; otherwise
+          # GITHUB_TOKEN (no cascade — see CASCADE CAVEAT in the header).
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -128,13 +128,13 @@ jobs:
       - name: Mint App token
         id: app_token
         if: ${{ vars.RELEASE_BOT_APP_ID != '' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.meta.outputs.title }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,21 +1,53 @@
 name: Create Release from tag
 
-# Fires when a `<version>-<versionCode>` tag is pushed (e.g. `3.5.1-1740`).
+# Creates a published GitHub Release for a `<version>-<versionCode>` tag.
 # The workflow:
-#   1. Validates the tag shape.
-#   2. Extracts the matching `## [<version> (<versionCode>)] - <date>` section
+#   1. Resolves the target tag (push event ref, or the `tag` dispatch input).
+#   2. Checks out that tag so the changelog is read from the tagged tree.
+#   3. Validates the tag shape.
+#   4. Extracts the matching `## [<version> (<versionCode>)] - <date>` section
 #      from `docs/whatsNew/WHATS_NEW_EN.md`.
-#   3. Creates a published GitHub Release with title `Release <version> (<versionCode>)`
+#   5. Creates a published GitHub Release with title `Release <version> (<versionCode>)`
 #      and the changelog section as the body.
 #
 # Publishing the release fires the existing `release.yaml` workflow, which
 # does the actual build + APK signing + Solana / F-Droid publishing. We do
 # NOT do any of that here — this workflow's only job is "tag -> release".
+#
+# Two trigger paths:
+#
+#   * push:tags — fires automatically when a matching tag is pushed. NOTE:
+#     GitHub runs the workflow file *as it exists in the tagged commit*, not
+#     on the default branch. A release branch (e.g. `prerelease/*`) that
+#     forked from `main` BEFORE this file was added will not contain it, so
+#     the push trigger silently does nothing for that tag. That is exactly
+#     what happened to tag `3.5.3-1745`.
+#
+#   * workflow_dispatch — runs this file *from the selected branch* (default
+#     `main`), so it works for ANY existing tag regardless of whether the
+#     tagged commit carries this workflow. This is the escape hatch for
+#     prerelease branches: push the tag, then run this workflow from `main`
+#     with the tag name. Use the Actions UI or:
+#       gh workflow run create-release.yml -f tag=3.5.3-1745
+#
+# CASCADE CAVEAT: releases created with the default `GITHUB_TOKEN` do NOT
+# trigger other workflows (GitHub's anti-recursion rule), so `release.yaml`
+# (on: release published) will NOT auto-fire from this workflow's release.
+# To make the build+publish chain run automatically, set a `RELEASE_PAT`
+# repo secret (a fine-grained PAT or GitHub App token with `contents: write`)
+# and this workflow will use it; otherwise it falls back to GITHUB_TOKEN and
+# an operator must (re)publish the release manually to kick off release.yaml.
 
 on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to create a release for (e.g. 3.5.3-1745)'
+        required: true
+        type: string
 
 permissions:
   contents: write  # required to create the release
@@ -24,21 +56,38 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Parse tag and extract changelog section
-        id: meta
+      - name: Resolve target tag
+        id: tag
         env:
-          TAG: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_REF: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          # Tag shape was already filtered by the tag pattern above, but
-          # double-check before we do anything destructive.
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="${PUSH_REF}"
+          fi
           if [[ ! "${TAG}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$ ]]; then
             echo "ERROR: tag '${TAG}' does not match <version>-<versionCode>." >&2
             exit 1
           fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Parse tag and extract changelog section
+        id: meta
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Shape already validated in the resolve step; re-derive the parts.
+          [[ "${TAG}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$ ]]
           VERSION="${BASH_REMATCH[1]}"
           VERSION_CODE="${BASH_REMATCH[2]}"
           TITLE="Release ${VERSION} (${VERSION_CODE})"
@@ -72,10 +121,12 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.meta.outputs.title }}
           body: ${{ steps.meta.outputs.body }}
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a PAT/App token so the published release cascades into
+          # release.yaml; fall back to GITHUB_TOKEN (no cascade — see header).
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Tag `3.5.3-1745` was pushed (merge of #2295) but **no GitHub Release was created**, so the build+publish chain never ran — there is no release at `releases/tag/3.5.3-1745` and `release.yaml` (which builds + signs + publishes to Play / F-Droid) never fired.

### Root cause

The release chain is two links:

```
push tag 3.5.3-1745
   └─► create-release.yml   (tag → published GitHub Release)
          └─► release.yaml   (on: release published → build + sign + publish)
```

For `push: tags` events, GitHub runs the workflow file **as it exists in the tagged commit**, not on `main`. `create-release.yml` was added to `main` on 2026-06-01 (`a673060a`). The tag `3.5.3-1745` lives on `prerelease/3.5.3-point`, which **forked from `main` before that commit and was never reintegrated** (`git compare` reports `diverged`, 18 commits behind). So `create-release.yml` is simply **not present in the tagged tree** — `GET contents/.github/workflows/create-release.yml?ref=<tag>` returns 404 — and the push trigger has nothing to run.

This is why prior releases (`3.5.1`, `3.5.2`) were all created **manually**; the single real run of `create-release.yml` (for `3.5.1`) failed. The auto-release has never actually worked end-to-end.

## Fix

1. **`workflow_dispatch` escape hatch** — add a `tag` input so the workflow can be run **from `main`** (where the file always lives) against any existing tag, regardless of whether the tagged commit carries the workflow. This covers every prerelease branch that forked before the workflow existed:
   ```
   gh workflow run create-release.yml -f tag=3.5.3-1745
   ```
2. **Checkout the tag ref** so the changelog section is read from the tagged tree (not from whatever the dispatch branch happens to be).
3. **Document + mitigate the cascade caveat** — releases created with the default `GITHUB_TOKEN` do **not** trigger other workflows (GitHub anti-recursion), so `release.yaml` won't auto-fire. The workflow now prefers an optional `RELEASE_PAT` secret (fine-grained PAT / App token with `contents: write`) and falls back to `GITHUB_TOKEN`.

## Immediate remediation (already done)

I manually created the `3.5.3-1745` release, which kicked off the `release.yaml` build (run 27147687255). This PR makes sure the next prerelease tag doesn't need that.

## Follow-ups (not in this PR)

- Add a `RELEASE_PAT` repo secret so the dispatch/auto path cascades into `release.yaml` without a manual re-publish.
- Consider merging `main` into `prerelease/*` branches (or branching them from `main`) before tagging so the `push:tags` path also works.
