### PR TITLE
[MOB-1130]: Hide sync banner by blocks remaining, not percentage

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
@@ -34,6 +34,17 @@ class WalletSnapshotDataSourceImpl(
                 if (synchronizer == null) {
                     flowOf(null)
                 } else {
+                    val blocksRemainingFlow =
+                        combine(
+                            synchronizer.networkHeight,
+                            synchronizer.fullyScannedHeight,
+                        ) { networkHeight, fullyScannedHeight ->
+                            if (networkHeight != null && fullyScannedHeight != null) {
+                                (networkHeight.value - fullyScannedHeight.value).coerceAtLeast(0L)
+                            } else {
+                                -1L
+                            }
+                        }
                     combine(
                         synchronizer.status,
                         synchronizer.progress,
@@ -48,6 +59,8 @@ class WalletSnapshotDataSourceImpl(
                             isSpendable = isSpendable,
                             restoringState = restoringState,
                         )
+                    }.combine(blocksRemainingFlow) { snapshot, blocksRemaining ->
+                        snapshot.copy(blocksRemaining = blocksRemaining)
                     }
                 }
             }.stateIn(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletSnapshot.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletSnapshot.kt
@@ -10,5 +10,6 @@ data class WalletSnapshot(
     val progress: PercentDecimal,
     val synchronizerError: SynchronizerError?,
     val isSpendable: Boolean,
-    val restoringState: WalletRestoringState
+    val restoringState: WalletRestoringState,
+    val blocksRemaining: Long = -1L,
 )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
@@ -239,26 +239,32 @@ class GetHomeMessageUseCase(
         walletSnapshot: WalletSnapshot,
         syncMessageShownBefore: Boolean,
         someBalance: Boolean,
-    ): RuntimeMessage? {
-        if (walletSnapshot.status != Synchronizer.Status.SYNCING) return null
+    ): RuntimeMessage? = syncingMessageFor(walletSnapshot, syncMessageShownBefore, someBalance)
+}
 
-        val progress = walletSnapshot.progress.decimal * 100f
-        return if (walletSnapshot.restoringState == WalletRestoringState.RESYNCING) {
-            HomeMessageData.Resyncing(progress)
-        } else if (walletSnapshot.restoringState == WalletRestoringState.RESTORING) {
-            HomeMessageData.Restoring(walletSnapshot.isSpendable && someBalance, progress)
-        } else {
-            if (!syncMessageShownBefore) {
-                if (walletSnapshot.blocksRemaining < SYNCING_BANNER_HIDE_BELOW_BLOCKS) {
-                    null
-                } else {
-                    HomeMessageData.Syncing(progress = progress)
-                }
+internal const val SYNCING_BANNER_HIDE_BELOW_BLOCKS = 3456L
+
+internal fun syncingMessageFor(
+    walletSnapshot: WalletSnapshot,
+    syncMessageShownBefore: Boolean,
+    someBalance: Boolean,
+): RuntimeMessage? {
+    if (walletSnapshot.status != Synchronizer.Status.SYNCING) return null
+
+    val progress = walletSnapshot.progress.decimal * 100f
+    return if (walletSnapshot.restoringState == WalletRestoringState.RESYNCING) {
+        HomeMessageData.Resyncing(progress)
+    } else if (walletSnapshot.restoringState == WalletRestoringState.RESTORING) {
+        HomeMessageData.Restoring(walletSnapshot.isSpendable && someBalance, progress)
+    } else {
+        if (!syncMessageShownBefore) {
+            if (walletSnapshot.blocksRemaining < SYNCING_BANNER_HIDE_BELOW_BLOCKS) {
+                null
             } else {
                 HomeMessageData.Syncing(progress = progress)
             }
+        } else {
+            HomeMessageData.Syncing(progress = progress)
         }
     }
 }
-
-private const val SYNCING_BANNER_HIDE_BELOW_BLOCKS = 3456L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
@@ -235,7 +235,6 @@ class GetHomeMessageUseCase(
             null
         }
 
-    @Suppress("MagicNumber")
     private fun createSyncingMessage(
         walletSnapshot: WalletSnapshot,
         syncMessageShownBefore: Boolean,
@@ -250,10 +249,16 @@ class GetHomeMessageUseCase(
             HomeMessageData.Restoring(walletSnapshot.isSpendable && someBalance, progress)
         } else {
             if (!syncMessageShownBefore) {
-                if (progress >= 98f || progress == 0f) null else HomeMessageData.Syncing(progress = progress)
+                if (walletSnapshot.blocksRemaining < SYNCING_BANNER_HIDE_BELOW_BLOCKS) {
+                    null
+                } else {
+                    HomeMessageData.Syncing(progress = progress)
+                }
             } else {
                 HomeMessageData.Syncing(progress = progress)
             }
         }
     }
 }
+
+private const val SYNCING_BANNER_HIDE_BELOW_BLOCKS = 3456L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
@@ -244,6 +244,7 @@ class GetHomeMessageUseCase(
 
 internal const val SYNCING_BANNER_HIDE_BELOW_BLOCKS = 3456L
 
+@Suppress("MagicNumber")
 internal fun syncingMessageFor(
     walletSnapshot: WalletSnapshot,
     syncMessageShownBefore: Boolean,

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseSyncThresholdTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseSyncThresholdTest.kt
@@ -31,7 +31,12 @@ class GetHomeMessageUseCaseSyncThresholdTest {
 
     @Test
     fun blocksRemainingAtThresholdShowsSyncBanner() {
-        val result = syncingMessageFor(snapshot(blocksRemaining = SYNCING_BANNER_HIDE_BELOW_BLOCKS), syncMessageShownBefore = false, someBalance = false)
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = SYNCING_BANNER_HIDE_BELOW_BLOCKS),
+                syncMessageShownBefore = false,
+                someBalance = false
+            )
         assertEquals(HomeMessageData.Syncing(progress = 50f), result)
     }
 
@@ -69,21 +74,23 @@ class GetHomeMessageUseCaseSyncThresholdTest {
 
     @Test
     fun restoringStateBypassesThresholdAndAlwaysShows() {
-        val result = syncingMessageFor(
-            snapshot(blocksRemaining = 10, restoringState = WalletRestoringState.RESTORING),
-            syncMessageShownBefore = false,
-            someBalance = true,
-        )
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = 10, restoringState = WalletRestoringState.RESTORING),
+                syncMessageShownBefore = false,
+                someBalance = true,
+            )
         assertEquals(HomeMessageData.Restoring(isSpendable = false, progress = 50f), result)
     }
 
     @Test
     fun resyncingStateBypassesThresholdAndAlwaysShows() {
-        val result = syncingMessageFor(
-            snapshot(blocksRemaining = 10, restoringState = WalletRestoringState.RESYNCING),
-            syncMessageShownBefore = false,
-            someBalance = false,
-        )
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = 10, restoringState = WalletRestoringState.RESYNCING),
+                syncMessageShownBefore = false,
+                someBalance = false,
+            )
         assertEquals(HomeMessageData.Resyncing(progress = 50f), result)
     }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseSyncThresholdTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseSyncThresholdTest.kt
@@ -25,7 +25,12 @@ class GetHomeMessageUseCaseSyncThresholdTest {
 
     @Test
     fun blocksRemainingAboveThresholdShowsSyncBanner() {
-        val result = syncingMessageFor(snapshot(blocksRemaining = 5000), syncMessageShownBefore = false, someBalance = false)
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = 5000),
+                syncMessageShownBefore = false,
+                someBalance = false,
+            )
         assertEquals(HomeMessageData.Syncing(progress = 50f), result)
     }
 
@@ -42,19 +47,34 @@ class GetHomeMessageUseCaseSyncThresholdTest {
 
     @Test
     fun blocksRemainingBelowThresholdHidesSyncBanner() {
-        val result = syncingMessageFor(snapshot(blocksRemaining = 100), syncMessageShownBefore = false, someBalance = false)
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = 100),
+                syncMessageShownBefore = false,
+                someBalance = false,
+            )
         assertNull(result)
     }
 
     @Test
     fun blocksRemainingZeroHidesSyncBanner() {
-        val result = syncingMessageFor(snapshot(blocksRemaining = 0), syncMessageShownBefore = false, someBalance = false)
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = 0),
+                syncMessageShownBefore = false,
+                someBalance = false,
+            )
         assertNull(result)
     }
 
     @Test
     fun sentinelMinusOneHidesSyncBanner() {
-        val result = syncingMessageFor(snapshot(blocksRemaining = -1L), syncMessageShownBefore = false, someBalance = false)
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = -1L),
+                syncMessageShownBefore = false,
+                someBalance = false,
+            )
         assertNull(result)
     }
 
@@ -67,8 +87,12 @@ class GetHomeMessageUseCaseSyncThresholdTest {
 
     @Test
     fun thresholdNotAppliedAfterFirstShow() {
-        // Once the banner has been shown once, subsequent low-blocks-remaining still keeps it visible.
-        val result = syncingMessageFor(snapshot(blocksRemaining = 10), syncMessageShownBefore = true, someBalance = false)
+        val result =
+            syncingMessageFor(
+                snapshot(blocksRemaining = 10),
+                syncMessageShownBefore = true,
+                someBalance = false,
+            )
         assertEquals(HomeMessageData.Syncing(progress = 50f), result)
     }
 

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseSyncThresholdTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseSyncThresholdTest.kt
@@ -1,0 +1,89 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.model.PercentDecimal
+import co.electriccoin.zcash.ui.common.model.WalletRestoringState
+import co.electriccoin.zcash.ui.common.model.WalletSnapshot
+import co.electriccoin.zcash.ui.common.repository.HomeMessageData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GetHomeMessageUseCaseSyncThresholdTest {
+    private fun snapshot(
+        blocksRemaining: Long,
+        restoringState: WalletRestoringState = WalletRestoringState.SYNCING,
+        progress: Float = 0.5f,
+    ) = WalletSnapshot(
+        status = Synchronizer.Status.SYNCING,
+        progress = PercentDecimal(progress),
+        synchronizerError = null,
+        isSpendable = false,
+        restoringState = restoringState,
+        blocksRemaining = blocksRemaining,
+    )
+
+    @Test
+    fun blocksRemainingAboveThresholdShowsSyncBanner() {
+        val result = syncingMessageFor(snapshot(blocksRemaining = 5000), syncMessageShownBefore = false, someBalance = false)
+        assertEquals(HomeMessageData.Syncing(progress = 50f), result)
+    }
+
+    @Test
+    fun blocksRemainingAtThresholdShowsSyncBanner() {
+        val result = syncingMessageFor(snapshot(blocksRemaining = SYNCING_BANNER_HIDE_BELOW_BLOCKS), syncMessageShownBefore = false, someBalance = false)
+        assertEquals(HomeMessageData.Syncing(progress = 50f), result)
+    }
+
+    @Test
+    fun blocksRemainingBelowThresholdHidesSyncBanner() {
+        val result = syncingMessageFor(snapshot(blocksRemaining = 100), syncMessageShownBefore = false, someBalance = false)
+        assertNull(result)
+    }
+
+    @Test
+    fun blocksRemainingZeroHidesSyncBanner() {
+        val result = syncingMessageFor(snapshot(blocksRemaining = 0), syncMessageShownBefore = false, someBalance = false)
+        assertNull(result)
+    }
+
+    @Test
+    fun sentinelMinusOneHidesSyncBanner() {
+        val result = syncingMessageFor(snapshot(blocksRemaining = -1L), syncMessageShownBefore = false, someBalance = false)
+        assertNull(result)
+    }
+
+    @Test
+    fun nonSyncingStatusReturnsNullRegardlessOfBlocksRemaining() {
+        val snap = snapshot(blocksRemaining = 100_000).copy(status = Synchronizer.Status.SYNCED)
+        val result = syncingMessageFor(snap, syncMessageShownBefore = false, someBalance = false)
+        assertNull(result)
+    }
+
+    @Test
+    fun thresholdNotAppliedAfterFirstShow() {
+        // Once the banner has been shown once, subsequent low-blocks-remaining still keeps it visible.
+        val result = syncingMessageFor(snapshot(blocksRemaining = 10), syncMessageShownBefore = true, someBalance = false)
+        assertEquals(HomeMessageData.Syncing(progress = 50f), result)
+    }
+
+    @Test
+    fun restoringStateBypassesThresholdAndAlwaysShows() {
+        val result = syncingMessageFor(
+            snapshot(blocksRemaining = 10, restoringState = WalletRestoringState.RESTORING),
+            syncMessageShownBefore = false,
+            someBalance = true,
+        )
+        assertEquals(HomeMessageData.Restoring(isSpendable = false, progress = 50f), result)
+    }
+
+    @Test
+    fun resyncingStateBypassesThresholdAndAlwaysShows() {
+        val result = syncingMessageFor(
+            snapshot(blocksRemaining = 10, restoringState = WalletRestoringState.RESYNCING),
+            syncMessageShownBefore = false,
+            someBalance = false,
+        )
+        assertEquals(HomeMessageData.Resyncing(progress = 50f), result)
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the 98% sync-banner threshold with an absolute **3,456 blocks remaining** (~3 days at 75s/block target).

The old percentage scaled with the wallet's birthday height, so older wallets saw the banner disappear while still tens of thousands of blocks behind sync — leading to confusion when funds weren't yet spendable. A fixed block-count threshold gives every wallet the same ~10s-of-remaining-work hide point, regardless of age.

## Changes

- `WalletSnapshot.kt`: add `blocksRemaining: Long`.
- `WalletSnapshotDataSource.kt`: combine `synchronizer.networkHeight` + `synchronizer.fullyScannedHeight` into `blocksRemaining = (tip - scanned).coerceAtLeast(0)`.
- `GetHomeMessageUseCase.kt`: threshold check swaps from `progress >= 98f` to `blocksRemaining < SYNCING_BANNER_HIDE_BELOW_BLOCKS` (3456).

The banner still shows the percentage in its label; only the hide/show decision changes.

## Test plan

- `./gradlew :ui-lib:compileZcashtestnetInternalDebugKotlin` ✅
- New wallet: banner hides at the very end of sync (unchanged from before).
- Old wallet (restored from far-back birthday): banner remains visible until the wallet is within ~3,456 blocks of chain tip, then hides cleanly.