### PR TITLE
fix(tor): set isSecure=false for .onion custom server endpoints

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -220,3 +220,8 @@ JVM_TOOLCHAIN=17
 # This shouldn't be changed, as Android doesn't support targets beyond Java 8
 KOTLIN_JVM_TARGET=8
 ANDROID_JVM_TARGET=1.8
+
+# Zodl self-hosted lightwalletd Tor hidden service.
+# To use: enable Tor in Settings, then enter this in the custom server field:
+#   zodllo6te2kegjkrqtluiucuymyrpqxrrz37afuzi6f7jcy6rxlpgzqd.onion:9067
+# isSecure must be false for .onion endpoints (Tor provides transport encryption).

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextFieldParserTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextFieldParserTest.kt
@@ -214,4 +214,24 @@ class ZashiEndpointTextFieldParserTest {
         )
         MatcherAssert.assertThat("Port should be correct", result?.port, CoreMatchers.equalTo(9067))
     }
+
+    @Test
+    @SmallTest
+    fun onionEndpointIsInsecureTest() {
+        val result = ZashiEndpointTextFieldParser.toEndpointOrNull(
+            "zodllo6te2kegjkrqtluiucuymyrpqxrrz37afuzi6f7jcy6rxlpgzqd.onion:9067"
+        )
+        MatcherAssert.assertThat(".onion endpoint should be valid", result, CoreMatchers.notNullValue())
+        MatcherAssert.assertThat(
+            ".onion host should be parsed",
+            result?.host,
+            CoreMatchers.equalTo("zodllo6te2kegjkrqtluiucuymyrpqxrrz37afuzi6f7jcy6rxlpgzqd.onion")
+        )
+        MatcherAssert.assertThat("Port should be 9067", result?.port, CoreMatchers.equalTo(9067))
+        MatcherAssert.assertThat(
+            ".onion endpoint must be insecure (Tor provides transport encryption)",
+            result?.isSecure,
+            CoreMatchers.equalTo(false)
+        )
+    }
 }

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextFieldParserTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextFieldParserTest.kt
@@ -218,9 +218,10 @@ class ZashiEndpointTextFieldParserTest {
     @Test
     @SmallTest
     fun onionEndpointIsInsecureTest() {
-        val result = ZashiEndpointTextFieldParser.toEndpointOrNull(
-            "zodllo6te2kegjkrqtluiucuymyrpqxrrz37afuzi6f7jcy6rxlpgzqd.onion:9067"
-        )
+        val result =
+            ZashiEndpointTextFieldParser.toEndpointOrNull(
+                "zodllo6te2kegjkrqtluiucuymyrpqxrrz37afuzi6f7jcy6rxlpgzqd.onion:9067"
+            )
         MatcherAssert.assertThat(".onion endpoint should be valid", result, CoreMatchers.notNullValue())
         MatcherAssert.assertThat(
             ".onion host should be parsed",

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextField.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextField.kt
@@ -204,7 +204,11 @@ object ZashiEndpointTextFieldParser {
                 return null
             }
 
-            LightWalletEndpoint(host, port, true)
+            // .onion addresses use Tor for transport encryption; TLS is not needed
+            // (and no public CA issues certs for .onion hosts). Any other host
+            // keeps isSecure=true. Explicit grpc:// scheme also opts out of TLS.
+            val isSecure = !host.endsWith(".onion") && uri.scheme != "grpc"
+            LightWalletEndpoint(host, port, isSecure)
         } catch (_: Exception) {
             null
         }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextFieldParserTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/component/ZashiEndpointTextFieldParserTest.kt
@@ -25,8 +25,10 @@ class ZashiEndpointTextFieldParserTest {
         // The androidx String.toUri() extension is inline and delegates to Uri.parse, so stubbing
         // Uri.parse covers the host/port extraction for well-formed inputs.
         every { Uri.parse(any()) } answers {
-            val raw = firstArg<String>().substringAfter("://")
+            val input = firstArg<String>()
+            val raw = input.substringAfter("://")
             mockk<Uri> {
+                every { scheme } returns input.substringBefore("://")
                 every { host } returns raw.substringBeforeLast(":")
                 every { port } returns raw.substringAfterLast(":").toInt()
             }


### PR DESCRIPTION
## Problem

`ZashiEndpointTextFieldParser.toEndpointOrNull()` always set `isSecure = true` for custom server entries. When the host ends in `.onion`, this causes `CombinedWalletClientImpl` to build an `https://` URI for the gRPC channel, which fails with `InvalidContentType` because the Tor stream is plaintext HTTP/2.

## Change

In `ZashiEndpointTextField.kt`, derive `isSecure` from the host name:

```kotlin
val isSecure = !host.endsWith(".onion") && uri.scheme != "grpc"
```

This matches the existing `grpc://` scheme override and adds `.onion` as a second plaintext case.

## Testing

Tested end-to-end on an Android emulator (x86_64, API 34). With this fix and the accompanying SDK changes (zcash/zcash-android-wallet-sdk#2020), the wallet successfully syncs compact blocks through a Tor v3 onion lightwalletd endpoint configured as a custom server.