### PR TITLE
Release 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [3.7.1 (1992)] - 2026-06-29
+
+### Fixed:
+- We fixed an issue impacting BTC swaps and payments.
+
 ## [3.7.0 (1986)] - 2026-06-23
 
 ### Added:

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.7.1 (1992)] - 2026-06-29
+
+### Fixed:
+- We fixed an issue impacting BTC swaps and payments.
+
 ## [3.7.0 (1986)] - 2026-06-23
 
 ### Added:

--- a/docs/whatsNew/WHATS_NEW_ES.md
+++ b/docs/whatsNew/WHATS_NEW_ES.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.7.1 (1992)] - 2026-06-29
+
+### Corregido:
+- Solucionamos un problema que afectaba a los swaps y pagos de BTC.
+
 ## [3.7.0 (1986)] - 2026-06-23
 
 ### Añadido:

--- a/fastlane/metadata/android/en-US/changelogs/1992.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1992.txt
@@ -1,0 +1,2 @@
+Fixed:
+- We fixed an issue impacting BTC swaps and payments.

--- a/fastlane/metadata/android/es/changelogs/1992.txt
+++ b/fastlane/metadata/android/es/changelogs/1992.txt
@@ -1,0 +1,2 @@
+Corregido:
+- Solucionamos un problema que afectaba a los swaps y pagos de BTC.

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ NDK_DEBUG_SYMBOL_LEVEL=symbol_table
 # VERSION_CODE is effectively ignored. VERSION_NAME is suffixed with the version code.
 # If not using automated Google Play deployment, then these serve as the actual version numbers.
 ZCASH_VERSION_CODE=1
-ZCASH_VERSION_NAME=3.7.0
+ZCASH_VERSION_NAME=3.7.1
 
 # Set these fields, as you need them (e.g. with values "Zcash X" and "co.electriccoin.zcash.x")
 # to distinguish a different release build that can be installed alongside the official version

--- a/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
+++ b/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package co.electriccoin.zcash.preference
 
 import android.content.Context
@@ -92,8 +94,39 @@ class EncryptedPreferenceProviderTest {
             assertFalse(text.contains(StringDefaultPreferenceFixture.KEY.key))
         }
 
+    @Test
+    @SmallTest
+    fun graceful_recovery_when_encrypted_prefs_are_corrupted() =
+        runBlocking {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+
+            // Simulate D2D transfer state: prefs file contains a keyset that was encrypted
+            // with a Keystore key from the source device (which doesn't exist on this device).
+            // We reproduce this by writing garbage to the known keyset keys in raw SharedPreferences.
+            // Note: emulator Keystore is software-backed and doesn't faithfully reproduce
+            // hardware key invalidation, so we corrupt the raw data directly instead.
+            context
+                .getSharedPreferences(RECOVERY_FILENAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_KEYSET, "corrupted_keyset_data")
+                .putString(VALUE_KEYSET, "corrupted_keyset_data")
+                .commit()
+
+            // Should NOT throw — fix catches the parse/decryption exception and recreates fresh prefs
+            val restoredProvider =
+                AndroidPreferenceProvider.newEncrypted(context, RECOVERY_FILENAME)
+
+            // Prefs are empty: user will re-enter seed phrase to recover wallet
+            assertFalse(restoredProvider.hasKey(StringDefaultPreferenceFixture.KEY))
+        }
+
     companion object {
-        private val FILENAME = "encrypted_preference_test"
+        private const val FILENAME = "encrypted_preference_test"
+        private const val RECOVERY_FILENAME = "encrypted_preference_recovery_test"
+
+        // Internal keyset key names used by EncryptedSharedPreferences to store Tink keysets
+        private const val KEY_KEYSET = "__androidx_security_crypto_encrypted_prefs_key_keyset__"
+        private const val VALUE_KEYSET = "__androidx_security_crypto_encrypted_prefs_value_keyset__"
 
         private suspend fun new() =
             AndroidPreferenceProvider.newEncrypted(

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.security.KeyStore
 import java.util.concurrent.Executors
 
 /**
@@ -195,6 +197,7 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
             return AndroidPreferenceProvider(sharedPreferences, singleThreadedDispatcher)
         }
 
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override suspend fun newEncrypted(context: Context, filename: String): PreferenceProvider =
         getOrCreate(encryptedCache, filename) {
         /*
@@ -205,24 +208,60 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
 
             val sharedPreferences =
                 withContext(singleThreadedDispatcher) {
-                    val mainKey =
-                        MasterKey
-                            .Builder(context)
-                            .apply {
-                                setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                            }.build()
-
-                    EncryptedSharedPreferences.create(
-                        context,
-                        filename,
-                        mainKey,
-                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-                    )
+                    try {
+                        createEncryptedSharedPreferences(context, filename)
+                    } catch (e: Exception) {
+                        // Android Keystore keys are hardware-bound and not transferred during device-to-device
+                        // migration, so the encrypted prefs file arrives on the new device but cannot be
+                        // decrypted. Wipe the orphaned file and recreate fresh.
+                        deleteCorruptedEncryptedPreferences(context, filename)
+                        createEncryptedSharedPreferences(context, filename)
+                    }
                 }
 
             return AndroidPreferenceProvider(sharedPreferences, singleThreadedDispatcher)
         }
+
+    private fun createEncryptedSharedPreferences(
+        context: Context,
+        filename: String
+    ): SharedPreferences {
+        val mainKey =
+            MasterKey
+                .Builder(context)
+                .apply { setKeyScheme(MasterKey.KeyScheme.AES256_GCM) }
+                .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            filename,
+            mainKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    private fun deleteCorruptedEncryptedPreferences(
+        context: Context,
+        filename: String
+    ) {
+        runCatching {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        }
+        // Clear in-memory SharedPreferences cache so the retry gets a clean instance.
+        // Without this, Android returns the cached (corrupted) instance even after file deletion.
+        runCatching {
+            context
+                .getSharedPreferences(filename, Context.MODE_PRIVATE)
+                .edit()
+                .clear()
+                .commit()
+        }
+        runCatching {
+            File(context.filesDir.parent, "shared_prefs/$filename.xml").delete()
+        }
+    }
 
     private suspend inline fun getOrCreate(
         map: MutableMap<String, PreferenceProvider>,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/NearSwapDataSourceImpl.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/NearSwapDataSourceImpl.kt
@@ -184,10 +184,10 @@ class NearSwapDataSourceImpl(
     override suspend fun checkSwapStatus(depositAddress: String, supportedTokens: List<SwapAsset>): SwapQuoteStatus {
         val response = this.nearApiProvider.checkSwapStatus(depositAddress)
         val originAsset =
-            supportedTokens.find { it.assetId == response.quoteResponse.quoteRequest.originAsset }
+            findAssetByEchoedId(supportedTokens, response.quoteResponse.quoteRequest.originAsset)
                 ?: throw TokenNotFoundException(response.quoteResponse.quoteRequest.originAsset)
         val destinationAsset =
-            supportedTokens.find { it.assetId == response.quoteResponse.quoteRequest.destinationAsset }
+            findAssetByEchoedId(supportedTokens, response.quoteResponse.quoteRequest.destinationAsset)
                 ?: throw TokenNotFoundException(response.quoteResponse.quoteRequest.destinationAsset)
         log("checkSwapStatus $depositAddress")
         return NearSwapQuoteStatus(
@@ -199,6 +199,15 @@ class NearSwapDataSourceImpl(
             refundAddress = getRefundAddress(response.quoteResponse, originAsset),
         )
     }
+
+    // The 1Click API normalises asset IDs for routing (e.g. "nep141:btc.omft.near" →
+    // "1cs_v1:btc:native:coin"). Try an exact match first; fall back to extracting the ticker
+    // from the normalised "1cs_v1:<ticker>:..." format and matching by tokenTicker.
+    private fun findAssetByEchoedId(supportedTokens: List<SwapAsset>, echoedId: String): SwapAsset? =
+        supportedTokens.find { it.assetId == echoedId }
+            ?: echoedId.split(":").getOrNull(1)?.let { ticker ->
+                supportedTokens.find { it.tokenTicker.equals(ticker, ignoreCase = true) }
+            }
 
     private suspend fun getDepositAddress(response: QuoteResponseDto, originAsset: SwapAsset): SwapAddress {
         val address = response.quote.depositAddress

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/near/NearSwapQuote.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/near/NearSwapQuote.kt
@@ -39,10 +39,9 @@ data class NearSwapQuote(
             "Swap quote asset mismatch: requested originAsset=${originAsset.assetId} " +
                 "but server returned ${response.quoteRequest.originAsset}"
         }
-        require(response.quoteRequest.destinationAsset == destinationAsset.assetId) {
-            "Swap quote asset mismatch: requested destinationAsset=${destinationAsset.assetId} " +
-                "but server returned ${response.quoteRequest.destinationAsset}"
-        }
+        // The 1Click API normalises the destination asset ID for optimal routing (e.g. it may
+        // rewrite "nep141:btc.omft.near" → "1cs_v1:btc:native:coin"). The echoed ID may therefore
+        // differ from the one the app requested; do not reject on this difference.
         // Guards zecExchangeRate (= amountInUsd / amountInFormatted) and the fee math below it against a
         // divide-by-zero. A quote with a non-positive input amount is invalid anyway; fail closed with a
         // clear message rather than letting an ArithmeticException surface from the property initializers.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/near/NearSwapQuote.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/near/NearSwapQuote.kt
@@ -35,13 +35,6 @@ data class NearSwapQuote(
     val expectedSlippageToleranceBps: Int? = null,
 ) : SwapQuote {
     init {
-        require(response.quoteRequest.originAsset == originAsset.assetId) {
-            "Swap quote asset mismatch: requested originAsset=${originAsset.assetId} " +
-                "but server returned ${response.quoteRequest.originAsset}"
-        }
-        // The 1Click API normalises the destination asset ID for optimal routing (e.g. it may
-        // rewrite "nep141:btc.omft.near" → "1cs_v1:btc:native:coin"). The echoed ID may therefore
-        // differ from the one the app requested; do not reject on this difference.
         // Guards zecExchangeRate (= amountInUsd / amountInFormatted) and the fee math below it against a
         // divide-by-zero. A quote with a non-positive input amount is invalid anyway; fail closed with a
         // clear message rather than letting an ArithmeticException surface from the property initializers.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/SwapRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/SwapRepository.kt
@@ -208,7 +208,7 @@ class SwapRepositoryImpl(
                         )
                     quote.update { SwapQuoteData.Success(quote = result) }
                 } catch (e: Exception) {
-                    quote.update { SwapQuoteData.Error(EXACT_OUTPUT, e) }
+                    quote.update { SwapQuoteData.Error(mode, e) }
                 }
             }
     }


### PR DESCRIPTION
Closes #2353

## Changes

## [3.7.1 (1992)] - 2026-06-29

### Fixed:
- We fixed an issue impacting BTC swaps and payments.

## [3.7.0 (1986)] - 2026-06-23

### Added:
- When your server selection is set to Automatic, we now broadcast your transactions across several servers at once, so they're more likely to send reliably. You can change this in Advanced Settings.

### Changed:
- We made a range of security and privacy improvements.

### Fixed:
- We fixed an issue with disconnecting a Keystone hardware wallet.
- We fixed a couple of transaction status display issues.

### Added:
- Currency Conversion now supports multiple fiat currencies. You can pick which currency your balances and payment amounts are shown in from the Currency Conversion settings and opt-in screens.
- When opening Send or Request while the selected currency's exchange rate can't be fetched, a bottom sheet now explains the issue and offers to switch to USD or continue entering amounts in ZEC.

### Fixed:
- Network request/response bodies and voting diagnostics are no longer written to logs in release builds, preventing sensitive data (recipient/refund addresses, amounts, transaction hashes) from leaking to logcat, bug reports, and crash dumps. Credential headers are also redacted from logs.
- Crash reporting (Firebase Crashlytics) collection is now off by default and is only enabled after the user opts in, so no crash data can be sent before consent.
- On the wallet-backup screen the recovery phrase is now masked until the biometric reveal, so the plaintext words can no longer be read from the accessibility/view tree behind the visual blur. While hidden, each word is announced to screen readers as a single descriptive label instead of spelling out the mask characters.
- The cross-chain swap slippage guarantee is now always enforced: the swap provider's minimum-amount bounds are treated as required, so a malicious or tampered response can no longer skip the slippage check by omitting them.
- Swap quotes rejected by the amount-consistency safety check are now reported to monitoring (without any amounts), so a future swap-provider format change surfaces as an observable signal instead of silently blocking swaps.
- Exchange rates are no longer requested over a direct (non-Tor) connection. When Tor Protection is disabled the request to the rate provider is now blocked instead of falling back to clearnet, preventing the user's IP address and request timing from being exposed.

## [3.6.0 (1914)] - 2026-06-16