### PR TITLE
ci: fix prev-tag selection to pick strictly older tag

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -75,7 +75,8 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          prev=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | grep -v "^${TAG}$" | head -1)
+          prev=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' \
+            | awk -v t="$TAG" 'found{print; exit} $0==t{found=1}')
           echo "tag=${prev}" >> "$GITHUB_OUTPUT"
 
       - name: Create Linear release


### PR DESCRIPTION
## Summary

Fixes the `Find previous tag` step to select the tag immediately below `TAG` in semver order, rather than the globally highest tag excluding `TAG`.

**Bug:** `grep -v "^${TAG}$" | head -1` returns the globally highest tag, which is correct only when `TAG` is the newest. For `workflow_dispatch` with an older tag (e.g. `-f tag=3.6.0-1914` while `3.7.0-1986` exists), it would return `3.7.0-1986` as `base_ref` — a newer tag — producing an empty backwards range and an empty Linear release.

**Fix:** Use `awk` to walk the sorted tag list and take the entry immediately after `TAG`, giving the true predecessor regardless of which tag is dispatched.