### PR TITLE
Resolve build-conventions AGP DSL deprecations (#1816, #1815)

### DIFF
--- a/build-conventions-secant/src/main/kotlin/secant.android-build-conventions.gradle.kts
+++ b/build-conventions-secant/src/main/kotlin/secant.android-build-conventions.gradle.kts
@@ -13,12 +13,6 @@ pluginManager.withPlugin("com.android.application") {
             minSdk = project.property("ANDROID_MIN_SDK_VERSION").toString().toInt()
             targetSdk = project.property("ANDROID_TARGET_SDK_VERSION").toString().toInt()
 
-            // en_XA and ar_XB are pseudolocales for debugging.
-            // The rest of the locales provides an explicit list of the languages to keep in the
-            // final app.  Doing this will strip out additional locales from libraries like
-            // Google Play Services and Firebase, which add unnecessary bloat.
-            resourceConfigurations.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
-
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
             testInstrumentationRunnerArguments["useTestStorageService"] = "true"
@@ -26,6 +20,14 @@ pluginManager.withPlugin("com.android.application") {
                 testInstrumentationRunnerArguments["clearPackageData"] = "true"
             }
         }
+    }
+
+    // en_XA and ar_XB are pseudolocales for debugging.
+    // The rest of the locales provides an explicit list of the languages to keep in the
+    // final app.  Doing this will strip out additional locales from libraries like
+    // Google Play Services and Firebase, which add unnecessary bloat.
+    project.the<com.android.build.api.dsl.ApplicationExtension>().androidResources {
+        localeFilters.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
     }
 }
 
@@ -35,18 +37,6 @@ pluginManager.withPlugin("com.android.library") {
 
         defaultConfig {
             minSdk = project.property("ANDROID_MIN_SDK_VERSION").toString().toInt()
-            // This is deprecated but we don't have a replacement for the instrumentation APKs yet
-            // TODO [#1815]: Gradle targetSdk deprecated #1815
-            // TODO [#1815]: https://github.com/Electric-Coin-Company/zashi-android/issues/1815
-            targetSdk = project.property("ANDROID_TARGET_SDK_VERSION").toString().toInt()
-
-            // The last two are for support of pseudolocales in debug builds.
-            // If we add other localizations, they should be included in this list.
-            // By explicitly setting supported locales, we strip out unused localizations from third party
-            // libraries (e.g. play services)
-            // TODO [#1816]: Gradle resourceConfigurations deprecation #1816
-            // TODO [#1816]: https://github.com/Electric-Coin-Company/zashi-android/issues/1816
-            resourceConfigurations.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
 
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             consumerProguardFiles("proguard-consumer.txt")
@@ -60,6 +50,14 @@ pluginManager.withPlugin("com.android.library") {
             jacocoVersion = project.property("JACOCO_VERSION").toString()
         }
     }
+
+    // targetSdk in a library's defaultConfig is deprecated (removed from the library DSL in AGP 9);
+    // for libraries it only sets the instrumentation-test APK target, so it moves to testOptions.
+    // Locale filtering likewise moved to the application module (androidResources.localeFilters);
+    // AGP exposes no library-module equivalent, so the former resourceConfigurations is dropped.
+    project.the<com.android.build.api.dsl.LibraryExtension>().testOptions {
+        targetSdk = project.property("ANDROID_TARGET_SDK_VERSION").toString().toInt()
+    }
 }
 
 pluginManager.withPlugin("com.android.test") {
@@ -69,14 +67,6 @@ pluginManager.withPlugin("com.android.test") {
         defaultConfig {
             minSdk = project.property("ANDROID_MIN_SDK_VERSION").toString().toInt()
             targetSdk = project.property("ANDROID_TARGET_SDK_VERSION").toString().toInt()
-
-            // The last two are for support of pseudolocales in debug builds.
-            // If we add other localizations, they should be included in this list.
-            // By explicitly setting supported locales, we strip out unused localizations from third party
-            // libraries (e.g. play services)
-            // TODO [#1816]: Gradle resourceConfigurations deprecation #1816
-            // TODO [#1816]: https://github.com/Electric-Coin-Company/zashi-android/issues/1816
-            resourceConfigurations.addAll(listOf("en", "en-rUS", "en-rGB", "en-rAU", "es", "en_XA", "ar_XB"))
 
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -89,6 +79,10 @@ pluginManager.withPlugin("com.android.test") {
             jacocoVersion = project.property("JACOCO_VERSION").toString()
         }
     }
+
+    // Locale filtering moved to the application module's androidResources.localeFilters.
+    // AGP exposes no com.android.test-module equivalent, and the former resourceConfigurations
+    // only trimmed locales from the generated test APK, so it is dropped here.
 }
 
 @Suppress("LongMethod")


### PR DESCRIPTION
Both of these were sitting in the Android build conventions as TODOs, and the AGP version we're on now (8.13.2) has the replacements, so I cleared them out.

**#1816 — `resourceConfigurations` → `androidResources.localeFilters`**

`resourceConfigurations` is deprecated in favor of `androidResources.localeFilters`. The wrinkle is that `localeFilters` only exists on the application module (it's declared on `ApplicationAndroidResources`, not the library or test variants), which lines up with the deprecation message about filtering locales "in applications". So the locale list moves to the app module.

The library and test modules have no equivalent, and their copy only ever trimmed locales out of the instrumentation and benchmark test APKs, so it's dropped there. Nothing the shipped app needs can disappear from that, since removing a filter only keeps more locales.

**#1815 — library `targetSdk` → `testOptions.targetSdk`**

The library module's `defaultConfig.targetSdk` is deprecated and gets removed from the library DSL in AGP 9. For a library it only sets the target for the instrumentation test APK, so it moves to `testOptions.targetSdk`. The old "no replacement yet" comment is stale on the current AGP. The app and test modules keep `defaultConfig.targetSdk` since it's only deprecated for libraries.

The locale values are carried over exactly as they were, so this is a rename of the same filtering rather than a behavior change.

Verified the convention plugins compile against AGP 8.13.2 and that the app module configures with the new `localeFilters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
