### PR TITLE
[MOD-1419]: Add multi-server / privacy info footer to Server Setup

### DIFF
--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiInfoText.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiInfoText.kt
@@ -26,10 +26,11 @@ fun ZashiInfoText(
     color: Color = ZashiColors.Text.textTertiary,
     style: TextStyle = ZashiTypography.textXs,
     textAlign: TextAlign = TextAlign.Start,
+    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
     Row(
         modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = verticalAlignment
     ) {
         Image(
             modifier = Modifier,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerView.kt
@@ -64,6 +64,7 @@ import co.electriccoin.zcash.ui.design.component.ZashiBadge
 import co.electriccoin.zcash.ui.design.component.ZashiBadgeDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiButton
 import co.electriccoin.zcash.ui.design.component.ZashiHorizontalDivider
+import co.electriccoin.zcash.ui.design.component.ZashiInfoText
 import co.electriccoin.zcash.ui.design.component.ZashiRadioButton
 import co.electriccoin.zcash.ui.design.component.ZashiSmallTopAppBar
 import co.electriccoin.zcash.ui.design.component.ZashiTextFieldDefaults
@@ -253,6 +254,18 @@ private fun ErrorDialog(dialogState: ServerDialogState) {
 }
 
 @Composable
+private fun MultiServerInfoFooter() {
+    ZashiInfoText(
+        text = stringResource(R.string.choose_server_multi_server_info),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.Top,
+    )
+}
+
+@Composable
 fun ChooseServerBottomBar(saveButtonState: ButtonState) {
     Column(
         modifier =
@@ -260,6 +273,7 @@ fun ChooseServerBottomBar(saveButtonState: ButtonState) {
                 .fillMaxWidth()
                 .background(ZashiColors.Surfaces.bgPrimary)
     ) {
+        MultiServerInfoFooter()
         ZashiHorizontalDivider()
         Spacer(modifier = Modifier.height(20.dp))
         ZashiButton(

--- a/ui-lib/src/main/res/ui/choose_server/values-es/strings.xml
+++ b/ui-lib/src/main/res/ui/choose_server/values-es/strings.xml
@@ -39,4 +39,6 @@
     <string name="choose_server_active">Activo</string>
     <string name="choose_server_testing">Probando</string>
     <string name="choose_server_default">Predeterminado</string>
+
+    <string name="choose_server_multi_server_info">Podemos usar varios servidores para optimizar el rendimiento. Para reducir la exposición de metadatos, selecciona el modo de conexión Manual para elegir un único servidor de tu preferencia y asegúrate de que Tor esté habilitado en Configuración Avanzada.</string>
 </resources>

--- a/ui-lib/src/main/res/ui/choose_server/values/strings.xml
+++ b/ui-lib/src/main/res/ui/choose_server/values/strings.xml
@@ -39,4 +39,6 @@
     <string name="choose_server_active">Active</string>
     <string name="choose_server_testing">Testing</string>
     <string name="choose_server_default">Default</string>
+
+    <string name="choose_server_multi_server_info">We may use multiple servers to optimize performance. To reduce metadata exposure, choose Manual connection mode to select your single server of choice, and ensure Tor is enabled in Advanced Settings.</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds an `ic_info` + tertiary-text footer above the Save button on the
Choose Server screen, mirroring the iOS change. Tells Automatic-mode
users their tx may go to multiple servers and points them at Manual + Tor
if they want single-server submission.

## Changes

- `choose_server/values{,-es}/strings.xml`: new `choose_server_multi_server_info`
- `ChooseServerView.kt`: new `MultiServerInfoFooter()` inside `ChooseServerBottomBar`, above the divider
- `ZashiInfoText.kt`: add `verticalAlignment` param (default `CenterVertically`, non-breaking) so the footer can pass `Alignment.Top` and align the icon to the first line

## Test plan

- Gradle sync; build `zcashmainnetStoreDebug`
- Choose Server: footer renders above Save with top-aligned icon
- Existing `ZashiInfoText` call sites unchanged (default preserved)

<img width="363" height="785" alt="Screenshot 2026-06-19 at 1 55 23 PM" src="https://github.com/user-attachments/assets/9b4fd283-e2db-4aef-92e6-e6362d2dda5c" />
