### PR TITLE
MOB-1144: Re-run fastest server race on every foreground refresh

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.common.repository
 
 import android.app.Application
 import cash.z.ecc.android.sdk.SdkSynchronizer
-import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletInitMode
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.FastestServersResult
@@ -30,7 +29,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
@@ -38,6 +36,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -47,7 +46,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 interface WalletRepository {
@@ -116,66 +114,38 @@ class WalletRepositoryImpl(
     @OptIn(ExperimentalCoroutinesApi::class)
     override val fastestEndpoints =
         channelFlow {
-            val synchronizerPipeline = MutableStateFlow<Synchronizer?>(null)
             var previousState: FastestServersState? = null
 
-            launch {
-                refreshFastestServersRequest
-                    .onStart { emit(Unit) }
-                    .flatMapLatest {
-                        var synchronizerEmitted = false
+            refreshFastestServersRequest
+                .onStart { emit(Unit) }
+                .flatMapLatest {
+                    flow {
+                        val synchronizer = synchronizerProvider.synchronizer.filterNotNull().first()
+                        emitAll(
+                            synchronizer
+                                .getFastestServers(lightWalletEndpointProvider.getEndpoints())
+                                .map {
+                                    when (it) {
+                                        FastestServersResult.Measuring -> {
+                                            previousState?.copy(isLoading = true)
+                                                ?: FastestServersState(servers = null, isLoading = true)
+                                        }
 
-                        synchronizerProvider
-                            .synchronizer
-                            .onEach { synchronizer ->
-                                val previousState = previousState
-                                if (synchronizerEmitted &&
-                                    !previousState?.servers.isNullOrEmpty() &&
-                                    !previousState.isLoading
-                                ) {
-                                    synchronizerPipeline.update { null }
-                                } else {
-                                    synchronizerPipeline.update { synchronizer }
-                                }
+                                        is FastestServersResult.Validating -> {
+                                            FastestServersState(servers = it.servers, isLoading = true)
+                                        }
 
-                                if (synchronizer != null) {
-                                    synchronizerEmitted = true
-                                }
-                            }
-                    }.collect()
-            }
-
-            launch {
-                synchronizerPipeline
-                    .flatMapLatest { synchronizer ->
-                        synchronizer
-                            ?.getFastestServers(lightWalletEndpointProvider.getEndpoints())
-                            ?.map {
-                                when (it) {
-                                    FastestServersResult.Measuring -> {
-                                        previousState?.copy(isLoading = true)
-                                            ?: FastestServersState(servers = null, isLoading = true)
-                                    }
-
-                                    is FastestServersResult.Validating -> {
-                                        FastestServersState(servers = it.servers, isLoading = true)
-                                    }
-
-                                    is FastestServersResult.Done -> {
-                                        FastestServersState(servers = it.servers, isLoading = false)
+                                        is FastestServersResult.Done -> {
+                                            FastestServersState(servers = it.servers, isLoading = false)
+                                        }
                                     }
                                 }
-                            } ?: flowOf(
-                            previousState ?: FastestServersState(
-                                servers = emptyList(),
-                                isLoading = false
-                            )
                         )
-                    }.onEach {
-                        previousState = it
-                        send(it)
-                    }.collect()
-            }
+                    }
+                }.onEach {
+                    previousState = it
+                    send(it)
+                }.collect()
 
             awaitClose()
         }.stateIn(


### PR DESCRIPTION
## Summary

Follow-up to MOB-1144 (Automatic server switch). Aligns Android behaviour with iOS: every background→foreground transition triggers exactly one fastest-server race, and the race cannot feed back into itself via synchronizer swaps.

## Problem

The foreground trigger in `AutomaticServerRepositoryImpl.init()` calls `walletRepository.refreshFastestServers()`, but no actual re-measurement happens. Logs show:

```
WalletRepositoryImpl: fastestEndpoints emit: isLoading=false, servers=[eu.zec.stardust.rest:443, …]
AutomaticServerRepositoryImpl: fastest head=eu.zec.stardust.rest:443 → updateWalletEndpoint
WalletRepositoryImpl.updateWalletEndpoint: no-op: already on eu.zec.stardust.rest
```

The cached head is re-emitted, no fresh race runs.

## Root cause

`WalletRepository.fastestEndpoints` routed refresh requests through a two-stage pipeline:

1. `refreshFastestServersRequest.flatMapLatest { synchronizer.onEach { synchronizerPipeline.update { it } } }`
2. `synchronizerPipeline.flatMapLatest { it.getFastestServers(...) }`

On a foreground refresh the inner `flatMapLatest` restarted and called `synchronizerPipeline.update { synchronizer }` — but with the **same Synchronizer instance**. `MutableStateFlow` deduplicates equal values, so the outer pipeline never re-emitted and `getFastestServers()` was never re-invoked.

## Fix

Drop the pipeline indirection and stop reacting to synchronizer changes. Each refresh request now:

1. Awaits the first non-null synchronizer via `filterNotNull().first()`
2. Races `getFastestServers()` on it
3. Stops; the next race only runs on the next refresh request

```kotlin
refreshFastestServersRequest
    .onStart { emit(Unit) }
    .flatMapLatest {
        flow {
            val synchronizer = synchronizerProvider.synchronizer.filterNotNull().first()
            emitAll(synchronizer.getFastestServers(...).map { ... })
        }
    }
```

## Why this can't loop

The previous design observed `synchronizerProvider.synchronizer` as an ongoing input to the race trigger. That coupling is the problem: `updateWalletEndpoint` swaps the synchronizer, which would re-trigger the race, which could pick a different head due to network jitter, which would swap again — a measure→switch→swap→measure loop.

By taking only the *current* synchronizer at the moment a refresh fires (and ignoring subsequent changes), the race is fully detached from its own side effects. Foreground produces exactly one race, exactly one potential swap.

## Test plan

- [ ] Install build, enable Automatic server selection
- [ ] Background app, wait ~5s, foreground — verify in logcat that `getFastestServers()` runs and `fastestEndpoints` emits `Measuring → Validating → Done`
- [ ] Verify endpoint switches when a faster server is available
- [ ] Verify cold-start still races on first launch (`onStart` emit)
- [ ] Verify only ONE swap happens per foreground event, even with fluctuating race results
- [ ] Verify Manual mode is unaffected (no race triggered)
- [ ] Verify in-transaction state still blocks `refreshFastestServers` (existing guard in `AutomaticServerRepositoryImpl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)