### PR TITLE
ci: force release published event so release.yaml always cascades

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,16 @@ name: Create Release from tag
 # (on: release published) will NOT auto-fire from this workflow's release.
 # To make the build+publish chain run automatically, this workflow mints a
 # short-lived GitHub App installation token (preferred over a long-lived PAT
-# in a PUBLIC repo) and creates the release with it. Wiring:
+# in a PUBLIC repo) and creates the release with it.
+#
+# A second subtlety bit 3.6.0: action-gh-release UPDATES a pre-existing
+# release instead of creating it, and an *update* does not emit a
+# `release: published` event, so release.yaml never fired. To cover that, a
+# follow-up step flips the release draft->published with the App token,
+# which re-emits `published` regardless of whether the release was new or
+# already existed (see the "Force published event" step below).
+#
+# Wiring:
 #   * repo variable  RELEASE_BOT_APP_ID    — the App's numeric id (not secret)
 #   * repo secret     RELEASE_BOT_APP_KEY  — the App's PEM private key
 # The App needs only `contents: write` on this single repo. If the variable
@@ -146,6 +155,46 @@ jobs:
           # App token (cascades into release.yaml) when available; otherwise
           # GITHUB_TOKEN (no cascade — see CASCADE CAVEAT in the header).
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      # Force a fresh `release: published` event so the build+publish chain in
+      # release.yaml always cascades — even when the release already existed.
+      #
+      # WHY: softprops/action-gh-release UPDATES an already-existing release
+      # rather than creating it, and *updating* a release does NOT emit a
+      # `release: published` event (only the create-as-published transition
+      # does). This is exactly what broke 3.6.0: the GitHub Release was created
+      # out-of-band before this workflow ran, the create step above silently
+      # turned into an update, no `published` event fired, and release.yaml
+      # (build + F-Droid + Solana) never ran.
+      #
+      # FIX: with the App token (which CAN trigger downstream workflows; the
+      # default GITHUB_TOKEN cannot — see CASCADE CAVEAT in the header), flip
+      # the release draft -> published. The draft=true PATCH followed by
+      # draft=false produces a genuine state transition into "published",
+      # which re-emits `release: published`. This is idempotent and safe to
+      # re-run: a release already published ends up published again, and a
+      # brand-new release (the create step published it) is re-published,
+      # which still emits the event we need. Skipped when no App token is
+      # available (GITHUB_TOKEN can't cascade anyway), same guard as the mint.
+      - name: Force published event (cascade into release.yaml)
+        if: ${{ vars.RELEASE_BOT_APP_ID != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Resolve the release id from the tag.
+          RELEASE_ID="$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.id')"
+          if [ -z "${RELEASE_ID}" ] || [ "${RELEASE_ID}" = "null" ]; then
+            echo "ERROR: could not resolve release id for tag '${TAG}'." >&2
+            exit 1
+          fi
+          echo "Re-publishing release ${RELEASE_ID} (tag ${TAG}) to force a published event..."
+          # draft -> published transition re-emits `release: published`.
+          gh api -X PATCH "repos/${REPO}/releases/${RELEASE_ID}" -F draft=true  >/dev/null
+          gh api -X PATCH "repos/${REPO}/releases/${RELEASE_ID}" -F draft=false >/dev/null
+          echo "Done; release.yaml should now cascade."
 
       - name: Create Linear release
         # Scans commits since the previous tag for MOB-### references and creates


### PR DESCRIPTION
## Why 3.6.0 didn't auto-publish

`create-release.yml` mints a GitHub App token and creates the release with it specifically so the published release **cascades** into `release.yaml` (build + APK signing + F-Droid + Solana). The App token is the right call — the default `GITHUB_TOKEN` can't trigger downstream workflows (GitHub's anti-recursion rule).

But there's a second subtlety that bit 3.6.0: the GitHub Release **already existed** when the workflow ran (release created 08:11; workflow ran 20:22 on the #2323 merge). `softprops/action-gh-release` on an existing release does an **UPDATE**, not a create — and *updating* a release does **NOT** emit a `release: published` event (only the create-as-published transition does). Result: `release.yaml` never fired and nothing got published.

## Fix — force a fresh `published` event

After the create/update step, a new guarded step re-publishes the release with the App token by flipping it `draft=true` then `draft=false`:

```
RELEASE_ID=$(gh api repos/{owner}/{repo}/releases/tags/$TAG --jq .id)
gh api -X PATCH repos/{owner}/{repo}/releases/$RELEASE_ID -F draft=true
gh api -X PATCH repos/{owner}/{repo}/releases/$RELEASE_ID -F draft=false
```

A genuine **draft → published state transition re-emits `release: published`** — so the cascade fires regardless of whether the release was brand-new (the create step already published it) or pre-existing (the update silently swallowed the event). This is the reliable approach: `gh release edit --draft=false` on an already-published release is a no-op and emits nothing, whereas the explicit draft→publish round-trip always produces the transition.

### Properties

- **Idempotent / safe to re-run.** An already-published release ends up published again; a new release is re-published. Either way the event we need is emitted.
- **Guarded** by `if: ${{ vars.RELEASE_BOT_APP_ID != '' }}` — the same condition as the token-mint step. With no App token, `GITHUB_TOKEN` can't cascade anyway, so re-publishing would be pointless; in that case an operator still republishes manually (unchanged fallback).
- Uses the App token (`steps.app_token.outputs.token`) — only the App token can trigger downstream workflows.
- Existing changelog-extraction and tag-resolution logic are untouched; this step only runs after them and reuses `steps.tag.outputs.tag`.

The header CASCADE CAVEAT comment is updated to document this second failure mode.

## Validation

`python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML.