### PR TITLE
[#1378] Fetch exchange rates over Tor only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 - Network request/response bodies and voting diagnostics are no longer written to logs in release builds, preventing sensitive data (recipient/refund addresses, amounts, transaction hashes) from leaking to logcat, bug reports, and crash dumps. Credential headers are also redacted from logs.
+- Exchange rates are no longer requested over a direct (non-Tor) connection. When Tor Protection is disabled the request to the rate provider is now blocked instead of falling back to clearnet, preventing the user's IP address and request timing from being exposed.
 
 ## [3.5.3 (1745)] - 2026-06-05
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/CMCApiProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/CMCApiProvider.kt
@@ -22,7 +22,7 @@ class CMCApiProviderImpl(
 ) : CMCApiProvider {
     override suspend fun getExchangeRateQuote(apiKey: String): GetCMCQuoteResponse =
         execute {
-            get("https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest") {
+            get("https://$CMC_API_HOST/v1/cryptocurrency/quotes/latest") {
                 parameter("symbol", "ZEC")
                 parameter("convert", "USD")
                 contentType(ContentType.Application.Json)
@@ -39,3 +39,7 @@ class CMCApiProviderImpl(
         // the Tor-only client rather than create(), which would fall back to clearnet when Tor is off.
         withContext(Dispatchers.IO) { httpClientProvider.createTor().use { block(it) } }
 }
+
+// MOB-1378: single source of truth for the exchange-rate provider host. Used both to build the request
+// URL above and by [HttpClientProvider] to refuse the same host on the direct (clearnet) client.
+internal const val CMC_API_HOST = "pro-api.coinmarketcap.com"

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/CMCApiProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/CMCApiProvider.kt
@@ -34,5 +34,8 @@ class CMCApiProviderImpl(
     @Throws(ResponseException::class)
     private suspend inline fun <T> execute(
         crossinline block: suspend HttpClient.() -> T
-    ): T = withContext(Dispatchers.IO) { httpClientProvider.create().use { block(it) } }
+    ): T =
+        // MOB-1378: exchange rates must only ever be fetched over Tor to protect the user's IP, so use
+        // the Tor-only client rather than create(), which would fall back to clearnet when Tor is off.
+        withContext(Dispatchers.IO) { httpClientProvider.createTor().use { block(it) } }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
@@ -130,7 +130,9 @@ private fun String.isExchangeRateHost(): Boolean = this == CMC_API_HOST
  * uncaught-exception handler rather than corrupting the call.
  */
 class ClearnetExchangeRateBlockedError :
-    AssertionError("Exchange rate fetching over clearnet is not allowed while Tor is disabled")
+    AssertionError(
+        "Exchange rate fetching over clearnet is not allowed while Tor is disabled"
+    )
 
 private const val MAX_RETRIES = 4
 private const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 120_000L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
@@ -14,9 +14,16 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
+import java.io.IOException
 
 interface HttpClientProvider {
     suspend fun create(): HttpClient
+
+    /**
+     * Returns a client that always routes over Tor, regardless of the user's Tor preference. Used for
+     * requests that must never touch clearnet (e.g. exchange-rate fetching, MOB-1378).
+     */
+    suspend fun createTor(): HttpClient
 
     suspend fun supportsKtorTimeouts(): Boolean = true
 }
@@ -30,7 +37,7 @@ class HttpClientProviderImpl(
 
     override suspend fun supportsKtorTimeouts(): Boolean = isTorEnabledStorageProvider.get() != true
 
-    private suspend fun createTor() =
+    override suspend fun createTor() =
         synchronizerProvider
             .getSynchronizer()
             .getTorHttpClient {
@@ -41,14 +48,33 @@ class HttpClientProviderImpl(
     private fun createDirect() =
         HttpClient(OkHttp) {
             configureHttpClient(installTimeouts = true)
+            engine {
+                // MOB-1378: Currency Conversion exchange rates must only ever be fetched over Tor
+                // (the in-app copy promises rates are fetched over Tor to protect the user's IP). This
+                // is the clearnet client, so refuse the CMC request at the network layer rather than
+                // silently leaking the user's IP / request timing to the rate provider when Tor is off.
+                addInterceptor { chain ->
+                    if (chain
+                            .request()
+                            .url
+                            .toString()
+                            .isExchangeRateRequest()
+                    ) {
+                        throw IOException("Exchange rate fetching over clearnet is not allowed while Tor is disabled")
+                    }
+                    chain.proceed(chain.request())
+                }
+            }
             install(HttpRequestRetry) {
                 maxRetries = MAX_RETRIES
                 retryIf { request, response ->
                     !request.url.toString().isVotingHelperPath() &&
+                        !request.url.toString().isExchangeRateRequest() &&
                         response.status.value in 500..599
                 }
                 retryOnExceptionIf { request, _ ->
-                    !request.url.toString().isVotingHelperPath()
+                    !request.url.toString().isVotingHelperPath() &&
+                        !request.url.toString().isExchangeRateRequest()
                 }
                 exponentialDelay()
             }
@@ -90,6 +116,11 @@ private fun String.isVotingHelperPath(): Boolean =
     contains("/shielded-vote/v1/shares") ||
         contains("/shielded-vote/v1/share-status/")
 
+// MOB-1378: the CMC quote API is the exchange-rate provider; requests to it must never leave over the
+// direct (clearnet) client.
+private fun String.isExchangeRateRequest(): Boolean = contains(CMC_API_HOST)
+
+private const val CMC_API_HOST = "pro-api.coinmarketcap.com"
 private const val MAX_RETRIES = 4
 private const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 120_000L
 private const val DEFAULT_CONNECT_TIMEOUT_MILLIS = 15_000L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
@@ -14,7 +14,6 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
-import java.io.IOException
 
 interface HttpClientProvider {
     suspend fun create(): HttpClient
@@ -60,7 +59,7 @@ class HttpClientProviderImpl(
                             .url.host
                             .isExchangeRateHost()
                     ) {
-                        throw IOException("Exchange rate fetching over clearnet is not allowed while Tor is disabled")
+                        throw ClearnetExchangeRateBlockedError()
                     }
                     chain.proceed(chain.request())
                 }
@@ -120,6 +119,18 @@ private fun String.isVotingHelperPath(): Boolean =
 // direct (clearnet) client. Matched on the host (not a substring of the full URL) so a path or query
 // that happens to echo the host can't trigger a false match. The host literal lives in CMCApiProvider.
 private fun String.isExchangeRateHost(): Boolean = this == CMC_API_HOST
+
+/**
+ * MOB-1378: raised by the direct (clearnet) client's backstop interceptor when an exchange-rate request
+ * would leave over clearnet. This is an unrecoverable invariant violation — a caller regressing from
+ * createTor() to create() for the CMC host — not a network condition to recover from. Extends
+ * [AssertionError] (an `Error`, not an `Exception`) so it is NOT swallowed by the `catch (Exception)`
+ * fallbacks downstream (e.g. ExchangeRateRepository) and instead crashes the app loudly. OkHttp's async
+ * dispatch rethrows non-IOException throwables on its dispatcher thread, so this propagates to the
+ * uncaught-exception handler rather than corrupting the call.
+ */
+class ClearnetExchangeRateBlockedError :
+    AssertionError("Exchange rate fetching over clearnet is not allowed while Tor is disabled")
 
 private const val MAX_RETRIES = 4
 private const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 120_000L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/HttpClientProvider.kt
@@ -49,16 +49,16 @@ class HttpClientProviderImpl(
         HttpClient(OkHttp) {
             configureHttpClient(installTimeouts = true)
             engine {
-                // MOB-1378: Currency Conversion exchange rates must only ever be fetched over Tor
-                // (the in-app copy promises rates are fetched over Tor to protect the user's IP). This
-                // is the clearnet client, so refuse the CMC request at the network layer rather than
-                // silently leaking the user's IP / request timing to the rate provider when Tor is off.
+                // MOB-1378: Currency Conversion exchange rates must only ever be fetched over Tor (the
+                // in-app copy promises rates are fetched over Tor to protect the user's IP). CMCApiProvider
+                // already routes through createTor(), so this clearnet client should never see a CMC
+                // request — this interceptor is a backstop that fails loudly if a future caller regresses
+                // to create(), rather than silently leaking the user's IP / request timing.
                 addInterceptor { chain ->
                     if (chain
                             .request()
-                            .url
-                            .toString()
-                            .isExchangeRateRequest()
+                            .url.host
+                            .isExchangeRateHost()
                     ) {
                         throw IOException("Exchange rate fetching over clearnet is not allowed while Tor is disabled")
                     }
@@ -69,12 +69,12 @@ class HttpClientProviderImpl(
                 maxRetries = MAX_RETRIES
                 retryIf { request, response ->
                     !request.url.toString().isVotingHelperPath() &&
-                        !request.url.toString().isExchangeRateRequest() &&
+                        !request.url.host.isExchangeRateHost() &&
                         response.status.value in 500..599
                 }
                 retryOnExceptionIf { request, _ ->
                     !request.url.toString().isVotingHelperPath() &&
-                        !request.url.toString().isExchangeRateRequest()
+                        !request.url.host.isExchangeRateHost()
                 }
                 exponentialDelay()
             }
@@ -117,10 +117,10 @@ private fun String.isVotingHelperPath(): Boolean =
         contains("/shielded-vote/v1/share-status/")
 
 // MOB-1378: the CMC quote API is the exchange-rate provider; requests to it must never leave over the
-// direct (clearnet) client.
-private fun String.isExchangeRateRequest(): Boolean = contains(CMC_API_HOST)
+// direct (clearnet) client. Matched on the host (not a substring of the full URL) so a path or query
+// that happens to echo the host can't trigger a false match. The host literal lives in CMCApiProvider.
+private fun String.isExchangeRateHost(): Boolean = this == CMC_API_HOST
 
-private const val CMC_API_HOST = "pro-api.coinmarketcap.com"
 private const val MAX_RETRIES = 4
 private const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 120_000L
 private const val DEFAULT_CONNECT_TIMEOUT_MILLIS = 15_000L

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/CMCApiProviderTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/CMCApiProviderTest.kt
@@ -33,7 +33,13 @@ class CMCApiProviderTest {
                 httpClientProvider.createCalls,
                 "CMC must never use create() (which can fall back to clearnet)"
             )
-            assertEquals(RATE.toBigDecimal(), response.data["ZEC"]?.quote?.get("USD")?.price)
+            assertEquals(
+                RATE.toBigDecimal(),
+                response.data["ZEC"]
+                    ?.quote
+                    ?.get("USD")
+                    ?.price
+            )
             assertTrue(httpClientProvider.requestedHosts.all { it == CMC_HOST })
         }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/CMCApiProviderTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/CMCApiProviderTest.kt
@@ -1,0 +1,71 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MOB-1378: exchange rates must only ever be fetched over Tor. [CMCApiProvider] must ask for the
+ * Tor-only client and must never use create(), which falls back to the direct (clearnet) client when
+ * Tor is disabled.
+ */
+class CMCApiProviderTest {
+    @Test
+    fun getExchangeRateQuoteUsesTorClientAndNeverTheDirectClient() =
+        runTest {
+            val httpClientProvider = RecordingHttpClientProvider()
+            val provider = CMCApiProviderImpl(httpClientProvider)
+
+            val response = provider.getExchangeRateQuote(apiKey = "key")
+
+            assertEquals(1, httpClientProvider.createTorCalls, "CMC must use the Tor-only client")
+            assertEquals(
+                0,
+                httpClientProvider.createCalls,
+                "CMC must never use create() (which can fall back to clearnet)"
+            )
+            assertEquals(RATE.toBigDecimal(), response.data["ZEC"]?.quote?.get("USD")?.price)
+            assertTrue(httpClientProvider.requestedHosts.all { it == CMC_HOST })
+        }
+}
+
+private const val RATE = 42.0
+private const val CMC_HOST = "pro-api.coinmarketcap.com"
+
+private class RecordingHttpClientProvider : HttpClientProvider {
+    var createCalls = 0
+        private set
+    var createTorCalls = 0
+        private set
+    val requestedHosts = mutableListOf<String>()
+
+    override suspend fun create(): HttpClient {
+        createCalls++
+        error("CMC must never be fetched over the direct (clearnet) client")
+    }
+
+    override suspend fun createTor(): HttpClient {
+        createTorCalls++
+        return HttpClient(
+            MockEngine { request ->
+                requestedHosts += request.url.host
+                respond(
+                    content = """{"data":{"ZEC":{"quote":{"USD":{"price":$RATE}}}}}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+        ) {
+            install(ContentNegotiation) { json() }
+        }
+    }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/CMCApiProviderTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/CMCApiProviderTest.kt
@@ -40,12 +40,11 @@ class CMCApiProviderTest {
                     ?.get("USD")
                     ?.price
             )
-            assertTrue(httpClientProvider.requestedHosts.all { it == CMC_HOST })
+            assertTrue(httpClientProvider.requestedHosts.all { it == CMC_API_HOST })
         }
 }
 
 private const val RATE = 42.0
-private const val CMC_HOST = "pro-api.coinmarketcap.com"
 
 private class RecordingHttpClientProvider : HttpClientProvider {
     var createCalls = 0

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
@@ -117,6 +117,8 @@ class KtorVotingApiProviderTest {
     ) : HttpClientProvider {
         override suspend fun supportsKtorTimeouts(): Boolean = supportsKtorTimeouts
 
+        override suspend fun createTor(): HttpClient = create()
+
         override suspend fun create(): HttpClient =
             HttpClient(
                 MockEngine { request ->


### PR DESCRIPTION
Exchange-rate fetching was not gated on Tor state: CMCApiProvider used HttpClientProvider.create(), which silently falls back to a direct (clearnet) client when Tor is disabled, exposing the user's IP and request timing to the rate provider — while the UI promises rates are fetched over Tor.

- HttpClientProvider: add createTor() to the interface, returning a client that always routes over Tor regardless of the user's toggle.
- CMCApiProvider: use createTor() instead of create() so the CMC quote request can never traverse clearnet.
- HttpClientProvider.createDirect(): refuse requests to the CMC host at the network layer (defense-in-depth), mirroring the existing isVotingHelperPath() special-casing, and skip retries for it.
- Add CMCApiProviderTest asserting CMC uses the Tor-only client and never create().

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [x] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._