### PR TITLE
ci: add workflow_dispatch escape hatch to linear-release

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -28,6 +28,12 @@ name: Linear release tracking
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to track in Linear (e.g. 3.7.0-1986)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -38,17 +44,30 @@ permissions:
 # cancel-in-progress: false so a second event waits for the first to finish
 # rather than aborting it mid-sync.
 concurrency:
-  group: linear-release-${{ github.event.release.tag_name }}
+  group: linear-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
   linear-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve target tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.release.tag_name }}  # the released tag's commit
+          ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
 
       - name: Create Linear release


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to `linear-release.yml` so it can be manually triggered for any tag — same escape hatch iOS already has.

The automatic `release: published` path remains unchanged. The manual path is needed when `create-release.yml` runs without a GitHub App token (`RELEASE_BOT_APP_ID` not set), which prevents the `published` event from cascading to this workflow.

## Test plan
- Merge and manually trigger for 3.7.0: `gh workflow run linear-release.yml -f tag=3.7.0-1986`
- Verify Linear shows a `3.7.0` Android release with MOB tickets attached