### PR TITLE
Fix Linear-release tag trigger — globs are not regex

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,7 +45,12 @@ name: Create Release from tag
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+      # GitHub Actions tag filters are glob patterns (minimatch), not regex.
+      # `+` is a literal `+` in glob — the previous `[0-9]+.[0-9]+.[0-9]+-[0-9]+`
+      # was being interpreted as "digit + literal `+` + literal `.` + …" and
+      # so only ever matched strings like `3+.5+.3+-1745+`, never real release
+      # tags like `3.5.3-1745`.
+      - '*.*.*-*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

The create-release workflow's tag trigger was written in regex form but GitHub Actions matches tags as **glob** (via minimatch), where `+` is a literal `+` character. The pattern only ever matched literal strings like `3+.5+.3+-1745+`, never real release tags like `3.5.3-1745` — the push trigger has never matched any pushed tag.

## Change

`'[0-9]+.[0-9]+.[0-9]+-[0-9]+'` → `'*.*.*-*'` in [`create-release.yml`](.github/workflows/create-release.yml).

In glob, `*` is "zero or more chars except `/`", which gobbles each numeric segment between the literal separators. Release tags are gated by deliberate dev action so the less-strict pattern is fine — no risk of a stray non-version tag accidentally matching.

Comment added inline so the next reader doesn't repeat the regex mistake. Doesn't change the `workflow_dispatch` escape hatch — that still works for manual reruns against arbitrary tags.

## Test plan

After merge: push the next release tag (`3.5.4-NNNN` or similar). The "Create Release from tag" workflow should fire automatically, resolve the changelog section, and publish the GitHub Release. From there the existing `release.yaml` workflow takes over for the actual build / APK / F-Droid publish.

Reported by Linear AI on the equivalent iOS issue (zodl-ios#NNNN).