### PR TITLE
ci: fix publish_to_solana KMS key + migrate to dapp-store-cli 1.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -234,7 +234,7 @@ jobs:
 
           echo "Decrypting config.yaml..."
           gcloud kms decrypt \
-            --key=config \
+            --key=gpg \
             --keyring=gpg \
             --location=global \
             --plaintext-file=/tmp/config.yaml \
@@ -263,40 +263,46 @@ jobs:
             "stores/solana/release-notes-template.yaml" \
             "docs/whatsNew/WHATS_NEW_EN.md"
 
-      - name: Create Solana dApp Store Release
+      # ---------------------------------------------------------------------
+      # Solana dApp Store CLI 0.15.0 -> 1.0.0 migration (2026-06)
+      #
+      # The previous flow used `@solana-mobile/dapp-store-cli@latest` with the
+      # 0.15.x interface: `create release ... -k <keypair> --config config.yaml`
+      # followed by `publish update ... --config config.yaml`. Solana Mobile
+      # shipped dapp-store-cli@1.0.0, a portal-backed CLI that REMOVED
+      # `create release`, `publish update`, `-k`, and `--config`. The legacy
+      # 0.15.0 is now hard-gated server-side and refuses to run, so neither the
+      # old pinned version nor `@latest` works any more.
+      #
+      # The 1.0.0 interface is a single invocation:
+      #   dapp-store --apk-file <apk> --keypair <keypair> --whats-new "<text>"
+      # plus a portal API key supplied via the env var DAPP_STORE_API_KEY
+      # (or `--api-key-stdin`). The release/version metadata that config.yaml
+      # used to carry now lives in the publish.solanamobile.com portal, so the
+      # GCS-backed config.yaml decrypt/re-encrypt scaffolding above is largely
+      # vestigial in the 1.0.0 model. We keep the KMS key fix (--key=gpg) and
+      # the keypair decrypt (still required to sign the on-chain submission)
+      # rather than rip the scaffolding out in this same PR.
+      #
+      # HUMAN PREREQUISITE: the DAPP_STORE_API_KEY repo secret does NOT exist
+      # yet. Generate it at publish.solanamobile.com -> settings -> API keys,
+      # then `gh secret set DAPP_STORE_API_KEY`. Until it exists this job will
+      # fail at this step; `continue-on-error: true` on the job keeps that from
+      # failing the release.
+      # ---------------------------------------------------------------------
+      - name: Publish to Solana dApp Store
         working-directory: stores/solana
+        env:
+          DAPP_STORE_API_KEY: ${{ secrets.DAPP_STORE_API_KEY }}
         run: |
-          echo "Creating release on Solana dApp Store..."
+          echo "Publishing to Solana dApp Store (dapp-store-cli 1.0.0)..."
 
-          npx @solana-mobile/dapp-store-cli@latest create release \
-            -k /tmp/solana-keypair.json \
-            -b $ANDROID_SDK_ROOT/build-tools/35.0.0 \
-            -u https://api.mainnet-beta.solana.com \
-            --config config.yaml
+          npx @solana-mobile/dapp-store-cli@1.0.0 \
+            --apk-file solana.apk \
+            --keypair /tmp/solana-keypair.json \
+            --whats-new "New features and improvements in this release."
 
-          echo "Release created successfully"
-
-      - name: Publish Update to Solana dApp Store
-        working-directory: stores/solana
-        run: |
-          echo "Publishing update to Solana dApp Store..."
-
-          npx @solana-mobile/dapp-store-cli@latest publish update \
-            -k /tmp/solana-keypair.json \
-            -u https://api.mainnet-beta.solana.com \
-            --complies-with-solana-dapp-store-policies \
-            --requestor-is-authorized \
-            --config config.yaml
-
-          echo "Update published successfully"
-
-      - name: Display publish information
-        working-directory: stores/solana
-        run: |
-          echo "Solana dApp Store Publishing Complete"
-          echo "Release Address: $(yq eval '.release.address' config.yaml)"
-          echo "Version: $(yq eval '.release.android_details.version' config.yaml)"
-          echo "Version Code: $(yq eval '.release.android_details.version_code' config.yaml)"
+          echo "Published successfully"
 
       - name: Re-encrypt and upload config.yaml to GCS
         run: |
@@ -308,7 +314,7 @@ jobs:
 
           echo "Re-encrypting config.yaml..."
           gcloud kms encrypt \
-            --key=config \
+            --key=gpg \
             --keyring=gpg \
             --location=global \
             --plaintext-file=stores/solana/config.yaml \


### PR DESCRIPTION
## Why

The `publish_to_solana` job in `.github/workflows/release.yaml` has **never succeeded**. Two confirmed root causes, fixed here.

## 1. Wrong KMS key (decrypt + re-encrypt of config.yaml)

The config.yaml **decrypt** step and the config.yaml **re-encrypt** step both used `--key=config`. That CryptoKey does **not exist** — the GCP KMS keyring `gpg` (project from `secrets.GCP_PROJECT_ID_PROD`) has exactly one key: `gpg` (directly verified). The keypair decrypt step already (correctly) used `--key=gpg`.

Both `--key=config` lines are now `--key=gpg`. The keypair decrypt step is left untouched.

## 2. Obsolete Solana dApp Store CLI (0.15.x → 1.0.0)

The job called the legacy interface:

```
npx @solana-mobile/dapp-store-cli@latest create release -k <keypair> ... --config config.yaml
npx @solana-mobile/dapp-store-cli@latest publish update  -k <keypair> ... --config config.yaml
```

Solana Mobile shipped `dapp-store-cli@1.0.0`, a portal-backed CLI that **removed** `create release`, `publish update`, `-k`, and `--config`. The old `0.15.0` is now hard-gated server-side and refuses to run, so neither `@latest` nor the pinned old version works.

Migrated to the single 1.0.0 invocation against the already-downloaded FOSS APK (`stores/solana/solana.apk`):

```
npx @solana-mobile/dapp-store-cli@1.0.0 \
  --apk-file solana.apk \
  --keypair /tmp/solana-keypair.json \
  --whats-new "New features and improvements in this release."
```

with the portal key supplied via env `DAPP_STORE_API_KEY`. A comment block documents the 0.15→1.0 migration and the API-key prerequisite.

The config.yaml metadata flow (decrypt/re-encrypt from GCS) is largely vestigial in the 1.0.0 portal model (the portal holds the metadata now), but it is **left in place** — the KMS key fix is correct and harmless, and the keypair decrypt is still required to sign the on-chain submission. Stripping the scaffolding can be a follow-up.

`continue-on-error: true` is kept on the job (it is best-effort).

## ⚠️ HUMAN PREREQUISITE — `DAPP_STORE_API_KEY` does not exist yet

**The `DAPP_STORE_API_KEY` repo secret does NOT exist.** The 1.0.0 CLI requires it, so this job will fail at the publish step until a human creates it:

1. Generate it at **publish.solanamobile.com → settings → API keys**
2. `gh secret set DAPP_STORE_API_KEY`

This is expected — the job is best-effort (`continue-on-error: true`), so its absence does not fail the release. But Solana publishing will not actually work until the secret is set.

## Validation

`python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML.