### PR TITLE
[MOB-1376] Mask recovery phrase until biometric reveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 - Network request/response bodies and voting diagnostics are no longer written to logs in release builds, preventing sensitive data (recipient/refund addresses, amounts, transaction hashes) from leaking to logcat, bug reports, and crash dumps. Credential headers are also redacted from logs.
+- On the wallet-backup screen the recovery phrase is now masked until the biometric reveal, so the plaintext words can no longer be read from the accessibility/view tree behind the visual blur.
 
 ## [3.5.3 (1745)] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 - Network request/response bodies and voting diagnostics are no longer written to logs in release builds, preventing sensitive data (recipient/refund addresses, amounts, transaction hashes) from leaking to logcat, bug reports, and crash dumps. Credential headers are also redacted from logs.
-- On the wallet-backup screen the recovery phrase is now masked until the biometric reveal, so the plaintext words can no longer be read from the accessibility/view tree behind the visual blur.
+- On the wallet-backup screen the recovery phrase is now masked until the biometric reveal, so the plaintext words can no longer be read from the accessibility/view tree behind the visual blur. While hidden, each word is announced to screen readers as a single descriptive label instead of spelling out the mask characters.
 
 ## [3.5.3 (1745)] - 2026-06-05
 

--- a/ui-design-lib/src/androidTest/java/co/electriccoin/zcash/ui/design/component/ZashiSeedTextTest.kt
+++ b/ui-design-lib/src/androidTest/java/co/electriccoin/zcash/ui/design/component/ZashiSeedTextTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -22,11 +22,11 @@ class ZashiSeedTextTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private val maskedSeedWord =
+    private val hiddenSeedWordDescription =
         InstrumentationRegistry
             .getInstrumentation()
             .targetContext
-            .getString(R.string.general_masked_seed_word)
+            .getString(R.string.general_hidden_seed_word)
 
     private val seedWords = List(SEED_WORD_COUNT) { "word$it" }
 
@@ -54,8 +54,11 @@ class ZashiSeedTextTest {
             composeTestRule.onNodeWithText(word).assertDoesNotExist()
         }
 
+        // While hidden, each word node exposes only a descriptive content description (the visible
+        // "•••••" mask is cleared from the accessibility tree) so a screen reader does not spell
+        // out the mask for every word.
         composeTestRule
-            .onAllNodesWithText(maskedSeedWord)
+            .onAllNodesWithContentDescription(hiddenSeedWordDescription)
             .assertCountEquals(SEED_WORD_COUNT)
     }
 
@@ -68,7 +71,7 @@ class ZashiSeedTextTest {
             composeTestRule.onNodeWithText(word).assertExists()
         }
 
-        composeTestRule.onAllNodesWithText(maskedSeedWord).assertCountEquals(0)
+        composeTestRule.onAllNodesWithContentDescription(hiddenSeedWordDescription).assertCountEquals(0)
     }
 }
 

--- a/ui-design-lib/src/androidTest/java/co/electriccoin/zcash/ui/design/component/ZashiSeedTextTest.kt
+++ b/ui-design-lib/src/androidTest/java/co/electriccoin/zcash/ui/design/component/ZashiSeedTextTest.kt
@@ -1,0 +1,75 @@
+package co.electriccoin.zcash.ui.design.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.filters.MediumTest
+import androidx.test.platform.app.InstrumentationRegistry
+import co.electriccoin.zcash.ui.design.R
+import co.electriccoin.zcash.ui.design.theme.ZcashTheme
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Guards the MOB-1376 fix: the plaintext recovery phrase must never reach the composable's
+ * text/semantics nodes until [SeedTextState.isRevealed] is true (i.e. after the biometric reveal).
+ * The blur is only a cosmetic effect, so we assert directly against the semantics tree.
+ */
+class ZashiSeedTextTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val maskedSeedWord =
+        InstrumentationRegistry
+            .getInstrumentation()
+            .targetContext
+            .getString(R.string.general_masked_seed_word)
+
+    private val seedWords = List(SEED_WORD_COUNT) { "word$it" }
+
+    private fun setContent(isRevealed: Boolean) {
+        composeTestRule.setContent {
+            ZcashTheme {
+                ZashiSeedText(
+                    modifier = Modifier.fillMaxWidth(),
+                    state =
+                        SeedTextState(
+                            seed = seedWords.joinToString(separator = " "),
+                            isRevealed = isRevealed,
+                        )
+                )
+            }
+        }
+    }
+
+    @Test
+    @MediumTest
+    fun plaintext_words_absent_from_semantics_while_hidden() {
+        setContent(isRevealed = false)
+
+        seedWords.forEach { word ->
+            composeTestRule.onNodeWithText(word).assertDoesNotExist()
+        }
+
+        composeTestRule
+            .onAllNodesWithText(maskedSeedWord)
+            .assertCountEquals(SEED_WORD_COUNT)
+    }
+
+    @Test
+    @MediumTest
+    fun plaintext_words_present_in_semantics_once_revealed() {
+        setContent(isRevealed = true)
+
+        seedWords.forEach { word ->
+            composeTestRule.onNodeWithText(word).assertExists()
+        }
+
+        composeTestRule.onAllNodesWithText(maskedSeedWord).assertCountEquals(0)
+    }
+}
+
+private const val SEED_WORD_COUNT = 24

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSeedText.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSeedText.kt
@@ -43,6 +43,7 @@ fun ZashiSeedText(
     modifier: Modifier = Modifier
 ) {
     val maskedSeedWord = stringResource(R.string.general_masked_seed_word)
+    val hiddenSeedWordDescription = stringResource(R.string.general_hidden_seed_word)
     val blur by animateDpAsState(if (state.isRevealed) 0.dp else 14.dp, label = "")
     val color by animateColorAsState(
         when {
@@ -88,6 +89,7 @@ fun ZashiSeedText(
                             content = { mod, text ->
                                 ZashiSeedWordTextContent(
                                     text = text,
+                                    contentDescription = if (state.isRevealed) null else hiddenSeedWordDescription,
                                     modifier = mod.blurCompat(blur, 14.dp)
                                 )
                             },

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSeedText.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSeedText.kt
@@ -42,6 +42,7 @@ fun ZashiSeedText(
     state: SeedTextState,
     modifier: Modifier = Modifier
 ) {
+    val maskedSeedWord = stringResource(R.string.general_masked_seed_word)
     val blur by animateDpAsState(if (state.isRevealed) 0.dp else 14.dp, label = "")
     val color by animateColorAsState(
         when {
@@ -54,12 +55,17 @@ fun ZashiSeedText(
     Box(
         modifier = modifier.background(color, RoundedCornerShape(10.dp)),
     ) {
+        // Until the user passes the biometric reveal, the plaintext mnemonic must not enter the
+        // composable's Text/semantics nodes - the blur is only a cosmetic effect (a no-op for
+        // accessibility services and view-tree inspection). We therefore render masked placeholders
+        // and only substitute the real words once the state is revealed. See security ticket MOB-1376.
         val rowItems =
-            remember(state) {
+            remember(state, maskedSeedWord) {
                 state.seed
                     .split(" ")
-                    .withIndex()
-                    .chunked(3)
+                    .mapIndexed { index, word ->
+                        IndexedValue(index, if (state.isRevealed) word else maskedSeedWord)
+                    }.chunked(3)
             }
 
         Column(

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSeedWordText.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSeedWordText.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -64,13 +66,22 @@ fun ZashiSeedWordPrefixContent(
 @Composable
 fun ZashiSeedWordTextContent(
     text: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null
 ) {
     Box(
         modifier = modifier then Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
     ) {
         Text(
-            modifier = Modifier,
+            // While hidden the visible text is a meaningless mask ("•••••"); override the
+            // accessibility node so a screen reader announces a single descriptive label instead
+            // of spelling out the mask for every word. Does not affect the security invariant.
+            modifier =
+                if (contentDescription != null) {
+                    Modifier.clearAndSetSemantics { this.contentDescription = contentDescription }
+                } else {
+                    Modifier
+                },
             text = text,
             color = ZashiColors.Text.textPrimary,
             style = ZashiTypography.textMd,

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -4,6 +4,7 @@
     <string name="back_navigation_content_description">Atrás</string>
     <string name="triple_dots">…</string>
     <string name="seed_recovery_reveal">Mostrar frase de recuperación</string>
+    <string name="general_masked_seed_word">•••••</string>
 
     <string name="general_service_unavailable">El servicio no está disponible</string>
     <string name="general_unexpected_error">Error inesperado</string>

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -5,6 +5,7 @@
     <string name="triple_dots">…</string>
     <string name="seed_recovery_reveal">Mostrar frase de recuperación</string>
     <string name="general_masked_seed_word">•••••</string>
+    <string name="general_hidden_seed_word">Palabra oculta de la frase de recuperación</string>
 
     <string name="general_service_unavailable">El servicio no está disponible</string>
     <string name="general_unexpected_error">Error inesperado</string>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="back_navigation_content_description">Back</string>
     <string name="triple_dots">…</string>
     <string name="seed_recovery_reveal">Reveal recovery phrase</string>
+    <string name="general_masked_seed_word">•••••</string>
 
     <string name="general_service_unavailable">The service is unavailable</string>
     <string name="general_unexpected_error">Unexpected error</string>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="triple_dots">…</string>
     <string name="seed_recovery_reveal">Reveal recovery phrase</string>
     <string name="general_masked_seed_word">•••••</string>
+    <string name="general_hidden_seed_word">Hidden recovery phrase word</string>
 
     <string name="general_service_unavailable">The service is unavailable</string>
     <string name="general_unexpected_error">Unexpected error</string>


### PR DESCRIPTION
The wallet-backup screen placed the full plaintext mnemonic into the composable's Text/semantics nodes and only applied a visual blur until the biometric reveal. On Android 12+ that blur is a cosmetic RenderEffect, so the words were readable from the accessibility/view tree with no authentication.

ZashiSeedText now renders masked placeholders while the state is hidden and substitutes the real words only once isRevealed is true (set exclusively on a successful biometric reveal in WalletBackupViewModel). Adds an instrumentation test asserting the plaintext words are absent from the semantics tree while hidden and present once revealed.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [x] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [x] **Run the app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._