### PR TITLE
fix: don't resolve swap-status assets by token ticker

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/NearSwapDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/NearSwapDataSource.kt
@@ -24,6 +24,7 @@ import co.electriccoin.zcash.ui.common.model.near.RefundType
 import co.electriccoin.zcash.ui.common.model.near.SubmitDepositTransactionRequest
 import co.electriccoin.zcash.ui.common.model.near.SwapAmountInconsistencyException
 import co.electriccoin.zcash.ui.common.model.near.SwapType
+import co.electriccoin.zcash.ui.common.model.near.requestedAssetId
 import co.electriccoin.zcash.ui.common.provider.BlockchainProvider
 import co.electriccoin.zcash.ui.common.provider.NearApiProvider
 import co.electriccoin.zcash.ui.common.provider.ResponseWithNearErrorException
@@ -209,14 +210,13 @@ class NearSwapDataSource(
         )
     }
 
-    // The 1Click API normalises asset IDs for routing (e.g. "nep141:btc.omft.near" →
-    // "1cs_v1:btc:native:coin"). Try an exact match first; fall back to extracting the ticker
-    // from the normalised "1cs_v1:<ticker>:..." format and matching by tokenTicker.
-    private fun findAssetByEchoedId(supportedTokens: List<SwapAsset>, echoedId: String): SwapAsset? =
-        supportedTokens.find { it.assetId == echoedId }
-            ?: echoedId.split(":").getOrNull(1)?.let { ticker ->
-                supportedTokens.find { it.tokenTicker.equals(ticker, ignoreCase = true) }
-            }
+    // The status endpoint echoes the asset ids the app sent, so this is normally an exact match. Mapping
+    // the echoed id first keeps the lookup working if status starts echoing the asset 1Click routed
+    // through instead.
+    private fun findAssetByEchoedId(supportedTokens: List<SwapAsset>, echoedId: String): SwapAsset? {
+        val requestedId = requestedAssetId(echoedId)
+        return supportedTokens.find { it.assetId == requestedId }
+    }
 
     private suspend fun getDepositAddress(response: QuoteResponseDto, originAsset: SwapAsset): SwapAddress {
         val address = response.quote.depositAddress

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/near/NearAssetId.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/near/NearAssetId.kt
@@ -1,0 +1,17 @@
+package co.electriccoin.zcash.ui.common.model.near
+
+private const val BITCOIN_ASSET_ID = "nep141:btc.omft.near"
+private const val BITCOIN_ROUTED_ASSET_ID = "1cs_v1:btc:native:coin"
+
+/**
+ * 1Click can quote a swap against a different representation of the same coin than the one requested: a
+ * quote for `nep141:btc.omft.near` is echoed back as `1cs_v1:btc:native:coin`. `/v0/status` echoes the
+ * requested id unchanged, so this only keeps the status lookup working if that ever changes.
+ *
+ * Apply it to echoed ids only, never to catalog ids. `/v0/tokens` lists both forms as separate assets,
+ * `BTC` and `BTC(OMNI)`, with independent liquidity, so rewriting catalog ids would collapse two entries
+ * onto one id and leave the lookup resolving by list position.
+ */
+private val routedAssetIds = mapOf(BITCOIN_ROUTED_ASSET_ID to BITCOIN_ASSET_ID)
+
+internal fun requestedAssetId(echoedId: String): String = routedAssetIds[echoedId] ?: echoedId

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/NearSwapDataSourceTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/NearSwapDataSourceTest.kt
@@ -369,6 +369,55 @@ class NearSwapDataSourceTest {
         }
     }
 
+    @Test
+    fun checkSwapStatusDoesNotResolveSameSymbolAssetOnWrongChain() {
+        runBlocking {
+            // The second segment of a 1cs_v1 id is the chain, not a ticker: this one is USDC on Solana. An
+            // id with no mapping back to a requested id is reported missing rather than matched against a
+            // token that happens to share that segment.
+            val sol = SwapAssetTestFixture.asset(tokenTicker = "sol", chainTicker = "sol")
+            coEvery { nearApiProvider.checkSwapStatus(any()) } returns
+                statusResponse(
+                    originAssetId = "1cs_v1:sol:spl:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    destinationAssetId = zec.assetId
+                )
+
+            assertFailsWith<AssetNotFoundException> {
+                dataSource.checkSwapStatus(depositAddress = "deposit", supportedTokens = listOf(sol, zec))
+            }
+        }
+    }
+
+    @Test
+    fun checkSwapStatusDoesNotResolveUnmappedColonDelimitedId() {
+        runBlocking {
+            coEvery { nearApiProvider.checkSwapStatus(any()) } returns
+                statusResponse(originAssetId = "other:btc:native:coin", destinationAssetId = zec.assetId)
+
+            assertFailsWith<AssetNotFoundException> {
+                dataSource.checkSwapStatus(depositAddress = "deposit", supportedTokens = listOf(origin, zec))
+            }
+        }
+    }
+
+    @Test
+    fun checkSwapStatusDoesNotResolveARoutedIdToTheCatalogEntryCarryingIt() {
+        runBlocking {
+            // /v0/tokens lists "1cs_v1:btc:native:coin" as its own asset, BTC(OMNI), alongside the
+            // "nep141:btc.omft.near" the app requests. Only the echoed id is mapped, so with just the
+            // BTC(OMNI) entry loaded nothing resolves. Mapping catalog ids too would match it here, and
+            // with both entries loaded would resolve by list position.
+            val btcOmni =
+                SwapAssetTestFixture.asset(tokenTicker = "btc(omni)", assetId = "1cs_v1:btc:native:coin")
+            coEvery { nearApiProvider.checkSwapStatus(any()) } returns
+                statusResponse(originAssetId = "1cs_v1:btc:native:coin", destinationAssetId = zec.assetId)
+
+            assertFailsWith<AssetNotFoundException> {
+                dataSource.checkSwapStatus(depositAddress = "deposit", supportedTokens = listOf(btcOmni, zec))
+            }
+        }
+    }
+
     private fun statusResponse(
         originAssetId: String,
         destinationAssetId: String

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/SwapAssetTestFixture.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/SwapAssetTestFixture.kt
@@ -22,14 +22,15 @@ object SwapAssetTestFixture {
         tokenTicker: String = "btc",
         chainTicker: String = "btc",
         usdPrice: BigDecimal? = BigDecimal("100000"),
-        decimals: Int = 8
+        decimals: Int = 8,
+        assetId: String = "$tokenTicker-$chainTicker"
     ): SwapAsset =
         NearSwapAsset(
             tokenTicker = tokenTicker,
             tokenName = stringRes(tokenTicker.uppercase()),
             tokenIcon = imageRes(0),
             usdPrice = usdPrice,
-            assetId = "$tokenTicker-$chainTicker",
+            assetId = assetId,
             decimals = decimals,
             blockchain = blockchain(chainTicker)
         )

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/near/NearAssetIdTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/near/NearAssetIdTest.kt
@@ -1,0 +1,22 @@
+package co.electriccoin.zcash.ui.common.model.near
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NearAssetIdTest {
+    @Test
+    fun mapsRoutedBitcoinIdBackToTheRequestedId() {
+        assertEquals("nep141:btc.omft.near", requestedAssetId("1cs_v1:btc:native:coin"))
+    }
+
+    @Test
+    fun leavesRequestedIdsUnchanged() {
+        assertEquals("nep141:btc.omft.near", requestedAssetId("nep141:btc.omft.near"))
+    }
+
+    @Test
+    fun leavesUnmappedRoutedIdsUnchanged() {
+        val baseUsdc = "1cs_v1:base:erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+        assertEquals(baseUsdc, requestedAssetId(baseUsdc))
+    }
+}


### PR DESCRIPTION
`checkSwapStatus` maps the asset ids in the status response back to the `SwapAsset` the app holds. When an id didn't match a catalog id exactly it fell back to reading the second colon-segment as a token ticker and matching on that. That segment is the chain, so the fallback could match a token on the wrong chain, and it accepted ids from any namespace because it never checked the prefix.

Replaced with an explicit map from the one id 1Click is known to route through back to the id the app requested, `1cs_v1:btc:native:coin` to `nep141:btc.omft.near`. Anything else falls through to the existing `AssetNotFoundException`.

## What the live API actually does

- `/v0/quote` substitutes the routing asset in its echo: request `nep141:btc.omft.near`, get back `1cs_v1:btc:native:coin`. Happens on both the origin and the destination side.
- `/v0/status` echoes the ids the client sent, unchanged. Confirmed both ways: send `nep141:btc.omft.near` and status returns it verbatim; send `1cs_v1:btc:native:coin` and status returns that.
- The two endpoints serve the same signed quote, identical `signature` and `timestamp`, with different ids. The substitution is in `/v0/quote`'s response, not in the stored quote.
- Sweeping all 28 curated assets, BTC is the only one 1Click substitutes.

So on today's API this path always hits the exact match, and neither the old fallback nor the new map runs. The map is a guard for status starting to echo the routed id, which is the failure 930776db4 was written for.

## Why only the echoed id is mapped

`/v0/tokens` lists both bitcoin ids as separate assets, `BTC` (`nep141:btc.omft.near`) and `BTC(OMNI)` (`1cs_v1:btc:native:coin`). `getSupportedTokensForStatus` runs against the uncurated list, so both are loaded.

Mapping catalog ids as well would give the two entries the same id and leave `find` picking by list position, which lands on the right one today only because BTC sits earlier in the catalog. `checkSwapStatusDoesNotResolveARoutedIdToTheCatalogEntryCarryingIt` covers that and fails if the mapping is applied to both sides.

## Possible follow-up

`SwapRepository.checkSwapStatus` already knows the origin and destination from `swapMetadata`, and calls `requireMatchingAsset` against them one line after the data source returns. Resolving the assets from that metadata would drop this lookup entirely and stop the status path depending on how 1Click serializes ids. Left out here to keep the change small.
