### PR TITLE
Orchard -> Ironwood migration: app dependency wiring

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/DateSourceModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/DateSourceModule.kt
@@ -6,6 +6,8 @@ import co.electriccoin.zcash.ui.common.datasource.ExchangeRateDataSource
 import co.electriccoin.zcash.ui.common.datasource.ExchangeRateDataSourceImpl
 import co.electriccoin.zcash.ui.common.datasource.MessageAvailabilityDataSource
 import co.electriccoin.zcash.ui.common.datasource.MessageAvailabilityDataSourceImpl
+import co.electriccoin.zcash.ui.common.datasource.MigrationDataSource
+import co.electriccoin.zcash.ui.common.datasource.MigrationDataSourceImpl
 import co.electriccoin.zcash.ui.common.datasource.NearSwapDataSourceImpl
 import co.electriccoin.zcash.ui.common.datasource.ProposalDataSource
 import co.electriccoin.zcash.ui.common.datasource.ProposalDataSourceImpl
@@ -30,4 +32,5 @@ val dataSourceModule =
         singleOf(::WalletSnapshotDataSourceImpl) bind WalletSnapshotDataSource::class
         singleOf(::NearSwapDataSourceImpl) bind SwapDataSource::class
         singleOf(::ExchangeRateDataSourceImpl) bind ExchangeRateDataSource::class
+        singleOf(::MigrationDataSourceImpl) bind MigrationDataSource::class
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/RepositoryModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/RepositoryModule.kt
@@ -18,6 +18,8 @@ import co.electriccoin.zcash.ui.common.repository.HomeMessageCacheRepository
 import co.electriccoin.zcash.ui.common.repository.HomeMessageCacheRepositoryImpl
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepositoryImpl
+import co.electriccoin.zcash.ui.common.repository.MigrationRepository
+import co.electriccoin.zcash.ui.common.repository.MigrationRepositoryImpl
 import co.electriccoin.zcash.ui.common.repository.SwapRepository
 import co.electriccoin.zcash.ui.common.repository.SwapRepositoryImpl
 import co.electriccoin.zcash.ui.common.repository.TransactionFilterRepository
@@ -77,4 +79,5 @@ val repositoryModule =
         }
         singleOf(::VotingKeystoneRepositoryImpl) bind VotingKeystoneRepository::class
         singleOf(::VotingSessionStoreImpl) bind VotingSessionStore::class
+        singleOf(::MigrationRepositoryImpl) bind MigrationRepository::class
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/UseCaseModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/UseCaseModule.kt
@@ -7,6 +7,8 @@ import co.electriccoin.zcash.ui.common.usecase.AuthorizeVotingSubmissionUseCase
 import co.electriccoin.zcash.ui.common.usecase.CancelProposalFlowUseCase
 import co.electriccoin.zcash.ui.common.usecase.CancelSwapQuoteUseCase
 import co.electriccoin.zcash.ui.common.usecase.CancelSwapUseCase
+import co.electriccoin.zcash.ui.common.usecase.ConfirmMigrationScheduleUseCase
+import co.electriccoin.zcash.ui.common.usecase.ConfirmNoteSplitUseCase
 import co.electriccoin.zcash.ui.common.usecase.ConfirmResyncUseCase
 import co.electriccoin.zcash.ui.common.usecase.CopyToClipboardUseCase
 import co.electriccoin.zcash.ui.common.usecase.CreateFlexaTransactionUseCase
@@ -22,6 +24,7 @@ import co.electriccoin.zcash.ui.common.usecase.DeriveKeystoneAccountUnifiedAddre
 import co.electriccoin.zcash.ui.common.usecase.DisconnectUseCase
 import co.electriccoin.zcash.ui.common.usecase.EnsureSwapAssetsLoadedUseCase
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
+import co.electriccoin.zcash.ui.common.usecase.ExecuteNextMigrationTransferUseCase
 import co.electriccoin.zcash.ui.common.usecase.ExportTaxUseCase
 import co.electriccoin.zcash.ui.common.usecase.FilterSwapAssetsUseCase
 import co.electriccoin.zcash.ui.common.usecase.FilterSwapBlockchainsUseCase
@@ -89,6 +92,7 @@ import co.electriccoin.zcash.ui.common.usecase.ObserveABContactPickedUseCase
 import co.electriccoin.zcash.ui.common.usecase.ObserveClearSendUseCase
 import co.electriccoin.zcash.ui.common.usecase.ObserveContactByAddressUseCase
 import co.electriccoin.zcash.ui.common.usecase.ObserveFastestServersUseCase
+import co.electriccoin.zcash.ui.common.usecase.ObserveMigrationStateUseCase
 import co.electriccoin.zcash.ui.common.usecase.ObserveProposalUseCase
 import co.electriccoin.zcash.ui.common.usecase.ObserveSelectedWalletAccountUseCase
 import co.electriccoin.zcash.ui.common.usecase.ObserveTransactionSubmitStateUseCase
@@ -109,6 +113,7 @@ import co.electriccoin.zcash.ui.common.usecase.PreselectSwapAssetUseCase
 import co.electriccoin.zcash.ui.common.usecase.ProcessSwapTransactionUseCase
 import co.electriccoin.zcash.ui.common.usecase.RefreshActiveVotingSessionUseCase
 import co.electriccoin.zcash.ui.common.usecase.RefreshFastestServersUseCase
+import co.electriccoin.zcash.ui.common.usecase.RefreshMigrationUseCase
 import co.electriccoin.zcash.ui.common.usecase.RefreshVotingRoundsUseCase
 import co.electriccoin.zcash.ui.common.usecase.RemindWalletBackupLaterUseCase
 import co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase
@@ -116,6 +121,7 @@ import co.electriccoin.zcash.ui.common.usecase.RescanBlockchainUseCase
 import co.electriccoin.zcash.ui.common.usecase.RescanQrUseCase
 import co.electriccoin.zcash.ui.common.usecase.ResetTransactionFiltersUseCase
 import co.electriccoin.zcash.ui.common.usecase.ResolveVotingRoundSessionUseCase
+import co.electriccoin.zcash.ui.common.usecase.RestartMigrationUseCase
 import co.electriccoin.zcash.ui.common.usecase.RestoreWalletUseCase
 import co.electriccoin.zcash.ui.common.usecase.ResyncErrorMapperUseCase
 import co.electriccoin.zcash.ui.common.usecase.SaveABContactUseCase
@@ -314,4 +320,10 @@ val useCaseModule =
         factoryOf(::SwapSupportMapper)
         factoryOf(::GetAutomaticEndpointUseCase)
         factoryOf(::IsServerAutomaticUseCase)
+        factoryOf(::ObserveMigrationStateUseCase)
+        factoryOf(::RefreshMigrationUseCase)
+        factoryOf(::ConfirmNoteSplitUseCase)
+        factoryOf(::ConfirmMigrationScheduleUseCase)
+        factoryOf(::ExecuteNextMigrationTransferUseCase)
+        factoryOf(::RestartMigrationUseCase)
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/ViewModelModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/ViewModelModule.kt
@@ -44,6 +44,7 @@ import co.electriccoin.zcash.ui.screen.hotfix.ephemeral.EphemeralHotfixVM
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsVM
 import co.electriccoin.zcash.ui.screen.integrations.IntegrationsVM
 import co.electriccoin.zcash.ui.screen.keepopen.KeepOpenVM
+import co.electriccoin.zcash.ui.screen.migration.MigrationViewModel
 import co.electriccoin.zcash.ui.screen.more.MoreVM
 import co.electriccoin.zcash.ui.screen.pay.PayVM
 import co.electriccoin.zcash.ui.screen.qrcode.QrCodeVM
@@ -211,4 +212,5 @@ val viewModelModule =
         viewModelOf(::KeystoneEstimationVM)
         viewModelOf(::KeystoneHeightVM)
         viewModelOf(::KeepOpenVM)
+        viewModelOf(::MigrationViewModel)
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MigrationDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MigrationDataSource.kt
@@ -1,0 +1,108 @@
+package co.electriccoin.zcash.ui.common.datasource
+
+import cash.z.ecc.android.sdk.AttentionReason
+import cash.z.ecc.android.sdk.MigrationProgress
+import cash.z.ecc.android.sdk.MigrationSchedule
+import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.NetworkPrivacyOptions
+import cash.z.ecc.android.sdk.NoteSplitProposal
+import cash.z.ecc.android.sdk.OrchardMigrationSdk
+import cash.z.ecc.android.sdk.TransferResult
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+// Re-export SDK sealed types so the rest of the app imports from one place.
+typealias SdkMigrationState = MigrationState
+typealias SdkMigrationProgress = MigrationProgress
+typealias SdkMigrationSchedule = MigrationSchedule
+typealias SdkNoteSplitProposal = NoteSplitProposal
+typealias SdkTransferResult = TransferResult
+typealias SdkAttentionReason = AttentionReason
+typealias SdkNetworkPrivacyOptions = NetworkPrivacyOptions
+
+interface MigrationDataSource {
+    suspend fun getMigrationState(): MigrationState
+
+    suspend fun getMigrationProgress(): MigrationProgress?
+
+    suspend fun isSyncRequiredBeforeNextTransfer(): Boolean
+
+    suspend fun hasOverdueTransfers(): Boolean
+
+    suspend fun hasInvalidTransfers(): Boolean
+
+    suspend fun isNoteSplitNeeded(): Boolean
+
+    suspend fun prepareNoteSplit(): NoteSplitProposal
+
+    suspend fun submitNoteSplit(proposal: NoteSplitProposal): TransferResult
+
+    suspend fun proposeMigrationTransfers(): MigrationSchedule
+
+    suspend fun signAndStoreMigrationSchedule(schedule: MigrationSchedule)
+
+    suspend fun executeNextPendingTransfer(options: NetworkPrivacyOptions): TransferResult?
+
+    suspend fun restartCurrentMigrationStep(): MigrationSchedule
+
+    fun initializePostUpgrade()
+}
+
+class MigrationDataSourceImpl(
+    private val synchronizerProvider: SynchronizerProvider,
+) : MigrationDataSource {
+    private suspend fun sdk(): OrchardMigrationSdk =
+        // TODO [MOB-IRONWOOD]: expose orchardMigration accessor on Synchronizer once the SDK
+        // property is wired in SdkSynchronizer. Replace with: synchronizerProvider.synchronizer.orchardMigration
+        error("OrchardMigrationSdk not yet accessible from Synchronizer — wire after SDK integration")
+
+    override suspend fun getMigrationState(): MigrationState =
+        withContext(Dispatchers.IO) { sdk().getMigrationState() }
+
+    override suspend fun getMigrationProgress(): MigrationProgress? =
+        withContext(Dispatchers.IO) { sdk().getMigrationProgress() }
+
+    override suspend fun isSyncRequiredBeforeNextTransfer(): Boolean =
+        withContext(Dispatchers.IO) { sdk().isSyncRequiredBeforeNextTransfer() }
+
+    override suspend fun hasOverdueTransfers(): Boolean =
+        withContext(Dispatchers.IO) { sdk().hasOverdueTransfers() }
+
+    override suspend fun hasInvalidTransfers(): Boolean =
+        withContext(Dispatchers.IO) { sdk().hasInvalidTransfers() }
+
+    override suspend fun isNoteSplitNeeded(): Boolean =
+        withContext(Dispatchers.IO) { sdk().isNoteSplitNeeded() }
+
+    override suspend fun prepareNoteSplit(): NoteSplitProposal =
+        withContext(Dispatchers.IO) { sdk().prepareNoteSplit() }
+
+    override suspend fun submitNoteSplit(proposal: NoteSplitProposal): TransferResult =
+        withContext(Dispatchers.IO) { sdk().submitNoteSplit(proposal) }
+
+    override suspend fun proposeMigrationTransfers(): MigrationSchedule =
+        withContext(Dispatchers.IO) { sdk().proposeMigrationTransfers() }
+
+    override suspend fun signAndStoreMigrationSchedule(schedule: MigrationSchedule) =
+        withContext(Dispatchers.IO) {
+            // SDK signs internally — no spending key needed here.
+            // SECURITY: the SDK is responsible for key management during signing.
+            sdk().signAndStoreMigrationSchedule(schedule)
+        }
+
+    override suspend fun executeNextPendingTransfer(options: NetworkPrivacyOptions): TransferResult? =
+        withContext(Dispatchers.IO) {
+            // SECURITY: isSyncRequiredBeforeNextTransfer() is checked in MigrationRepository
+            // before this call. Do not call here to avoid double-checking in wrong order.
+            sdk().executeNextPendingTransfer(options)
+        }
+
+    override suspend fun restartCurrentMigrationStep(): MigrationSchedule =
+        withContext(Dispatchers.IO) { sdk().restartCurrentMigrationStep() }
+
+    override fun initializePostUpgrade() {
+        // TODO [MOB-IRONWOOD]: call after Ironwood network upgrade detection in app lifecycle.
+        // Obtain sdk() synchronously or wire via a lifecycle-aware observer.
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MigrationDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/MigrationDataSource.kt
@@ -8,6 +8,7 @@ import cash.z.ecc.android.sdk.NetworkPrivacyOptions
 import cash.z.ecc.android.sdk.NoteSplitProposal
 import cash.z.ecc.android.sdk.OrchardMigrationSdk
 import cash.z.ecc.android.sdk.TransferResult
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -22,6 +23,13 @@ typealias SdkAttentionReason = AttentionReason
 typealias SdkNetworkPrivacyOptions = NetworkPrivacyOptions
 
 interface MigrationDataSource {
+    suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan
+
     suspend fun getMigrationState(): MigrationState
 
     suspend fun getMigrationProgress(): MigrationProgress?
@@ -56,6 +64,21 @@ class MigrationDataSourceImpl(
         // TODO [MOB-IRONWOOD]: expose orchardMigration accessor on Synchronizer once the SDK
         // property is wired in SdkSynchronizer. Replace with: synchronizerProvider.synchronizer.orchardMigration
         error("OrchardMigrationSdk not yet accessible from Synchronizer — wire after SDK integration")
+
+    override suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan =
+        withContext(Dispatchers.IO) {
+            synchronizerProvider.getSynchronizer().planOrchardDenominationSplit(
+                totalInputZatoshi = totalInputZatoshi,
+                prepFeeZatoshi = prepFeeZatoshi,
+                migrationFeeZatoshi = migrationFeeZatoshi,
+                minimumOutputZatoshi = minimumOutputZatoshi
+            )
+        }
 
     override suspend fun getMigrationState(): MigrationState =
         withContext(Dispatchers.IO) { sdk().getMigrationState() }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationRepository.kt
@@ -3,11 +3,11 @@ package co.electriccoin.zcash.ui.common.repository
 import cash.z.ecc.android.sdk.AttentionReason
 import cash.z.ecc.android.sdk.MigrationProgress
 import cash.z.ecc.android.sdk.MigrationSchedule
-import cash.z.ecc.android.sdk.MigrationState
 import cash.z.ecc.android.sdk.NetworkPrivacyOptions
 import cash.z.ecc.android.sdk.NoteSplitProposal
 import cash.z.ecc.android.sdk.TransferResult
 import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.datasource.MigrationDataSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -64,8 +64,15 @@ interface MigrationRepository {
     suspend fun restart()
 }
 
+private object DenominationPlanDefaults {
+    const val PREP_FEE_ZATOSHI = 10_000L
+    const val MIGRATION_FEE_ZATOSHI = 10_000L
+    const val MINIMUM_OUTPUT_ZATOSHI = 50_000L
+}
+
 class MigrationRepositoryImpl(
     private val migrationDataSource: MigrationDataSource,
+    private val accountDataSource: AccountDataSource,
 ) : MigrationRepository {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -75,41 +82,40 @@ class MigrationRepositoryImpl(
     private val _migrationState = MutableStateFlow<MigrationUiState>(MigrationUiState.Loading)
     override val migrationState: StateFlow<MigrationUiState> = _migrationState.asStateFlow()
 
+    // Real SDK call (cash.z.ecc.android.sdk.Synchronizer.planOrchardDenominationSplit, PR #2008).
+    // Everything beyond this — proposal building/broadcast/status derivation — is still blocked
+    // on the unstable nu6.3 Ironwood crate surface; see ironwood-migration-execution.md.
     override fun refresh() {
         scope.launch {
             runCatching {
-                val sdkState = migrationDataSource.getMigrationState()
+                val orchardAvailable =
+                    accountDataSource
+                        .getSelectedAccount()
+                        .unified.balance.available.value
+
+                if (orchardAvailable <= 0L) {
+                    _migrationState.value = MigrationUiState.NotStarted
+                    return@runCatching
+                }
+
+                val plan =
+                    migrationDataSource.planOrchardDenominationSplit(
+                        totalInputZatoshi = orchardAvailable,
+                        prepFeeZatoshi = DenominationPlanDefaults.PREP_FEE_ZATOSHI,
+                        migrationFeeZatoshi = DenominationPlanDefaults.MIGRATION_FEE_ZATOSHI,
+                        minimumOutputZatoshi = DenominationPlanDefaults.MINIMUM_OUTPUT_ZATOSHI
+                    )
+
                 _migrationState.value =
-                    when (sdkState) {
-                        is MigrationState.NotStarted -> {
-                            if (migrationDataSource.isNoteSplitNeeded()) {
-                                val proposal = migrationDataSource.prepareNoteSplit()
-                                MigrationUiState.AwaitingNoteSplitConfirm(proposal)
-                            } else {
-                                MigrationUiState.NotStarted
-                            }
-                        }
-
-                        is MigrationState.SplitPendingConfirmation -> {
-                            MigrationUiState.AwaitingSplitConfirmation
-                        }
-
-                        is MigrationState.ReadyToPropose -> {
-                            val schedule = migrationDataSource.proposeMigrationTransfers()
-                            MigrationUiState.ProposalReview(schedule)
-                        }
-
-                        is MigrationState.InProgress -> {
-                            MigrationUiState.InProgress(sdkState.progress)
-                        }
-
-                        is MigrationState.RequiresAttention -> {
-                            MigrationUiState.RequiresAttention(sdkState.reason)
-                        }
-
-                        is MigrationState.Complete -> {
-                            MigrationUiState.Complete
-                        }
+                    if (plan.migrationOutputs.isEmpty()) {
+                        MigrationUiState.NotStarted
+                    } else {
+                        MigrationUiState.AwaitingNoteSplitConfirm(
+                            NoteSplitProposal(
+                                outputNotes = plan.migrationOutputs,
+                                fee = plan.prepFeeZatoshi
+                            )
+                        )
                     }
             }.onFailure { e ->
                 Twig.error(e) { "MigrationRepository.refresh failed" }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationRepository.kt
@@ -1,0 +1,233 @@
+package co.electriccoin.zcash.ui.common.repository
+
+import cash.z.ecc.android.sdk.AttentionReason
+import cash.z.ecc.android.sdk.MigrationProgress
+import cash.z.ecc.android.sdk.MigrationSchedule
+import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.NetworkPrivacyOptions
+import cash.z.ecc.android.sdk.NoteSplitProposal
+import cash.z.ecc.android.sdk.TransferResult
+import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.common.datasource.MigrationDataSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
+
+// UI-layer migration states — wraps SDK sealed types for Compose consumption.
+sealed interface MigrationUiState {
+    data object Loading : MigrationUiState
+
+    data object NotStarted : MigrationUiState
+
+    data class AwaitingNoteSplitConfirm(
+        val proposal: NoteSplitProposal
+    ) : MigrationUiState
+
+    data object AwaitingSplitConfirmation : MigrationUiState
+
+    data class ProposalReview(
+        val schedule: MigrationSchedule
+    ) : MigrationUiState
+
+    data class InProgress(
+        val progress: MigrationProgress
+    ) : MigrationUiState
+
+    data class RequiresAttention(
+        val reason: AttentionReason
+    ) : MigrationUiState
+
+    data object Complete : MigrationUiState
+
+    data class Error(
+        val message: String
+    ) : MigrationUiState
+}
+
+interface MigrationRepository {
+    val migrationState: StateFlow<MigrationUiState>
+
+    fun refresh()
+
+    suspend fun confirmNoteSplit(proposal: NoteSplitProposal)
+
+    suspend fun confirmSchedule(schedule: MigrationSchedule)
+
+    suspend fun executeNextTransfer(useTor: Boolean)
+
+    suspend fun restart()
+}
+
+class MigrationRepositoryImpl(
+    private val migrationDataSource: MigrationDataSource,
+) : MigrationRepository {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Non-reentrant: executeNextTransfer must never overlap confirmSchedule or itself.
+    private val executionMutex = Mutex()
+
+    private val _migrationState = MutableStateFlow<MigrationUiState>(MigrationUiState.Loading)
+    override val migrationState: StateFlow<MigrationUiState> = _migrationState.asStateFlow()
+
+    override fun refresh() {
+        scope.launch {
+            runCatching {
+                val sdkState = migrationDataSource.getMigrationState()
+                _migrationState.value =
+                    when (sdkState) {
+                        is MigrationState.NotStarted -> {
+                            if (migrationDataSource.isNoteSplitNeeded()) {
+                                val proposal = migrationDataSource.prepareNoteSplit()
+                                MigrationUiState.AwaitingNoteSplitConfirm(proposal)
+                            } else {
+                                MigrationUiState.NotStarted
+                            }
+                        }
+
+                        is MigrationState.SplitPendingConfirmation -> {
+                            MigrationUiState.AwaitingSplitConfirmation
+                        }
+
+                        is MigrationState.ReadyToPropose -> {
+                            val schedule = migrationDataSource.proposeMigrationTransfers()
+                            MigrationUiState.ProposalReview(schedule)
+                        }
+
+                        is MigrationState.InProgress -> {
+                            MigrationUiState.InProgress(sdkState.progress)
+                        }
+
+                        is MigrationState.RequiresAttention -> {
+                            MigrationUiState.RequiresAttention(sdkState.reason)
+                        }
+
+                        is MigrationState.Complete -> {
+                            MigrationUiState.Complete
+                        }
+                    }
+            }.onFailure { e ->
+                Twig.error(e) { "MigrationRepository.refresh failed" }
+                _migrationState.value = MigrationUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    override suspend fun confirmNoteSplit(proposal: NoteSplitProposal): Unit =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                _migrationState.value = MigrationUiState.AwaitingSplitConfirmation
+                when (val result = migrationDataSource.submitNoteSplit(proposal)) {
+                    is TransferResult.Success -> {
+                        refresh()
+                    }
+
+                    is TransferResult.NetworkError -> {
+                        _migrationState.value = MigrationUiState.Error("Network error — try again")
+                    }
+
+                    is TransferResult.InvalidNote -> {
+                        _migrationState.value = MigrationUiState.Error("Note split failed: invalid note")
+                    }
+
+                    is TransferResult.Expired -> {
+                        _migrationState.value = MigrationUiState.Error("Note split expired — please retry")
+                    }
+                }
+            }.onFailure { e ->
+                Twig.error(e) { "MigrationRepository.confirmNoteSplit failed" }
+                _migrationState.value = MigrationUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+
+    override suspend fun confirmSchedule(schedule: MigrationSchedule) =
+        withContext(Dispatchers.IO) {
+            if (executionMutex.tryLock()) {
+                try {
+                    runCatching {
+                        // SDK signs internally — no USK handling needed here.
+                        migrationDataSource.signAndStoreMigrationSchedule(schedule)
+                        // State will move to InProgress; refresh to pick it up.
+                        refresh()
+                    }.onFailure { e ->
+                        Twig.error(e) { "MigrationRepository.confirmSchedule failed" }
+                        _migrationState.value = MigrationUiState.Error(e.message ?: "Unknown error")
+                    }
+                } finally {
+                    executionMutex.unlock()
+                }
+            }
+        }
+
+    override suspend fun executeNextTransfer(useTor: Boolean) =
+        withContext(Dispatchers.IO) {
+            if (executionMutex.tryLock()) {
+                try {
+                    runCatching {
+                        // Sync gate: SDK may need a sync pass before spending change from the
+                        // previous transfer. Exit and let the sync cycle handle it.
+                        if (migrationDataSource.isSyncRequiredBeforeNextTransfer()) {
+                            _migrationState.value =
+                                MigrationUiState.RequiresAttention(
+                                    AttentionReason.SyncRequiredBeforeNext
+                                )
+                            return@runCatching
+                        }
+                        val options = NetworkPrivacyOptions(useTor = useTor)
+                        when (val result = migrationDataSource.executeNextPendingTransfer(options)) {
+                            is TransferResult.Success -> {
+                                refresh()
+                            }
+
+                            is TransferResult.NetworkError -> {
+                                Unit
+                            }
+
+                            // transient; leave state, retry next open
+                            is TransferResult.InvalidNote -> {
+                                // TODO [MOB-IRONWOOD]: TransferResult.InvalidNote carries no transferId,
+                                // but AttentionReason.InvalidTransfer requires one. Flag to SDK team —
+                                // either InvalidNote needs a transferId field, or the app must track
+                                // "current transfer id" itself before calling executeNextPendingTransfer.
+                                _migrationState.value =
+                                    MigrationUiState.RequiresAttention(
+                                        AttentionReason.InvalidTransfer(transferId = "unknown")
+                                    )
+                            }
+
+                            is TransferResult.Expired -> {
+                                _migrationState.value =
+                                    MigrationUiState.RequiresAttention(
+                                        AttentionReason.TransferExpired
+                                    )
+                            }
+
+                            null -> {
+                                Unit
+                            } // no transfer due at current height
+                        }
+                    }.onFailure { e ->
+                        Twig.error(e) { "MigrationRepository.executeNextTransfer failed" }
+                    }
+                } finally {
+                    executionMutex.unlock()
+                }
+            }
+        }
+
+    override suspend fun restart(): Unit =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val newSchedule = migrationDataSource.restartCurrentMigrationStep()
+                _migrationState.value = MigrationUiState.ProposalReview(newSchedule)
+            }.onFailure { e ->
+                Twig.error(e) { "MigrationRepository.restart failed" }
+                _migrationState.value = MigrationUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationUseCase.kt
@@ -1,0 +1,45 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import cash.z.ecc.android.sdk.MigrationSchedule
+import cash.z.ecc.android.sdk.NoteSplitProposal
+import co.electriccoin.zcash.ui.common.repository.MigrationRepository
+import co.electriccoin.zcash.ui.common.repository.MigrationUiState
+import kotlinx.coroutines.flow.StateFlow
+
+class ObserveMigrationStateUseCase(
+    private val migrationRepository: MigrationRepository
+) {
+    operator fun invoke(): StateFlow<MigrationUiState> = migrationRepository.migrationState
+}
+
+class RefreshMigrationUseCase(
+    private val migrationRepository: MigrationRepository
+) {
+    operator fun invoke() = migrationRepository.refresh()
+}
+
+class ConfirmNoteSplitUseCase(
+    private val migrationRepository: MigrationRepository
+) {
+    suspend operator fun invoke(proposal: NoteSplitProposal) =
+        migrationRepository.confirmNoteSplit(proposal)
+}
+
+class ConfirmMigrationScheduleUseCase(
+    private val migrationRepository: MigrationRepository
+) {
+    suspend operator fun invoke(schedule: MigrationSchedule) =
+        migrationRepository.confirmSchedule(schedule)
+}
+
+class ExecuteNextMigrationTransferUseCase(
+    private val migrationRepository: MigrationRepository
+) {
+    suspend operator fun invoke(useTor: Boolean) = migrationRepository.executeNextTransfer(useTor)
+}
+
+class RestartMigrationUseCase(
+    private val migrationRepository: MigrationRepository
+) {
+    suspend operator fun invoke() = migrationRepository.restart()
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/migration/MigrationView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/migration/MigrationView.kt
@@ -1,0 +1,245 @@
+package co.electriccoin.zcash.ui.screen.migration
+
+// TODO [MOB-IRONWOOD]: Replace placeholder strings with proper resources (strings.xml).
+// TODO [MOB-IRONWOOD]: Replace placeholder UI with finalised designs from 3.7.1(4) equivalent.
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cash.z.ecc.android.sdk.AttentionReason
+import cash.z.ecc.android.sdk.MigrationProgress
+import cash.z.ecc.android.sdk.MigrationSchedule
+import cash.z.ecc.android.sdk.NoteSplitProposal
+import co.electriccoin.zcash.ui.common.repository.MigrationUiState
+
+@Composable
+fun MigrationScreen(viewModel: MigrationViewModel) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.onResume()
+    }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        when (val state = uiState.migrationState) {
+            MigrationUiState.Loading -> {
+                CircularProgressIndicator()
+            }
+
+            MigrationUiState.NotStarted -> {
+                Unit
+            }
+
+            // no-op; banner in HomeScreen drives entry
+
+            is MigrationUiState.AwaitingNoteSplitConfirm -> {
+                NoteSplitConfirmContent(
+                    proposal = state.proposal,
+                    torEnabled = uiState.torEnabled,
+                    onTorToggled = viewModel::onTorToggled,
+                    onConfirm = { viewModel.onNoteSplitConfirm(state.proposal) },
+                )
+            }
+
+            MigrationUiState.AwaitingSplitConfirmation -> {
+                WaitingContent(
+                    title = "Preparing your funds",
+                    detail = "Splitting notes for privacy — waiting for on-chain confirmation.",
+                )
+            }
+
+            is MigrationUiState.ProposalReview -> {
+                ScheduleReviewContent(
+                    schedule = state.schedule,
+                    torEnabled = uiState.torEnabled,
+                    onTorToggled = viewModel::onTorToggled,
+                    onConfirm = { viewModel.onScheduleConfirm(state.schedule) },
+                )
+            }
+
+            is MigrationUiState.InProgress -> {
+                ProgressContent(
+                    progress = state.progress,
+                    torEnabled = uiState.torEnabled,
+                    onTorToggled = viewModel::onTorToggled,
+                    onSendNext = viewModel::onExecuteNextTransfer,
+                )
+            }
+
+            is MigrationUiState.RequiresAttention -> {
+                AttentionContent(
+                    reason = state.reason,
+                    onRetry = viewModel::onRestart,
+                )
+            }
+
+            MigrationUiState.Complete -> {
+                CompleteContent()
+            }
+
+            is MigrationUiState.Error -> {
+                ErrorContent(
+                    message = state.message,
+                    onRetry = viewModel::onRestart,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NoteSplitConfirmContent(
+    proposal: NoteSplitProposal,
+    torEnabled: Boolean,
+    onTorToggled: (Boolean) -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Prepare your Orchard funds", textAlign = TextAlign.Center)
+        Text(
+            "Before migrating, your funds need to be split into smaller amounts for privacy. This requires one on-chain transaction.",
+            textAlign = TextAlign.Center,
+        )
+        TorToggleRow(enabled = torEnabled, onToggled = onTorToggled)
+        Button(onClick = onConfirm) { Text("Prepare funds") }
+    }
+}
+
+@Composable
+private fun ScheduleReviewContent(
+    schedule: MigrationSchedule,
+    torEnabled: Boolean,
+    onTorToggled: (Boolean) -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Review migration plan", textAlign = TextAlign.Center)
+        Text(
+            "Your funds will be moved in ${schedule.transfers.size} transfers over approximately " +
+                "${schedule.estimatedDurationHours} hours. Open ZODL each day to continue.",
+            textAlign = TextAlign.Center,
+        )
+        TorToggleRow(enabled = torEnabled, onToggled = onTorToggled)
+        Button(onClick = onConfirm) { Text("Start migration") }
+    }
+}
+
+@Composable
+private fun ProgressContent(
+    progress: MigrationProgress,
+    torEnabled: Boolean,
+    onTorToggled: (Boolean) -> Unit,
+    onSendNext: () -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Migration in progress", textAlign = TextAlign.Center)
+        LinearProgressIndicator(
+            progress = { progress.completedTransfers.toFloat() / progress.totalTransfers.toFloat() },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text("${progress.completedTransfers} of ${progress.totalTransfers} transfers complete")
+        if (progress.nextTransferReadyAtHeight != null) {
+            Text("Next transfer available around block ${progress.nextTransferReadyAtHeight}")
+        } else {
+            TorToggleRow(enabled = torEnabled, onToggled = onTorToggled)
+            Button(onClick = onSendNext) { Text("Send next transfer") }
+        }
+    }
+}
+
+@Composable
+private fun WaitingContent(title: String, detail: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        CircularProgressIndicator()
+        Text(title)
+        Text(detail, textAlign = TextAlign.Center)
+    }
+}
+
+@Composable
+private fun AttentionContent(reason: AttentionReason, onRetry: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            when (reason) {
+                is AttentionReason.InvalidTransfer -> "Transfer already sent"
+                AttentionReason.TransferExpired -> "Transfer expired"
+                AttentionReason.SyncRequiredBeforeNext -> "Sync required"
+            },
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            when (reason) {
+                is AttentionReason.InvalidTransfer -> {
+                    "This transfer was already sent, possibly from another device. " +
+                        "Open ZODL on your primary device to continue."
+                }
+
+                AttentionReason.TransferExpired -> {
+                    "A scheduled transfer expired before it could be sent. ZODL will prepare a new one."
+                }
+
+                AttentionReason.SyncRequiredBeforeNext -> {
+                    "ZODL needs to sync with the network before sending the next transfer. " +
+                        "Please stay connected and try again."
+                }
+            },
+            textAlign = TextAlign.Center,
+        )
+        Button(onClick = onRetry) { Text("Try again") }
+    }
+}
+
+@Composable
+private fun CompleteContent() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Migration complete", textAlign = TextAlign.Center)
+        Text("All your funds have been moved to the Ironwood pool.", textAlign = TextAlign.Center)
+    }
+}
+
+@Composable
+private fun ErrorContent(message: String, onRetry: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Migration error", textAlign = TextAlign.Center)
+        Text(message, textAlign = TextAlign.Center)
+        Button(onClick = onRetry) { Text("Retry") }
+    }
+}
+
+@Composable
+private fun TorToggleRow(enabled: Boolean, onToggled: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column {
+            Text("Use Tor")
+            Text("Recommended — hides your IP during migration")
+        }
+        Switch(checked = enabled, onCheckedChange = onToggled)
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/migration/MigrationViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/migration/MigrationViewModel.kt
@@ -1,0 +1,82 @@
+package co.electriccoin.zcash.ui.screen.migration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cash.z.ecc.android.sdk.MigrationSchedule
+import cash.z.ecc.android.sdk.NoteSplitProposal
+import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.common.repository.MigrationUiState
+import co.electriccoin.zcash.ui.common.usecase.ConfirmMigrationScheduleUseCase
+import co.electriccoin.zcash.ui.common.usecase.ConfirmNoteSplitUseCase
+import co.electriccoin.zcash.ui.common.usecase.ExecuteNextMigrationTransferUseCase
+import co.electriccoin.zcash.ui.common.usecase.ObserveMigrationStateUseCase
+import co.electriccoin.zcash.ui.common.usecase.RefreshMigrationUseCase
+import co.electriccoin.zcash.ui.common.usecase.RestartMigrationUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class MigrationScreenState(
+    val migrationState: MigrationUiState = MigrationUiState.Loading,
+    val torEnabled: Boolean = true, // ON by default per design doc §9.3
+)
+
+class MigrationViewModel(
+    private val observeMigrationState: ObserveMigrationStateUseCase,
+    private val refreshMigration: RefreshMigrationUseCase,
+    private val confirmNoteSplit: ConfirmNoteSplitUseCase,
+    private val confirmSchedule: ConfirmMigrationScheduleUseCase,
+    private val executeNextTransfer: ExecuteNextMigrationTransferUseCase,
+    private val restartMigration: RestartMigrationUseCase,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(MigrationScreenState())
+    val uiState: StateFlow<MigrationScreenState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            observeMigrationState().collect { state ->
+                _uiState.update { current -> current.copy(migrationState = state) }
+                // When we enter InProgress, auto-advance: attempt next transfer.
+                if (state is MigrationUiState.InProgress) {
+                    executeNextIfReady()
+                }
+            }
+        }
+    }
+
+    fun onResume() {
+        refreshMigration()
+    }
+
+    fun onTorToggled(enabled: Boolean) {
+        _uiState.update { current -> current.copy(torEnabled = enabled) }
+    }
+
+    fun onNoteSplitConfirm(proposal: NoteSplitProposal) {
+        viewModelScope.launch { confirmNoteSplit(proposal) }
+    }
+
+    fun onScheduleConfirm(schedule: MigrationSchedule) {
+        viewModelScope.launch { confirmSchedule(schedule) }
+    }
+
+    fun onExecuteNextTransfer() {
+        executeNextIfReady()
+    }
+
+    fun onRestart() {
+        viewModelScope.launch { restartMigration() }
+    }
+
+    private fun executeNextIfReady() {
+        viewModelScope.launch {
+            runCatching {
+                executeNextTransfer(_uiState.value.torEnabled)
+            }.onFailure { e ->
+                Twig.error(e) { "MigrationViewModel.executeNextTransfer failed" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Scaffolds the Approach B (guided on-open, no background automation) migration UI layer: `MigrationDataSource`/`MigrationRepository`/`MigrationUseCase`/`MigrationViewModel`/`MigrationView`, DI-registered.
- `MigrationRepository.refresh()` now calls the real `Synchronizer.planOrchardDenominationSplit` (zcash-android-wallet-sdk PR #2008), using the selected account's actual Orchard spendable balance, instead of going through the still-stubbed `OrchardMigrationSdk` surface.
- Mirrors zodl-ios PR #1873's `MigrationProcessorLiveKey.refresh()` pattern.

## What's real vs. stubbed
- Real: `refresh()` → `planOrchardDenominationSplit` → real `DenominationPlan` from actual on-chain Orchard balance.
- Still stub-only (throws via `OrchardMigrationSdk` placeholder, blocked on unstable `nu6.3` Ironwood crate surface): note-split submission, schedule proposal/confirmation, transfer execution, restart. See `.claude/context/ironwood-migration-execution.md` in the `zodl` planning repo for full current status across all three repos.

## Test plan
- [x] `./gradlew :ui-lib:compileZcashtestnetFossDebugKotlin` — builds clean (verified against local SDK include-build with PR #2008's changes)
- [x] `ktlintFormat` / `ktlint` / `detekt` — all pass
- [ ] Manual on-device verification once SDK PR #2008 lands on a published artifact