### PR TITLE
Track Linear releases on release:published (run from main)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,8 +11,12 @@ name: Create Release from tag
 #      and the changelog section as the body.
 #
 # Publishing the release fires the existing `release.yaml` workflow, which
-# does the actual build + APK signing + Solana / F-Droid publishing. We do
+# does the actual build + APK signing + Solana / F-Droid publishing, and the
+# `linear-release.yml` workflow, which records the release in Linear. We do
 # NOT do any of that here — this workflow's only job is "tag -> release".
+# (Linear tracking used to be a trailing step here; it now lives in
+# `linear-release.yml` on `release: published` so it runs from `main` rather
+# than depending on this file being present on the tagged commit.)
 #
 # Two trigger paths:
 #
@@ -92,7 +96,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.tag.outputs.tag }}
-          fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
 
       - name: Parse tag and extract changelog section
         id: meta
@@ -194,12 +197,4 @@ jobs:
           # draft -> published transition re-emits `release: published`.
           gh api -X PATCH "repos/${REPO}/releases/${RELEASE_ID}" -F draft=true  >/dev/null
           gh api -X PATCH "repos/${REPO}/releases/${RELEASE_ID}" -F draft=false >/dev/null
-          echo "Done; release.yaml should now cascade."
-
-      - name: Create Linear release
-        # Scans commits since the previous tag for MOB-### references and creates
-        # a Linear release with those issues attached. Reads LINEAR_ACCESS_KEY from
-        # the repo's Actions secrets (configured per-pipeline in Linear settings).
-        uses: linear/linear-release-action@v0
-        with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          echo "Done; release.yaml and linear-release.yml should now cascade."

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,43 @@
+name: Linear release tracking
+
+# Records a published GitHub Release in Linear. The single job runs Linear's
+# release action, which scans commits since the previous release tag for
+# `MOB-###` references and creates a matching release under the Android Linear
+# pipeline (Settings → Releases in Linear), with those issues attached.
+#
+# Why `release: published` and not `push: tags`? For tag-push events GitHub runs
+# the workflow file *as it exists on the tagged commit*. Release tags are cut
+# from prerelease branches that can predate this file, so a tag trigger would
+# silently miss them (the same limitation documented in create-release.yml).
+# `release` events run the workflow from the default branch (main) instead, so
+# this file is always used regardless of what the tag points at — while still
+# scanning exactly the released tag's commit range.
+#
+# This fires off the same `release: published` event that create-release.yml
+# emits (via its App-token cascade / "Force published event" step), so it runs
+# automatically whenever a release is published — no manual step required.
+#
+# Requires the LINEAR_ACCESS_KEY repo secret, generated against the Android
+# pipeline in Linear's UI.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  linear-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}  # the released tag's commit
+          fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
+
+      - name: Create Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -13,9 +13,14 @@ name: Linear release tracking
 # this file is always used regardless of what the tag points at — while still
 # scanning exactly the released tag's commit range.
 #
-# This fires off the same `release: published` event that create-release.yml
-# emits (via its App-token cascade / "Force published event" step), so it runs
-# automatically whenever a release is published — no manual step required.
+# This consumes the same `release: published` event that create-release.yml
+# emits, so it runs automatically — BUT only when create-release.yml mints its
+# GitHub App token (RELEASE_BOT_APP_ID set): the default GITHUB_TOKEN does not
+# cascade events to other workflows. In the no-App fallback, an operator's
+# manual re-publish of the release is what drives this workflow (same caveat
+# release.yaml already lives with). create-release.yml's "Force published
+# event" step toggles draft->published, so a single release can emit
+# `published` more than once — see the `concurrency` guard below.
 #
 # Requires the LINEAR_ACCESS_KEY repo secret, generated against the Android
 # pipeline in Linear's UI.
@@ -26,6 +31,15 @@ on:
 
 permissions:
   contents: read
+
+# Serialize runs for a given tag. create-release.yml's create-as-published +
+# "Force published event" toggle can emit `release: published` more than once
+# for the same release; this prevents overlapping Linear syncs for that tag.
+# cancel-in-progress: false so a second event waits for the first to finish
+# rather than aborting it mid-sync.
+concurrency:
+  group: linear-release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
 
 jobs:
   linear-release:
@@ -38,6 +52,6 @@ jobs:
           fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
 
       - name: Create Linear release
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@3b634623620454bac33390451a1dd15ba78e3dc4 # v0.14.4
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}


### PR DESCRIPTION
## What
Move Linear release tracking out of `create-release.yml` into a standalone **`linear-release.yml`** triggered on **`release: published`**. Mirrors the iOS fix (zodl-ios#1855) and replaces the reverted glob change (#2335 → #2336).

## Why
The Linear step was a trailing step of `create-release.yml`, whose automatic `push: tags` path uses the workflow **as it exists on the tagged commit** — so it silently missed tags cut from prerelease branches that predate the file (the limitation already documented in that file's header). "From main" was only reachable via the manual `workflow_dispatch`.

`release: published` runs from **`main`** and fires on the same event `release.yaml` already consumes (emitted by `create-release.yml`'s App-token cascade), so Linear tracking now runs automatically from `main` on every published release — no dependency on the tagged commit, no manual step.

## Changes
- **New** `linear-release.yml`: `on: release: { types: [published] }`, `permissions: contents: read`, checkout pinned to `github.event.release.tag_name` with `fetch-depth: 0`.
- **`create-release.yml`**: remove the embedded Linear step; drop the now-unused `fetch-depth: 0` (only that step needed it — changelog extraction reads the tree, not history); update header notes.

## Review hardening
- `concurrency` guard keyed on the tag — `create-release.yml` emits `published` up to twice (create-as-published + the force-publish toggle), so runs are serialized to avoid overlapping Linear syncs.
- SHA-pinned `linear/linear-release-action` (was floating `@v0`) to match the repo's pin-every-action convention.
- Header qualified: the auto-cascade only happens on the App-token path (`RELEASE_BOT_APP_ID` is configured); the default `GITHUB_TOKEN` doesn't trigger downstream workflows.