### PR TITLE
[MOB-1339] Treat "already in mempool" submit rejections as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 - The cross-chain swap slippage guarantee is now always enforced: the swap provider's minimum-amount bounds are treated as required, so a malicious or tampered response can no longer skip the slippage check by omitting them.
 - Swap quotes rejected by the amount-consistency safety check are now reported to monitoring (without any amounts), so a future swap-provider format change surfaces as an observable signal instead of silently blocking swaps.
 - Exchange rates are no longer requested over a direct (non-Tor) connection. When Tor Protection is disabled the request to the rate provider is now blocked instead of falling back to clearnet, preventing the user's IP address and request timing from being exposed.
+- We fixed a bug where a successful TEX send could show a misleading "transaction failed" screen.
 
 ## [3.5.3 (1745)] - 2026-06-05
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -277,7 +277,7 @@ class ProposalDataSourceImpl(
 
             val successCount =
                 submitResults
-                    .count { it is TransactionSubmitResult.Success }
+                    .count { it.isEffectiveSuccess() }
             val txIds =
                 submitResults
                     .map { it.txIdString() }
@@ -290,7 +290,9 @@ class ProposalDataSourceImpl(
                             }
 
                             is TransactionSubmitResult.Failure -> {
-                                if (it.grpcError) {
+                                if (it.isEffectiveSuccess()) {
+                                    "success (already known to network): ${it.description}"
+                                } else if (it.grpcError) {
                                     it.description.orEmpty()
                                 } else {
                                     "code: ${it.code} desc: ${it.description}"
@@ -306,7 +308,8 @@ class ProposalDataSourceImpl(
                 submitResults
                     .mapNotNull {
                         when (it) {
-                            is TransactionSubmitResult.Failure -> it.grpcError
+                            is TransactionSubmitResult.Failure ->
+                                if (it.isEffectiveSuccess()) null else it.grpcError
                             is TransactionSubmitResult.NotAttempted -> null
                             is TransactionSubmitResult.Success -> null
                         }
@@ -315,6 +318,7 @@ class ProposalDataSourceImpl(
             val (errCode, errDesc) =
                 submitResults
                     .filterIsInstance<TransactionSubmitResult.Failure>()
+                    .filterNot { it.isEffectiveSuccess() }
                     .lastOrNull { !it.grpcError }
                     ?.let { it.code to it.description } ?: (0 to "")
 
@@ -434,3 +438,13 @@ data class ExactOutputSwapTransactionProposal(
 ) : SwapTransactionProposal
 
 private const val DEFAULT_SHIELDING_THRESHOLD = 100000L
+
+private fun isAlreadyKnownToNetwork(description: String?): Boolean {
+    val lower = description?.lowercase() ?: return false
+    return lower.contains("already exists in mempool") ||
+        lower.contains("already queued for download")
+}
+
+private fun TransactionSubmitResult.isEffectiveSuccess(): Boolean =
+    this is TransactionSubmitResult.Success ||
+        (this is TransactionSubmitResult.Failure && !grpcError && isAlreadyKnownToNetwork(description))


### PR DESCRIPTION
## Summary
- A TEX send (or any send that's rebroadcast after the original submit already landed in the network) currently surfaces a misleading "transaction failed" screen.
- Root cause: lightwalletd / zcashd returns `transaction already exists in mempool` or `transaction dropped because it is already queued for download` as a non-zero submit error, which the SDK reports as `TransactionSubmitResult.Failure`. Those descriptions actually mean the tx is already on the network — i.e. the broadcast succeeded.
- Fix: `ProposalDataSourceImpl.submitTransactionInternal` now classifies a `Failure` with one of those two descriptions as effective success — counts toward `successCount`, excluded from the resubmittable-failure set, status string rewritten so debug logs still surface the underlying description.
- This is the app-layer guard. The matching SDK-level fix lives at [Cosmos-Harry/zcash-android-wallet-sdk → harry/treat-already-in-mempool-as-success](https://github.com/Cosmos-Harry/zcash-android-wallet-sdk/pull/new/harry/treat-already-in-mempool-as-success) and becomes redundant (harmless) once that lands in our dependency pin.

Linear: MOB-1339

## Test plan
- [ ] Send to a TEX address from a v3.5.1+ wallet where the previous attempt is known to have broadcast successfully (e.g. retried after a confirmation timeout).
- [ ] Confirm the success screen renders instead of the failure screen.
- [ ] Confirm transaction list still shows the tx in the expected state.
- [ ] No regression for genuine failures: send with insufficient funds → failure screen still appears with the real error.