### PR TITLE
Fix crash: EncryptedSharedPreferences fails after device-to-device transfer (MOB-1452)

### DIFF
--- a/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
+++ b/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package co.electriccoin.zcash.preference
 
 import android.content.Context
@@ -92,8 +94,39 @@ class EncryptedPreferenceProviderTest {
             assertFalse(text.contains(StringDefaultPreferenceFixture.KEY.key))
         }
 
+    @Test
+    @SmallTest
+    fun graceful_recovery_when_encrypted_prefs_are_corrupted() =
+        runBlocking {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+
+            // Simulate D2D transfer state: prefs file contains a keyset that was encrypted
+            // with a Keystore key from the source device (which doesn't exist on this device).
+            // We reproduce this by writing garbage to the known keyset keys in raw SharedPreferences.
+            // Note: emulator Keystore is software-backed and doesn't faithfully reproduce
+            // hardware key invalidation, so we corrupt the raw data directly instead.
+            context
+                .getSharedPreferences(RECOVERY_FILENAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_KEYSET, "corrupted_keyset_data")
+                .putString(VALUE_KEYSET, "corrupted_keyset_data")
+                .commit()
+
+            // Should NOT throw — fix catches the parse/decryption exception and recreates fresh prefs
+            val restoredProvider =
+                AndroidPreferenceProvider.newEncrypted(context, RECOVERY_FILENAME)
+
+            // Prefs are empty: user will re-enter seed phrase to recover wallet
+            assertFalse(restoredProvider.hasKey(StringDefaultPreferenceFixture.KEY))
+        }
+
     companion object {
-        private val FILENAME = "encrypted_preference_test"
+        private const val FILENAME = "encrypted_preference_test"
+        private const val RECOVERY_FILENAME = "encrypted_preference_recovery_test"
+
+        // Internal keyset key names used by EncryptedSharedPreferences to store Tink keysets
+        private const val KEY_KEYSET = "__androidx_security_crypto_encrypted_prefs_key_keyset__"
+        private const val VALUE_KEYSET = "__androidx_security_crypto_encrypted_prefs_value_keyset__"
 
         private suspend fun new() =
             AndroidPreferenceProvider.newEncrypted(

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.security.KeyStore
 import java.util.concurrent.Executors
 
 /**
@@ -195,6 +197,7 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
             return AndroidPreferenceProvider(sharedPreferences, singleThreadedDispatcher)
         }
 
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override suspend fun newEncrypted(context: Context, filename: String): PreferenceProvider =
         getOrCreate(encryptedCache, filename) {
         /*
@@ -205,24 +208,60 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
 
             val sharedPreferences =
                 withContext(singleThreadedDispatcher) {
-                    val mainKey =
-                        MasterKey
-                            .Builder(context)
-                            .apply {
-                                setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                            }.build()
-
-                    EncryptedSharedPreferences.create(
-                        context,
-                        filename,
-                        mainKey,
-                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-                    )
+                    try {
+                        createEncryptedSharedPreferences(context, filename)
+                    } catch (e: Exception) {
+                        // Android Keystore keys are hardware-bound and not transferred during device-to-device
+                        // migration, so the encrypted prefs file arrives on the new device but cannot be
+                        // decrypted. Wipe the orphaned file and recreate fresh.
+                        deleteCorruptedEncryptedPreferences(context, filename)
+                        createEncryptedSharedPreferences(context, filename)
+                    }
                 }
 
             return AndroidPreferenceProvider(sharedPreferences, singleThreadedDispatcher)
         }
+
+    private fun createEncryptedSharedPreferences(
+        context: Context,
+        filename: String
+    ): SharedPreferences {
+        val mainKey =
+            MasterKey
+                .Builder(context)
+                .apply { setKeyScheme(MasterKey.KeyScheme.AES256_GCM) }
+                .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            filename,
+            mainKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    private fun deleteCorruptedEncryptedPreferences(
+        context: Context,
+        filename: String
+    ) {
+        runCatching {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        }
+        // Clear in-memory SharedPreferences cache so the retry gets a clean instance.
+        // Without this, Android returns the cached (corrupted) instance even after file deletion.
+        runCatching {
+            context
+                .getSharedPreferences(filename, Context.MODE_PRIVATE)
+                .edit()
+                .clear()
+                .commit()
+        }
+        runCatching {
+            File(context.filesDir.parent, "shared_prefs/$filename.xml").delete()
+        }
+    }
 
     private suspend inline fun getOrCreate(
         map: MutableMap<String, PreferenceProvider>,


### PR DESCRIPTION
## Problem

24 affected users (41% increase) on Android 16 experience a crash loop on every app launch:

```
javax.crypto.AEADBadTagException
  at EncryptedSharedPreferences.create(...)
```

**Root cause:** Device-to-device transfer copies the `EncryptedSharedPreferences` file but not the Android Keystore key used to decrypt it. On the new device, the app tries to decrypt the file with a non-existent key → `AEADBadTagException` → crash.

The key is NOT bound to biometric authentication — the issue is purely the Keystore being hardware-bound and non-transferable.

## Fix

Wrap `EncryptedSharedPreferences.create()` in a try/catch. On failure:
1. Delete the corrupted prefs file
2. Delete the stale Android Keystore master key entry
3. Recreate fresh

The user will need to re-enter their seed phrase once, after which everything is restored (address book and metadata keys are re-derived from seed, so no permanent data loss for those).

## Impact

- Voting recovery state and migration plan state are lost (not seed-derivable)
- Address book and transaction metadata are recoverable after seed re-entry
- No wallet funds affected

## Files Changed

- `preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt`