### PR TITLE
[MOB-1361] Disable Firebase collection by default until consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 - Network request/response bodies and voting diagnostics are no longer written to logs in release builds, preventing sensitive data (recipient/refund addresses, amounts, transaction hashes) from leaking to logcat, bug reports, and crash dumps. Credential headers are also redacted from logs.
+- Crash reporting (Firebase Crashlytics) collection is now off by default and is only enabled after the user opts in, so no crash data can be sent before consent.
 
 ## [3.5.3 (1745)] - 2026-06-05
 

--- a/crash-android-lib/src/zcashmainnetStoreDebug/AndroidManifest.xml
+++ b/crash-android-lib/src/zcashmainnetStoreDebug/AndroidManifest.xml
@@ -9,6 +9,17 @@
             android:name="google_analytics_adid_collection_enabled"
             android:value="false" />
 
+        <!-- Collection must stay OFF by default until the user opts in. Crashlytics auto-collection
+             is on by default and runtime disabling only applies on the next run, so without these
+             flags an early crash could send a payload before consent. Runtime enables collection via
+             setCrashlyticsCollectionEnabled(true) only after the user opts in. -->
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
+
         <!-- We want better control over the timing of Firebase initialization -->
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"

--- a/crash-android-lib/src/zcashmainnetStoreRelease/AndroidManifest.xml
+++ b/crash-android-lib/src/zcashmainnetStoreRelease/AndroidManifest.xml
@@ -9,6 +9,17 @@
             android:name="google_analytics_adid_collection_enabled"
             android:value="false" />
 
+        <!-- Collection must stay OFF by default until the user opts in. Crashlytics auto-collection
+             is on by default and runtime disabling only applies on the next run, so without these
+             flags an early crash could send a payload before consent. Runtime enables collection via
+             setCrashlyticsCollectionEnabled(true) only after the user opts in. -->
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
+
         <!-- We want better control over the timing of Firebase initialization -->
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"

--- a/crash-android-lib/src/zcashtestnetStoreDebug/AndroidManifest.xml
+++ b/crash-android-lib/src/zcashtestnetStoreDebug/AndroidManifest.xml
@@ -9,6 +9,17 @@
             android:name="google_analytics_adid_collection_enabled"
             android:value="false" />
 
+        <!-- Collection must stay OFF by default until the user opts in. Crashlytics auto-collection
+             is on by default and runtime disabling only applies on the next run, so without these
+             flags an early crash could send a payload before consent. Runtime enables collection via
+             setCrashlyticsCollectionEnabled(true) only after the user opts in. -->
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
+
         <!-- We want better control over the timing of Firebase initialization -->
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"

--- a/crash-android-lib/src/zcashtestnetStoreRelease/AndroidManifest.xml
+++ b/crash-android-lib/src/zcashtestnetStoreRelease/AndroidManifest.xml
@@ -9,6 +9,17 @@
             android:name="google_analytics_adid_collection_enabled"
             android:value="false" />
 
+        <!-- Collection must stay OFF by default until the user opts in. Crashlytics auto-collection
+             is on by default and runtime disabling only applies on the next run, so without these
+             flags an early crash could send a payload before consent. Runtime enables collection via
+             setCrashlyticsCollectionEnabled(true) only after the user opts in. -->
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
+
         <!-- We want better control over the timing of Firebase initialization -->
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"


### PR DESCRIPTION
Store builds shipped without a firebase_crashlytics_collection_enabled default-off flag, so Crashlytics auto-collection was on by default and a crash during first-run/no-consent startup could send a payload before the user opted in (runtime disabling only applies on the next run).

Add firebase_crashlytics_collection_enabled=false and firebase_analytics_collection_enabled=false meta-data to all store manifests so collection stays off until GlobalCrashReporter.enable() (setCrashlyticsCollectionEnabled(true)) runs after the consent preference is read.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._