### PR TITLE
Revert #2335 — "globs are not regex" tag-trigger change (premature merge)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -54,12 +54,7 @@ name: Create Release from tag
 on:
   push:
     tags:
-      # GitHub Actions tag filters are glob patterns (minimatch), not regex.
-      # `+` is a literal `+` in glob — the previous `[0-9]+.[0-9]+.[0-9]+-[0-9]+`
-      # was being interpreted as "digit + literal `+` + literal `.` + …" and
-      # so only ever matched strings like `3+.5+.3+-1745+`, never real release
-      # tags like `3.5.3-1745`.
-      - '*.*.*-*'
+      - '[0-9]+.[0-9]+.[0-9]+-[0-9]+'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Reverts #2335 (`d1cac347`).

**Why revert:**
1. **Merged prematurely.** #2335 was authored by @Cosmos-Harry and the team was still researching the equivalent feedback on the iOS PR zodl-inc/zodl-ios#1855
2. **The premise is technically incorrect.** GitHub Actions `on.push.tags` filters use GitHub's [filter-pattern syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), **not** minimatch globs — `+` means "one or more" and `[0-9]` is a character range (GitHub's own semver example is `v[12].[0-9]+.[0-9]+`). So the original `[0-9]+.[0-9]+.[0-9]+-[0-9]+` was a **valid, tighter** matcher — it already matched real tags like `3.6.0-1914`.
3. **Evidence the trigger was never broken:** `create-release.yml` did fire from `push:tags` for `3.6.0-1914` (run on 2026-06-17 20:22, `event=push`, success). What actually broke 3.6.0's release was the downstream cascade (the `action-gh-release` update-vs-create quirk), fixed separately in #2328 — a different root cause.

This revert restores the original strict pattern and removes the misleading comment. Harry's branch (`harry/fix-linear-release-tag-glob`) has been restored so the original PR's work is preserved for the team to revisit if desired.