### PR TITLE
[#323] Add content descriptions to Pay and Swap buttons

### DIFF
--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -449,6 +449,7 @@
 
     <!-- ===== pay ===== -->
     <string name="crosspay_help_payWith">CrossPay con</string>
+    <string name="pay_info_content_description">Información del pago</string>
     <string name="pay_info_subtitle">Haz pagos entre cadenas en cualquier moneda o token compatible con NEAR.\n\nSi el deslizamiento real y las condiciones de la red resultan en que tu destinatario reciba menos de la cantidad prometida, tu transacción será revertida. Recibirás un reembolso completo menos las comisiones de red.</string>
     <string name="swapAndPay_slippageWarn">Cualquier parte no utilizada de la comisión por deslizamiento será reembolsada si el intercambio se ejecuta con un deslizamiento menor al esperado.</string>
 
@@ -716,6 +717,8 @@
     <string name="keystoneTransactionReject_rejectSig">Rechazar firma</string>
 
     <!-- ===== swap ===== -->
+    <string name="swap_change_direction_content_description">Cambiar dirección del swap</string>
+    <string name="swap_info_content_description">Información del swap</string>
     <string name="swap_info_message">Haz swap de %1$s con cualquier token compatible con NEAR.\n\nSi haces swap HACIA %2$s, enviarás fondos desde una wallet de terceros y deberás proporcionar una dirección donde se pueda reembolsar el cambio.\n\nSi haces swap DESDE %3$s, debes proporcionar una dirección válida para el activo al que haces swap.</string>
     <string name="swapAndPay_help_swapWith">Swap con</string>
     <string name="swap_select_token">Seleccionar token</string>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -483,6 +483,7 @@
 
     <!-- ===== pay ===== -->
     <string name="crosspay_help_payWith">CrossPay with</string>
+    <string name="pay_info_content_description">Payment information</string>
     <string name="pay_info_subtitle">Make cross-chain payments in any NEAR-supported coin or token.\n\nIf the actual slippage and network conditions result in your recipient receiving less than the promised amount, your transaction will be reversed. You will receive a full refund minus network fees.</string>
     <string name="swapAndPay_slippageWarn">Any unused portion of the slippage fee will be refunded if the swap executes with lower slippage than expected.</string>
 
@@ -787,6 +788,8 @@
     <string name="coinVote_delegationSigning_memo" translatable="false">Memo</string>
 
     <!-- ===== swap ===== -->
+    <string name="swap_change_direction_content_description">Change swap direction</string>
+    <string name="swap_info_content_description">Swap information</string>
     <string name="swap_info_message">Swap %1$s with any NEAR-supported token.\n\nIf swapping TO %2$s, you will send funds from a 3rd party wallet and provide an address where change can be refunded.\n\nIf swapping FROM %3$s, you must provide a valid address for the asset you are swapping to.</string>
     <string name="swapAndPay_help_swapWith">Swap with</string>
     <string name="swap_select_token">Select Token</string>

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
@@ -44,6 +44,7 @@ internal class ExactOutputVMMapper {
             info =
                 IconButtonState(
                     icon = co.electriccoin.zcash.ui.design.R.drawable.ic_info,
+                    contentDescription = stringRes(R.string.pay_info_content_description),
                     onClick = callbacks.onSwapInfoClick
                 ),
             address = createAddressState(state, callbacks.onAddressChange),

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
@@ -80,6 +80,7 @@ internal class SwapVMMapper {
             swapInfoButton =
                 IconButtonState(
                     co.electriccoin.zcash.ui.design.R.drawable.ic_info,
+                    contentDescription = stringRes(R.string.swap_info_content_description),
                     onClick = callbacks.onSwapInfoClick
                 ),
             infoItems = createListItems(state),
@@ -114,6 +115,7 @@ internal class SwapVMMapper {
             changeModeButton =
                 IconButtonState(
                     icon = R.drawable.ic_swap_change_mode,
+                    contentDescription = stringRes(R.string.swap_change_direction_content_description),
                     onClick = callbacks.onChangeButtonClick
                 ),
             onAddressClick =


### PR DESCRIPTION
Part of #323

Follow-up to #2233.

Adds missing `contentDescription` values to the information buttons on the Pay (ExactOutput) and Swap screens, plus the swap-direction toggle. These three controls are icon-only, so without descriptions TalkBack users cannot identify their actions.

Adds action-specific English and Spanish strings in `ui-design-lib`. There are no visual changes, so screenshots are not applicable.

## Validation

- Repository-pinned ktlint 1.8.0 passes for both modified Kotlin files
- Both modified string resource files pass `xmllint`
- `git diff --check` passes
- The full Gradle task graph could not run locally because no Android SDK is configured; repository CI will run the compile and static-analysis checks

## Manual test plan

1. Enable TalkBack.
2. Open the Pay screen and focus the information button; verify it is announced as payment information.
3. Open the Swap screen and focus the information and direction buttons; verify they are announced as swap information and change swap direction.
4. Repeat with the app language set to Spanish and verify the localized announcements.