### PR TITLE
[#MOB-1346] Disable/redact ktor body logging in release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed:
+- Network request/response bodies and voting diagnostics are no longer written to logs in release builds, preventing sensitive data (recipient/refund addresses, amounts, transaction hashes) from leaking to logcat, bug reports, and crash dumps. Credential headers are also redacted from logs.
+
 ## [3.5.2 (1742)] - 2026-06-04
 
 ### Changed:

--- a/spackle-android-lib/proguard-consumer.txt
+++ b/spackle-android-lib/proguard-consumer.txt
@@ -7,3 +7,16 @@
     public static *** error(...);
     public static *** assertLoggingStripped();
 }
+
+# Strip out direct android.util.Log calls in release as well, so any logging that bypasses the Twig
+# wrapper still cannot leak to logcat/bugreports/crash dumps. We declare this explicitly instead of
+# relying on it being contributed transitively by an SDK dependency's consumer rules (MOB-1346).
+# Requires R8 optimizations (proguard-android-optimize.txt).
+-assumenosideeffects class android.util.Log {
+    public static int v(...);
+    public static int d(...);
+    public static int i(...);
+    public static int w(...);
+    public static int e(...);
+    public static int wtf(...);
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
@@ -1,6 +1,7 @@
 package co.electriccoin.zcash.ui.common.provider
 
 import android.util.Log
+import co.electriccoin.zcash.ui.BuildConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
@@ -66,16 +67,12 @@ class HttpClientProviderImpl(
         }
         install(Logging) {
             logger = KtorLogger()
-            level = LogLevel.ALL
-            sanitizeHeader { header -> header == HttpHeaders.Authorization }
+            // MOB-1346: full request/response bodies (swap recipient + refund addresses + amounts,
+            // voting payloads) must not reach logcat/bugreports in release. Bodies only in debug.
+            level = if (BuildConfig.DEBUG) LogLevel.ALL else LogLevel.NONE
+            sanitizeHeader { header -> header in SANITIZED_HEADERS }
         }
         expectSuccess = true
-    }
-
-    private companion object {
-        const val MAX_RETRIES = 4
-        const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 120_000L
-        const val DEFAULT_CONNECT_TIMEOUT_MILLIS = 15_000L
     }
 }
 
@@ -92,3 +89,11 @@ private class KtorLogger : Logger {
 private fun String.isVotingHelperPath(): Boolean =
     contains("/shielded-vote/v1/shares") ||
         contains("/shielded-vote/v1/share-status/")
+
+private const val MAX_RETRIES = 4
+private const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 120_000L
+private const val DEFAULT_CONNECT_TIMEOUT_MILLIS = 15_000L
+
+// Credential-bearing headers redacted from logs even in debug. The shared client also serves the
+// CMC quote API (X-CMC_PRO_API_KEY) and the voting helper (X-Helper-Token).
+private val SANITIZED_HEADERS = setOf(HttpHeaders.Authorization, "X-CMC_PRO_API_KEY", "X-Helper-Token")


### PR DESCRIPTION
Stop ktor from writing full request/response bodies to logs in release:
- Gate the Logging plugin level on BuildConfig.DEBUG (LogLevel.NONE in release, ALL only in debug), so swap/vote payloads (recipient + refund addresses, amounts) are never built or emitted in release.
- Extend header sanitization beyond Authorization to also redact X-CMC_PRO_API_KEY and X-Helper-Token, which share this client.
- Add an explicit `-assumenosideeffects class android.util.Log` rule to spackle's consumer proguard, alongside the existing Twig rule, so direct Log calls are stripped by our own rule rather than relying on a transitive SDK consumer rule. Verified against the minified release DEX.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._