### PR TITLE
fix: swap quote hangs forever when the ZEC asset is missing

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/SwapRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/SwapRepository.kt
@@ -99,7 +99,11 @@ data class SwapAssetsData(
     val error: Exception? = null,
 )
 
-/** Thrown by [SwapRepository.checkSwapStatus] when the supported-asset list could not be loaded. */
+/**
+ * Raised when the supported-asset list could not be loaded, so the ZEC side of a swap cannot be
+ * resolved. Thrown by [SwapRepository.checkSwapStatus]; reported as [SwapQuoteData.Error] by the
+ * quote requests.
+ */
 class SwapAssetsUnavailableException : Exception("Swap assets are unavailable")
 
 @Suppress("TooManyFunctions")
@@ -219,7 +223,11 @@ class SwapRepositoryImpl(
         requestQuoteJob =
             scope.launch {
                 quote.update { SwapQuoteData.Loading }
-                val destinationAsset = assets.value.zecAsset ?: return@launch
+                val destinationAsset =
+                    assets.value.zecAsset ?: run {
+                        quote.update { SwapQuoteData.Error(FLEX_INPUT, SwapAssetsUnavailableException()) }
+                        return@launch
+                    }
                 try {
                     val result =
                         swapDataSource.requestQuote(
@@ -277,7 +285,11 @@ class SwapRepositoryImpl(
         requestQuoteJob =
             scope.launch {
                 quote.update { SwapQuoteData.Loading }
-                val originAsset = assets.value.zecAsset ?: return@launch
+                val originAsset =
+                    assets.value.zecAsset ?: run {
+                        quote.update { SwapQuoteData.Error(mode, SwapAssetsUnavailableException()) }
+                        return@launch
+                    }
                 try {
                     val result =
                         swapDataSource.requestQuote(

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/SwapRepositoryImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/SwapRepositoryImplTest.kt
@@ -253,10 +253,10 @@ class SwapRepositoryImplTest {
         }
 
     @Test
-    fun quoteIsNoOpWhenAssetsNotLoaded() =
+    fun exactInputQuoteFailsWithSwapAssetsUnavailableWhenNoZecAssetIsLoaded() =
         runTest {
-            // Without a prior refresh there is no ZEC asset, so the request short-circuits: the quote is
-            // left in Loading and the data source is never queried.
+            // Without a prior refresh there is no ZEC asset, so the request cannot be built. It must still
+            // reach a terminal state: consumers await the first non-Loading value and would hang otherwise.
             val dataSource = mockk<SwapDataSource>(relaxed = true)
             val repository = repository(dataSource)
 
@@ -268,7 +268,53 @@ class SwapRepositoryImplTest {
                 slippage = BigDecimal("2")
             )
 
-            assertEquals(SwapQuoteData.Loading, repository.quote.value)
+            val result = repository.quote.value
+            assertIs<SwapQuoteData.Error>(result)
+            assertEquals(SwapMode.EXACT_INPUT, result.mode)
+            assertIs<SwapAssetsUnavailableException>(result.exception)
+            coVerify(exactly = 0) { dataSource.requestQuote(any(), any(), any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun exactOutputQuoteFailsWithSwapAssetsUnavailableWhenNoZecAssetIsLoaded() =
+        runTest {
+            // The error must carry the request's own mode so the quote screen shows the payment copy.
+            val dataSource = mockk<SwapDataSource>(relaxed = true)
+            val repository = repository(dataSource)
+
+            repository.requestExactOutputQuote(
+                amount = BigDecimal("1"),
+                address = "destination",
+                refundAddress = "refund",
+                destinationAsset = btc,
+                slippage = BigDecimal("2")
+            )
+
+            val result = repository.quote.value
+            assertIs<SwapQuoteData.Error>(result)
+            assertEquals(SwapMode.EXACT_OUTPUT, result.mode)
+            assertIs<SwapAssetsUnavailableException>(result.exception)
+            coVerify(exactly = 0) { dataSource.requestQuote(any(), any(), any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun flexInputQuoteFailsWithSwapAssetsUnavailableWhenNoZecAssetIsLoaded() =
+        runTest {
+            val dataSource = mockk<SwapDataSource>(relaxed = true)
+            val repository = repository(dataSource)
+
+            repository.requestFlexInputIntoZec(
+                amount = BigDecimal("2"),
+                refundAddress = "refund",
+                destinationAddress = "destination",
+                originAsset = btc,
+                slippage = BigDecimal("2")
+            )
+
+            val result = repository.quote.value
+            assertIs<SwapQuoteData.Error>(result)
+            assertEquals(SwapMode.FLEX_INPUT, result.mode)
+            assertIs<SwapAssetsUnavailableException>(result.exception)
             coVerify(exactly = 0) { dataSource.requestQuote(any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 


### PR DESCRIPTION
`refreshAssetsInternal` writes `data` and `zecAsset` in one atomic update from the same token list, so this is not a load-timing gap. Reaching `zecAsset == null` while `data` is populated requires a response that genuinely contains no entry matching `isZCashAsset`, which is a hardcoded case-insensitive match on token ticker `zec` and chain ticker `zec`.

`requestRefreshAssets()` re-fetches on a 30 second loop. If a later refresh returns a list with no ZEC entry while the user is already sitting on the Swap screen, `filterSwapAssets` still yields a non-null `data`, so the control that starts the request stays enabled, while the success path overwrites `zecAsset` with null and sets `error` to null, so nothing surfaces the change. A 1Click chain or ticker rename, say chain `zcash` rather than `zec`, produces the same state permanently. Both quote paths then set the quote to `Loading` and return without ever publishing a terminal state.

```kotlin
quote.update { SwapQuoteData.Loading }
val destinationAsset = assets.value.zecAsset ?: return@launch
```

`RequestSwapQuoteUseCase` then awaits the first non-Loading value with `quote.first { it !in listOf(null, SwapQuoteData.Loading) }`, so it suspends forever. `isRequestingQuote` never resets and `SwapVMMapper` leaves every control on the Swap and Pay screens disabled. There is no in-screen recovery, so the user has to restart the app.

The same condition is already treated as a failure further down this file. `getSupportedTokensForStatus()` throws `SwapAssetsUnavailableException` when `zecAsset` is null rather than returning quietly, so the quote path is inconsistent with the status path. This change makes the quote path fail the same way, emitting `SwapQuoteData.Error` carrying that existing exception. `SwapQuoteVM.createErrorState` already renders it as "Quote unavailable" with cancel and edit actions, so no new strings or UI are involved.

Worth flagging that this flips an assertion in the existing `quoteIsNoOpWhenAssetsNotLoaded`, which asserted `Loading` while exercising the repository in isolation and was never composed with the use case await that actually hangs. It is renamed and now asserts the terminal error, with equivalent cases added for the exact-output and flex-input entry points.

This depends on a server-side condition, so it needs 1Click to return a list with no ZEC entry, and no funds are at risk. The cost when that happens is a silent freeze of the primary swap flow. Unit tests only, not exercised on a device, since I cannot force that response against the real API.

`./gradlew :ui-lib:testZcashmainnetStoreDebugUnitTest --tests '*SwapRepositoryImplTest*'` passes, 33 tests. Reverting the source change with the new tests in place fails all three.
