### PR TITLE
ci: fix Linear release naming and commit scanning

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -70,7 +70,17 @@ jobs:
           ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0  # full history so the Linear release action sees every commit since the previous tag
 
+      - name: Find previous tag
+        id: prev
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          prev=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | grep -v "^${TAG}$" | head -1)
+          echo "tag=${prev}" >> "$GITHUB_OUTPUT"
+
       - name: Create Linear release
         uses: linear/linear-release-action@3b634623620454bac33390451a1dd15ba78e3dc4 # v0.14.4
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ steps.tag.outputs.tag }}
+          base_ref: ${{ steps.prev.outputs.tag }}


### PR DESCRIPTION
## Summary

The previous PR added `workflow_dispatch` but the Linear action was still producing releases named after commit hashes with 0 issues found.

Root cause: without `version` and `base_ref`, the Linear action can't determine the release name or where to start scanning commits from.

- `version` — names the release `3.7.0-1986` instead of a commit hash
- `base_ref` — auto-detected from the previous git tag; tells the action to scan all commits since that tag

## Test plan
- Merge and re-trigger: `gh workflow run linear-release.yml -f tag=3.7.0-1986`
- Verify Linear shows a properly named `3.7.0-1986` release with MOB tickets attached