### PR TITLE
Surface consensus-branch mismatch diagnostics in the Sync Error sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 - When a send fails because the wallet's chain state changed between tapping review and confirm (due to syncing catching up, a reorg, or the app resuming from background), a clear actionable message is now shown instead of the generic error copy.
+- When syncing stops because ZODL and the server it is connected to are incompatible, the Sync Error sheet now explains what happened and shows which server is in use and exactly what the two sides disagree about, instead of generic "check your connection" copy. These failures previously opened a different error sheet that showed a raw stack trace and offered no way to change server; they now open the Sync Error sheet, where Switch server is available. Support reports for these failures lead with the same readable summary rather than only a stack trace.
 
 ### Added:
 - Currency Conversion now supports multiple fiat currencies. You can pick which currency your balances and payment amounts are shown in from the Currency Conversion settings and opt-in screens.

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/error/SyncErrorViewTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/error/SyncErrorViewTest.kt
@@ -1,0 +1,121 @@
+package co.electriccoin.zcash.ui.screen.error
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.filters.MediumTest
+import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.design.component.ButtonState
+import co.electriccoin.zcash.ui.design.component.listitem.SimpleListItemState
+import co.electriccoin.zcash.ui.design.theme.ZcashTheme
+import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.test.getStringResource
+import org.junit.Rule
+import kotlin.test.Test
+
+/**
+ * The Sync Error sheet renders the incompatible-server diagnostics when they are present, and is
+ * left untouched for the generic sync errors that carry none.
+ */
+class SyncErrorViewTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    @MediumTest
+    fun generic_error_shows_the_default_message_and_no_detail_test() {
+        setContent(diagnostics = null)
+
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_message)).assertExists()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_detail_server)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_detail_error_type)).assertDoesNotExist()
+    }
+
+    @Test
+    @MediumTest
+    fun incompatible_server_replaces_the_default_message_with_an_explanation_test() {
+        setContent(diagnostics = diagnostics())
+
+        composeTestRule
+            .onNodeWithText(getStringResource(R.string.sync_error_incompatible_consensus_message))
+            .assertExists()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_message)).assertDoesNotExist()
+    }
+
+    @Test
+    @MediumTest
+    fun incompatible_server_lists_the_server_and_both_branch_ids_test() {
+        setContent(diagnostics = diagnostics())
+
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_detail_server)).assertExists()
+        composeTestRule.onNodeWithText(SERVER).assertExists()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_detail_expected_branch)).assertExists()
+        composeTestRule.onNodeWithText(CLIENT_BRANCH_ID).assertExists()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_detail_server_branch)).assertExists()
+        composeTestRule.onNodeWithText(SERVER_BRANCH_ID).assertExists()
+        composeTestRule.onNodeWithText(ERROR_TYPE).assertExists()
+    }
+
+    @Test
+    @MediumTest
+    fun switch_server_is_offered_and_no_extra_button_is_added_test() {
+        setContent(diagnostics = diagnostics())
+
+        // Try again, Switch server and Contact Support, and nothing new alongside them.
+        composeTestRule.onNodeWithText(TRY_AGAIN).assertExists()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_switch_server)).assertExists()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_contact_support)).assertExists()
+        composeTestRule.onNodeWithText(getStringResource(R.string.sync_error_disable_tor)).assertDoesNotExist()
+    }
+
+    private fun setContent(diagnostics: SyncErrorDiagnosticsState?) {
+        composeTestRule.setContent {
+            ZcashTheme {
+                SyncErrorContent(
+                    state =
+                        SyncErrorState(
+                            tryAgain = ButtonState(text = stringRes(TRY_AGAIN), onClick = {}),
+                            switchServer =
+                                ButtonState(
+                                    text = stringRes(R.string.sync_error_switch_server),
+                                    onClick = {}
+                                ),
+                            disableTor = null,
+                            support =
+                                ButtonState(
+                                    text = stringRes(R.string.sync_error_contact_support),
+                                    onClick = {}
+                                ),
+                            onBack = {},
+                            diagnostics = diagnostics
+                        ),
+                    contentPadding = PaddingValues()
+                )
+            }
+        }
+    }
+}
+
+private fun diagnostics() =
+    SyncErrorDiagnosticsState(
+        explanation = stringRes(R.string.sync_error_incompatible_consensus_message),
+        facts =
+            listOf(
+                SimpleListItemState(stringRes(R.string.sync_error_detail_server), stringRes(SERVER)),
+                SimpleListItemState(
+                    stringRes(R.string.sync_error_detail_expected_branch),
+                    stringRes(CLIENT_BRANCH_ID)
+                ),
+                SimpleListItemState(
+                    stringRes(R.string.sync_error_detail_server_branch),
+                    stringRes(SERVER_BRANCH_ID)
+                ),
+                SimpleListItemState(stringRes(R.string.sync_error_detail_error_type), stringRes(ERROR_TYPE))
+            )
+    )
+
+private const val TRY_AGAIN = "Try again"
+private const val SERVER = "zec.rocks:443"
+private const val CLIENT_BRANCH_ID = "0x5437f330"
+private const val SERVER_BRANCH_ID = "0x37a5165b"
+private const val ERROR_TYPE = "MismatchedConsensusBranch"

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/ServerCompatibilityError.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/ServerCompatibilityError.kt
@@ -1,0 +1,85 @@
+package co.electriccoin.zcash.ui.common.model
+
+import cash.z.ecc.android.sdk.exception.CompactBlockProcessorException
+import co.electriccoin.zcash.ui.design.util.getCausesAsSequence
+
+/**
+ * A sync failure caused by ZODL and the lightwalletd server disagreeing about the state of the
+ * Zcash network.
+ *
+ * These failures are permanent for as long as the pairing lasts: sync can never make progress, so
+ * retrying is not a remedy. The remedies are updating ZODL or switching to a different server.
+ *
+ * Either side may be the stale one, and none of the values carried here are ordered, so nothing in
+ * this type can be used to decide whether it is ZODL or the server that is behind.
+ */
+sealed interface ServerCompatibilityError {
+    /**
+     * The name of the underlying SDK exception. Shown to the user as the error type and included in
+     * support reports so that a report can be tied back to a specific SDK failure.
+     */
+    val type: String
+
+    data class ConsensusBranch(
+        val clientBranchId: String,
+        val serverBranchId: String
+    ) : ServerCompatibilityError {
+        override val type: String
+            get() = CompactBlockProcessorException.MismatchedConsensusBranch::class.simpleName.orEmpty()
+    }
+
+    data class Network(
+        val clientNetwork: String?,
+        val serverNetwork: String?
+    ) : ServerCompatibilityError {
+        override val type: String
+            get() = CompactBlockProcessorException.MismatchedNetwork::class.simpleName.orEmpty()
+    }
+
+    data class SaplingActivationHeight(
+        val clientHeight: Long,
+        val serverHeight: Long
+    ) : ServerCompatibilityError {
+        override val type: String
+            get() = CompactBlockProcessorException.MismatchedSaplingActivationHeight::class.simpleName.orEmpty()
+    }
+}
+
+/**
+ * Returns the server-compatibility failure behind this error, or null if this error has some other
+ * cause. The whole cause chain is searched, because the SDK wraps these exceptions before they
+ * reach the app.
+ */
+fun SynchronizerError.toServerCompatibilityError(): ServerCompatibilityError? =
+    cause
+        ?.getCausesAsSequence()
+        .orEmpty()
+        .firstNotNullOfOrNull { it.toServerCompatibilityErrorOrNull() }
+
+private fun Throwable.toServerCompatibilityErrorOrNull(): ServerCompatibilityError? =
+    when (this) {
+        is CompactBlockProcessorException.MismatchedConsensusBranch -> {
+            ServerCompatibilityError.ConsensusBranch(
+                clientBranchId = clientBranchId,
+                serverBranchId = serverBranchId
+            )
+        }
+
+        is CompactBlockProcessorException.MismatchedNetwork -> {
+            ServerCompatibilityError.Network(
+                clientNetwork = clientNetwork,
+                serverNetwork = serverNetwork
+            )
+        }
+
+        is CompactBlockProcessorException.MismatchedSaplingActivationHeight -> {
+            ServerCompatibilityError.SaplingActivationHeight(
+                clientHeight = clientHeight,
+                serverHeight = serverHeight
+            )
+        }
+
+        else -> {
+            null
+        }
+    }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
@@ -1,10 +1,13 @@
 package co.electriccoin.zcash.ui.common.usecase
 
 import android.content.Context
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.model.ServerCompatibilityError
 import co.electriccoin.zcash.ui.common.model.SubmitResult
 import co.electriccoin.zcash.ui.common.model.SwapAsset
 import co.electriccoin.zcash.ui.common.model.SynchronizerError
+import co.electriccoin.zcash.ui.common.model.toServerCompatibilityError
 import co.electriccoin.zcash.ui.common.provider.BlockchainProvider
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getString
@@ -15,6 +18,7 @@ class SendEmailUseCase(
     private val context: Context,
     private val getSupport: GetSupportUseCase,
     private val blockchainProvider: BlockchainProvider,
+    private val getSelectedEndpoint: GetSelectedEndpointUseCase,
 ) {
     /**
      * Sends a generic email with custom recipient, subject and message.
@@ -56,10 +60,12 @@ class SendEmailUseCase(
      * Sends a support email for a synchronizer error.
      */
     suspend operator fun invoke(synchronizerError: SynchronizerError) {
+        val incompatibility = synchronizerError.toServerCompatibilityError()
         sendSupportEmail(
             subject = context.getString(R.string.app_name),
             messageBody =
                 EmailUtil.formatMessage(
+                    prefix = incompatibility?.let { serverCompatibilityReport(it, getSelectedEndpoint()) },
                     body = synchronizerError.getStackTrace(null),
                     supportInfo = getSupport().toSupportString(SupportInfoType.entries.toSet())
                 )
@@ -252,4 +258,40 @@ internal fun buildGrpcFailureEmailBody(reportDescription: String?): String =
                 appendLine()
                 appendLine(it)
             }
+    }
+
+/**
+ * A readable summary of a server-compatibility failure, placed above the stack trace so that a
+ * support report can be triaged without reading one.
+ *
+ * Deliberately unlocalized, matching the rest of the support report (see
+ * [co.electriccoin.zcash.ui.screen.support.model.AppInfo.toSupportString]): these lines are read by
+ * support staff, not by the user.
+ */
+private fun serverCompatibilityReport(
+    error: ServerCompatibilityError,
+    endpoint: LightWalletEndpoint?
+): String =
+    buildString {
+        appendLine("Incompatible server")
+        appendLine("Error type: ${error.type}")
+        if (endpoint != null) {
+            appendLine("Server: ${endpoint.host}:${endpoint.port}")
+        }
+        when (error) {
+            is ServerCompatibilityError.ConsensusBranch -> {
+                appendLine("Expected consensus branch ID: 0x${error.clientBranchId}")
+                appendLine("Server consensus branch ID: 0x${error.serverBranchId}")
+            }
+
+            is ServerCompatibilityError.Network -> {
+                appendLine("Expected network: ${error.clientNetwork}")
+                appendLine("Server network: ${error.serverNetwork}")
+            }
+
+            is ServerCompatibilityError.SaplingActivationHeight -> {
+                appendLine("Expected Sapling activation height: ${error.clientHeight}")
+                appendLine("Server Sapling activation height: ${error.serverHeight}")
+            }
+        }
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/NavigateToErrorUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/NavigateToErrorUseCase.kt
@@ -5,6 +5,7 @@ import co.electriccoin.lightwallet.client.model.UninitializedTorClientException
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.model.SubmitResult
 import co.electriccoin.zcash.ui.common.model.SynchronizerError
+import co.electriccoin.zcash.ui.common.model.toServerCompatibilityError
 import co.electriccoin.zcash.ui.common.repository.HomeMessageData
 import co.electriccoin.zcash.ui.design.util.getCausesAsSequence
 
@@ -46,8 +47,13 @@ class NavigateToErrorUseCase(
     }
 
     @Suppress("MagicNumber")
-    private fun isSyncError(synchronizerError: SynchronizerError): Boolean =
-        synchronizerError.cause
+    private fun isSyncError(synchronizerError: SynchronizerError): Boolean {
+        // A server the app is incompatible with is a sync error whose remedy is "Switch server",
+        // which only the sync error sheet offers. Without this the mismatch falls through to the
+        // generic error bottom sheet, which shows a stack trace and no way to change server.
+        if (synchronizerError.toServerCompatibilityError() != null) return true
+
+        return synchronizerError.cause
             ?.getCausesAsSequence()
             .orEmpty()
             .any { e ->
@@ -70,6 +76,7 @@ class NavigateToErrorUseCase(
                     else -> false
                 }
             }
+    }
 
     fun requireCurrentArgs() = args as ErrorArgs
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/SyncErrorState.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/SyncErrorState.kt
@@ -2,11 +2,24 @@ package co.electriccoin.zcash.ui.screen.error
 
 import co.electriccoin.zcash.ui.design.component.ButtonState
 import co.electriccoin.zcash.ui.design.component.ModalBottomSheetState
+import co.electriccoin.zcash.ui.design.component.listitem.SimpleListItemState
+import co.electriccoin.zcash.ui.design.util.StringResource
 
 data class SyncErrorState(
     val tryAgain: ButtonState,
     val switchServer: ButtonState,
     val disableTor: ButtonState?,
     val support: ButtonState,
-    override val onBack: () -> Unit
+    override val onBack: () -> Unit,
+    val diagnostics: SyncErrorDiagnosticsState? = null
 ) : ModalBottomSheetState
+
+/**
+ * Extra detail shown only for failures the user can act on knowingly, currently the
+ * server-compatibility family. It is null for generic or transient sync errors, where retrying is
+ * the right remedy and naming internals would only be noise.
+ */
+data class SyncErrorDiagnosticsState(
+    val explanation: StringResource,
+    val facts: List<SimpleListItemState>
+)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/SyncErrorVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/SyncErrorVM.kt
@@ -1,21 +1,27 @@
 package co.electriccoin.zcash.ui.screen.error
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.model.ServerCompatibilityError
+import co.electriccoin.zcash.ui.common.model.toServerCompatibilityError
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.usecase.GetSelectedEndpointUseCase
 import co.electriccoin.zcash.ui.common.usecase.IsTorEnabledUseCase
 import co.electriccoin.zcash.ui.common.usecase.SendEmailUseCase
 import co.electriccoin.zcash.ui.design.component.ButtonState
+import co.electriccoin.zcash.ui.design.component.listitem.SimpleListItemState
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.chooseserver.ChooseServerArgs
 import co.electriccoin.zcash.ui.screen.tor.settings.TorSettingsArgs
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
@@ -25,56 +31,127 @@ class SyncErrorVM(
     private val navigationRouter: NavigationRouter,
     private val sendEmailUseCase: SendEmailUseCase,
     private val synchronizerProvider: SynchronizerProvider,
+    getSelectedEndpointUseCase: GetSelectedEndpointUseCase,
     isTorEnabledUseCase: IsTorEnabledUseCase
 ) : ViewModel() {
     val state: StateFlow<SyncErrorState> =
-        isTorEnabledUseCase
-            .observe()
-            .take(1)
-            .map { isTorEnabled ->
-                createState(isTorEnabled)
-            }.stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
-                initialValue = createState(false)
-            )
+        combine(
+            isTorEnabledUseCase.observe().take(1),
+            getSelectedEndpointUseCase.observe()
+        ) { isTorEnabled, endpoint ->
+            createState(isTorEnabled = isTorEnabled, endpoint = endpoint)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
+            initialValue = createState(isTorEnabled = false, endpoint = null)
+        )
 
     private fun onBack() = navigationRouter.back()
 
-    private fun createState(isTorEnabled: Boolean) =
-        SyncErrorState(
-            tryAgain =
+    private fun createState(
+        isTorEnabled: Boolean,
+        endpoint: LightWalletEndpoint?
+    ) = SyncErrorState(
+        tryAgain =
+            ButtonState(
+                text = stringRes(co.electriccoin.zcash.ui.design.R.string.disconnectHWWallet_tryAgain),
+                icon = R.drawable.ic_sync_error_try_again,
+                trailingIcon = co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right,
+                onClick = ::onTryAgainClick
+            ),
+        switchServer =
+            ButtonState(
+                text = stringRes(R.string.sync_error_switch_server),
+                icon = R.drawable.ic_sync_error_switch_server,
+                trailingIcon = co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right,
+                onClick = ::onSwitchServerClick
+            ),
+        disableTor =
+            if (isTorEnabled) {
                 ButtonState(
-                    text = stringRes(co.electriccoin.zcash.ui.design.R.string.disconnectHWWallet_tryAgain),
-                    icon = R.drawable.ic_sync_error_try_again,
+                    text = stringRes(R.string.sync_error_disable_tor),
+                    icon = R.drawable.ic_sync_error_disable_tor,
                     trailingIcon = co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right,
-                    onClick = ::onTryAgainClick
-                ),
-            switchServer =
-                ButtonState(
-                    text = stringRes(R.string.sync_error_switch_server),
-                    icon = R.drawable.ic_sync_error_switch_server,
-                    trailingIcon = co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right,
-                    onClick = ::onSwitchServerClick
-                ),
-            disableTor =
-                if (isTorEnabled) {
-                    ButtonState(
-                        text = stringRes(R.string.sync_error_disable_tor),
-                        icon = R.drawable.ic_sync_error_disable_tor,
-                        trailingIcon = co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right,
-                        onClick = ::onDisableTorClick
+                    onClick = ::onDisableTorClick
+                )
+            } else {
+                null
+            },
+        support =
+            ButtonState(
+                text = stringRes(R.string.sync_error_contact_support),
+                onClick = ::sendReportClick
+            ),
+        onBack = ::onBack,
+        diagnostics = createDiagnostics(endpoint)
+    )
+
+    /**
+     * Diagnostics are shown only for the server-compatibility family, where the user has to make a
+     * decision (update or switch server) and the specifics tell them which. Generic and transient
+     * sync errors get no detail, because there retrying is the remedy and internals are only noise.
+     */
+    private fun createDiagnostics(endpoint: LightWalletEndpoint?): SyncErrorDiagnosticsState? {
+        val error = args.synchronizerError.toServerCompatibilityError() ?: return null
+        return SyncErrorDiagnosticsState(
+            explanation = stringRes(explanationOf(error)),
+            facts =
+                buildList {
+                    if (endpoint != null) {
+                        add(
+                            SimpleListItemState(
+                                title = stringRes(R.string.sync_error_detail_server),
+                                text = stringRes("${endpoint.host}:${endpoint.port}")
+                            )
+                        )
+                    }
+                    addAll(mismatchFacts(error))
+                    add(
+                        SimpleListItemState(
+                            title = stringRes(R.string.sync_error_detail_error_type),
+                            text = stringRes(error.type)
+                        )
                     )
-                } else {
-                    null
-                },
-            support =
-                ButtonState(
-                    text = stringRes(R.string.sync_error_contact_support),
-                    onClick = ::sendReportClick
-                ),
-            onBack = ::onBack
+                }
         )
+    }
+
+    @StringRes
+    private fun explanationOf(error: ServerCompatibilityError) =
+        when (error) {
+            is ServerCompatibilityError.ConsensusBranch -> R.string.sync_error_incompatible_consensus_message
+            is ServerCompatibilityError.Network -> R.string.sync_error_incompatible_network_message
+            is ServerCompatibilityError.SaplingActivationHeight -> R.string.sync_error_incompatible_sapling_message
+        }
+
+    private fun mismatchFacts(error: ServerCompatibilityError): List<SimpleListItemState> =
+        when (error) {
+            is ServerCompatibilityError.ConsensusBranch -> {
+                listOf(
+                    fact(R.string.sync_error_detail_expected_branch, "0x${error.clientBranchId}"),
+                    fact(R.string.sync_error_detail_server_branch, "0x${error.serverBranchId}")
+                )
+            }
+
+            is ServerCompatibilityError.Network -> {
+                listOfNotNull(
+                    error.clientNetwork?.let { fact(R.string.sync_error_detail_expected_network, it) },
+                    error.serverNetwork?.let { fact(R.string.sync_error_detail_server_network, it) }
+                )
+            }
+
+            is ServerCompatibilityError.SaplingActivationHeight -> {
+                listOf(
+                    fact(R.string.sync_error_detail_expected_sapling, error.clientHeight.toString()),
+                    fact(R.string.sync_error_detail_server_sapling, error.serverHeight.toString())
+                )
+            }
+        }
+
+    private fun fact(
+        @StringRes titleRes: Int,
+        value: String
+    ) = SimpleListItemState(title = stringRes(titleRes), text = stringRes(value))
 
     private fun onTryAgainClick() {
         synchronizerProvider.resetSynchronizer()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/SyncErrorView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/error/SyncErrorView.kt
@@ -22,11 +22,14 @@ import co.electriccoin.zcash.ui.design.component.Spacer
 import co.electriccoin.zcash.ui.design.component.ZashiButton
 import co.electriccoin.zcash.ui.design.component.ZashiCardButton
 import co.electriccoin.zcash.ui.design.component.ZashiScreenModalBottomSheet
+import co.electriccoin.zcash.ui.design.component.listitem.SimpleListItemState
+import co.electriccoin.zcash.ui.design.component.listitem.ZashiSimpleListItem
 import co.electriccoin.zcash.ui.design.component.rememberScreenModalBottomSheetState
 import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -77,10 +80,17 @@ fun SyncErrorContent(
         )
         Spacer(12.dp)
         Text(
-            text = stringResource(R.string.sync_error_message),
+            text = state.diagnostics?.explanation?.getValue() ?: stringResource(R.string.sync_error_message),
             color = ZashiColors.Text.textTertiary,
             style = ZashiTypography.textSm
         )
+        state.diagnostics?.facts?.forEach { fact ->
+            Spacer(12.dp)
+            ZashiSimpleListItem(
+                modifier = Modifier.fillMaxWidth(),
+                state = fact
+            )
+        }
         Spacer(24.dp)
         ZashiCardButton(
             modifier = Modifier.fillMaxWidth(),
@@ -141,6 +151,59 @@ private fun Preview() =
                             onClick = {}
                         ),
                     onBack = {}
+                )
+        )
+    }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewScreens
+@Composable
+private fun IncompatibleServerPreview() =
+    ZcashTheme {
+        SyncErrorView(
+            state =
+                SyncErrorState(
+                    tryAgain =
+                        ButtonState(
+                            text = stringRes("Try again"),
+                            icon = R.drawable.ic_sync_error_try_again,
+                            onClick = {},
+                            trailingIcon = co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right,
+                        ),
+                    switchServer =
+                        ButtonState(
+                            text = stringRes("Switch server"),
+                            icon = R.drawable.ic_sync_error_switch_server,
+                            trailingIcon = co.electriccoin.zcash.ui.design.R.drawable.ic_chevron_right,
+                            onClick = {}
+                        ),
+                    disableTor = null,
+                    support =
+                        ButtonState(
+                            text = stringRes("Contact Support"),
+                            onClick = {}
+                        ),
+                    onBack = {},
+                    diagnostics =
+                        SyncErrorDiagnosticsState(
+                            explanation =
+                                stringRes(
+                                    "ZODL and this server are following different versions of the Zcash " +
+                                        "consensus rules, so syncing can't continue. One of them is on an older " +
+                                        "release — updating ZODL or switching to a different server will get you " +
+                                        "syncing again."
+                                ),
+                            facts =
+                                listOf(
+                                    SimpleListItemState(stringRes("Server"), stringRes("zec.rocks:443")),
+                                    SimpleListItemState(stringRes("Expected branch ID"), stringRes("0x5437f330")),
+                                    SimpleListItemState(stringRes("Server branch ID"), stringRes("0x37a5165b")),
+                                    SimpleListItemState(
+                                        stringRes("Error type"),
+                                        stringRes("MismatchedConsensusBranch")
+                                    )
+                                )
+                        )
                 )
         )
     }

--- a/ui-lib/src/main/res/ui/error/values-es/sync_error_strings.xml
+++ b/ui-lib/src/main/res/ui/error/values-es/sync_error_strings.xml
@@ -5,4 +5,17 @@
     <string name="sync_error_switch_server">Cambiar servidor</string>
     <string name="sync_error_disable_tor">Deshabilitar protección Tor</string>
     <string name="sync_error_contact_support">Contactar Soporte</string>
+
+    <string name="sync_error_incompatible_consensus_message">ZODL y este servidor siguen versiones distintas de las reglas de consenso de Zcash, así que la sincronización no puede continuar. Uno de los dos está en una versión anterior: actualiza ZODL o cambia de servidor para volver a sincronizar.</string>
+    <string name="sync_error_incompatible_network_message">Este servidor está en una red de Zcash distinta de la que ZODL tiene configurada, así que la sincronización no puede continuar. Cambia a un servidor de la misma red.</string>
+    <string name="sync_error_incompatible_sapling_message">ZODL y este servidor no coinciden en la altura de activación de Sapling, así que la sincronización no puede continuar. Actualiza ZODL o cambia de servidor para volver a sincronizar.</string>
+
+    <string name="sync_error_detail_server">Servidor</string>
+    <string name="sync_error_detail_error_type">Tipo de error</string>
+    <string name="sync_error_detail_expected_branch">ID de rama esperado</string>
+    <string name="sync_error_detail_server_branch">ID de rama del servidor</string>
+    <string name="sync_error_detail_expected_network">Red esperada</string>
+    <string name="sync_error_detail_server_network">Red del servidor</string>
+    <string name="sync_error_detail_expected_sapling">Altura Sapling esperada</string>
+    <string name="sync_error_detail_server_sapling">Altura Sapling del servidor</string>
 </resources>

--- a/ui-lib/src/main/res/ui/error/values/sync_error_strings.xml
+++ b/ui-lib/src/main/res/ui/error/values/sync_error_strings.xml
@@ -5,4 +5,22 @@
     <string name="sync_error_switch_server">Switch server</string>
     <string name="sync_error_disable_tor">Disable Tor protection</string>
     <string name="sync_error_contact_support">Contact Support</string>
+
+    <!-- Shown instead of sync_error_message when the app and the server are incompatible. Retrying
+         cannot help in these cases, so the copy points at the two remedies that can. Neither side
+         can be identified as the stale one, so the copy must not blame the server. -->
+    <string name="sync_error_incompatible_consensus_message">ZODL and this server are following different versions of the Zcash consensus rules, so syncing can\'t continue. One of them is on an older release — updating ZODL or switching to a different server will get you syncing again.</string>
+    <string name="sync_error_incompatible_network_message">This server is on a different Zcash network than ZODL is set up for, so syncing can\'t continue. Switch to a server on the same network.</string>
+    <string name="sync_error_incompatible_sapling_message">ZODL and this server disagree about when the Sapling upgrade activated, so syncing can\'t continue. Updating ZODL or switching to a different server will get you syncing again.</string>
+
+    <!-- Labels for the diagnostic facts listed under the explanation above. Kept short so the value
+         beside them stays readable. -->
+    <string name="sync_error_detail_server">Server</string>
+    <string name="sync_error_detail_error_type">Error type</string>
+    <string name="sync_error_detail_expected_branch">Expected branch ID</string>
+    <string name="sync_error_detail_server_branch">Server branch ID</string>
+    <string name="sync_error_detail_expected_network">Expected network</string>
+    <string name="sync_error_detail_server_network">Server network</string>
+    <string name="sync_error_detail_expected_sapling">Expected Sapling height</string>
+    <string name="sync_error_detail_server_sapling">Server Sapling height</string>
 </resources>

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/ServerCompatibilityErrorTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/model/ServerCompatibilityErrorTest.kt
@@ -1,0 +1,114 @@
+package co.electriccoin.zcash.ui.common.model
+
+import cash.z.ecc.android.sdk.exception.CompactBlockProcessorException
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Recognising the failures where ZODL and the lightwalletd server disagree about the state of the
+ * network. These are read off the SDK exception's properties rather than parsed out of its message,
+ * whose wording is not a contract.
+ */
+class ServerCompatibilityErrorTest {
+    @Test
+    fun readsBothBranchIdsFromAConsensusBranchMismatch() {
+        val error =
+            SynchronizerError.Processor(
+                CompactBlockProcessorException.MismatchedConsensusBranch(
+                    clientBranchId = CLIENT_BRANCH_ID,
+                    serverBranchId = SERVER_BRANCH_ID
+                )
+            )
+
+        assertEquals(
+            ServerCompatibilityError.ConsensusBranch(
+                clientBranchId = CLIENT_BRANCH_ID,
+                serverBranchId = SERVER_BRANCH_ID
+            ),
+            error.toServerCompatibilityError()
+        )
+    }
+
+    @Test
+    fun readsBothSidesOfANetworkMismatch() {
+        val error =
+            SynchronizerError.Processor(
+                CompactBlockProcessorException.MismatchedNetwork(
+                    clientNetwork = "mainnet",
+                    serverNetwork = "testnet"
+                )
+            )
+
+        assertEquals(
+            ServerCompatibilityError.Network(clientNetwork = "mainnet", serverNetwork = "testnet"),
+            error.toServerCompatibilityError()
+        )
+    }
+
+    @Test
+    fun readsBothSidesOfASaplingActivationHeightMismatch() {
+        val error =
+            SynchronizerError.Processor(
+                CompactBlockProcessorException.MismatchedSaplingActivationHeight(
+                    clientHeight = 419_200L,
+                    serverHeight = 280_000L
+                )
+            )
+
+        assertEquals(
+            ServerCompatibilityError.SaplingActivationHeight(clientHeight = 419_200L, serverHeight = 280_000L),
+            error.toServerCompatibilityError()
+        )
+    }
+
+    @Test
+    fun findsTheMismatchWhenTheSdkHasWrappedIt() {
+        val wrapped =
+            IllegalStateException(
+                "sync failed",
+                CompactBlockProcessorException.MismatchedConsensusBranch(
+                    clientBranchId = CLIENT_BRANCH_ID,
+                    serverBranchId = SERVER_BRANCH_ID
+                )
+            )
+
+        val result = SynchronizerError.Processor(RuntimeException("outer", wrapped)).toServerCompatibilityError()
+
+        assertEquals(
+            ServerCompatibilityError.ConsensusBranch(
+                clientBranchId = CLIENT_BRANCH_ID,
+                serverBranchId = SERVER_BRANCH_ID
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun ignoresErrorsThatAreNotCompatibilityFailures() {
+        assertNull(SynchronizerError.Processor(IOException("connection reset")).toServerCompatibilityError())
+    }
+
+    @Test
+    fun ignoresErrorsWithNoCauseAtAll() {
+        assertNull(SynchronizerError.Processor(null).toServerCompatibilityError())
+    }
+
+    @Test
+    fun namesTheUnderlyingSdkExceptionAsTheErrorType() {
+        assertEquals(
+            "MismatchedConsensusBranch",
+            ServerCompatibilityError.ConsensusBranch(CLIENT_BRANCH_ID, SERVER_BRANCH_ID).type
+        )
+        assertEquals("MismatchedNetwork", ServerCompatibilityError.Network("mainnet", "testnet").type)
+        assertEquals(
+            "MismatchedSaplingActivationHeight",
+            ServerCompatibilityError.SaplingActivationHeight(1L, 2L).type
+        )
+    }
+}
+
+// NU6.2, which the SDK expects, and NU6.3/Ironwood, observed on a server ahead of the app.
+private const val CLIENT_BRANCH_ID = "5437f330"
+private const val SERVER_BRANCH_ID = "37a5165b"

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/error/NavigateToErrorUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/error/NavigateToErrorUseCaseTest.kt
@@ -1,0 +1,89 @@
+package co.electriccoin.zcash.ui.screen.error
+
+import cash.z.ecc.android.sdk.exception.CompactBlockProcessorException
+import co.electriccoin.lightwallet.client.model.ResponseException
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.common.model.SynchronizerError
+import co.electriccoin.zcash.ui.common.repository.HomeMessageData
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Which sync failures reach the Sync Error sheet. The sheet is the only place that offers "Switch
+ * server", so a failure whose remedy is changing server has to route here rather than to the
+ * generic error sheet, which shows a stack trace and no way to change server.
+ */
+class NavigateToErrorUseCaseTest {
+    @Test
+    fun consensusBranchMismatchOpensTheSyncErrorSheet() {
+        val router = mockk<NavigationRouter>(relaxed = true)
+
+        val handled =
+            NavigateToErrorUseCase(router).navigateToSyncError(
+                error(
+                    CompactBlockProcessorException.MismatchedConsensusBranch(
+                        clientBranchId = "5437f330",
+                        serverBranchId = "37a5165b"
+                    )
+                )
+            )
+
+        assertTrue(handled)
+        verify(exactly = 1) { router.forward(SyncErrorArgs) }
+    }
+
+    @Test
+    fun networkMismatchOpensTheSyncErrorSheet() {
+        val router = mockk<NavigationRouter>(relaxed = true)
+
+        val handled =
+            NavigateToErrorUseCase(router).navigateToSyncError(
+                error(CompactBlockProcessorException.MismatchedNetwork("mainnet", "testnet"))
+            )
+
+        assertTrue(handled)
+        verify(exactly = 1) { router.forward(SyncErrorArgs) }
+    }
+
+    @Test
+    fun saplingActivationHeightMismatchOpensTheSyncErrorSheet() {
+        val router = mockk<NavigationRouter>(relaxed = true)
+
+        val handled =
+            NavigateToErrorUseCase(router).navigateToSyncError(
+                error(CompactBlockProcessorException.MismatchedSaplingActivationHeight(419_200L, 280_000L))
+            )
+
+        assertTrue(handled)
+        verify(exactly = 1) { router.forward(SyncErrorArgs) }
+    }
+
+    @Test
+    fun serverErrorsStillOpenTheSyncErrorSheet() {
+        val router = mockk<NavigationRouter>(relaxed = true)
+
+        val handled =
+            NavigateToErrorUseCase(router).navigateToSyncError(
+                error(ResponseException(503, "unavailable", IOException("transport")))
+            )
+
+        assertTrue(handled)
+        verify(exactly = 1) { router.forward(SyncErrorArgs) }
+    }
+
+    @Test
+    fun unrelatedFailuresAreLeftToTheGenericErrorHandling() {
+        val router = mockk<NavigationRouter>(relaxed = true)
+
+        val handled = NavigateToErrorUseCase(router).navigateToSyncError(error(IOException("boom")))
+
+        assertFalse(handled)
+        verify(exactly = 0) { router.forward(any()) }
+    }
+}
+
+private fun error(cause: Throwable) = HomeMessageData.Error(SynchronizerError.Processor(cause))

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/error/SyncErrorVMTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/error/SyncErrorVMTest.kt
@@ -1,0 +1,178 @@
+package co.electriccoin.zcash.ui.screen.error
+
+import cash.z.ecc.android.sdk.exception.CompactBlockProcessorException
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.model.SynchronizerError
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.usecase.GetSelectedEndpointUseCase
+import co.electriccoin.zcash.ui.common.usecase.IsTorEnabledUseCase
+import co.electriccoin.zcash.ui.common.usecase.SendEmailUseCase
+import co.electriccoin.zcash.ui.design.component.listitem.SimpleListItemState
+import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.screen.chooseserver.ChooseServerArgs
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import java.io.IOException
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The Sync Error sheet's diagnostics: when sync stops because ZODL and the server are incompatible,
+ * the sheet explains why and names the server and both sides of the disagreement. Generic and
+ * transient sync errors, where retrying is the remedy, keep the existing copy and gain no detail.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncErrorVMTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun genericSyncErrorShowsNoDiagnostics() =
+        runTest {
+            val vm = vm(cause = IOException("connection reset"))
+            backgroundScope.launch { vm.state.collect {} }
+
+            assertNull(vm.state.value.diagnostics)
+        }
+
+    @Test
+    fun consensusBranchMismatchExplainsItselfWithoutBlamingEitherSide() =
+        runTest {
+            val vm = vm(cause = consensusMismatch())
+            backgroundScope.launch { vm.state.collect {} }
+
+            val diagnostics = assertNotNull(vm.state.value.diagnostics)
+            assertEquals(stringRes(R.string.sync_error_incompatible_consensus_message), diagnostics.explanation)
+        }
+
+    @Test
+    fun consensusBranchMismatchNamesTheServerAndBothBranchIds() =
+        runTest {
+            val vm = vm(cause = consensusMismatch())
+            backgroundScope.launch { vm.state.collect {} }
+
+            assertEquals(
+                listOf(
+                    fact(R.string.sync_error_detail_server, "zec.rocks:443"),
+                    fact(R.string.sync_error_detail_expected_branch, "0x$CLIENT_BRANCH_ID"),
+                    fact(R.string.sync_error_detail_server_branch, "0x$SERVER_BRANCH_ID"),
+                    fact(R.string.sync_error_detail_error_type, "MismatchedConsensusBranch")
+                ),
+                assertNotNull(vm.state.value.diagnostics).facts
+            )
+        }
+
+    @Test
+    fun serverLineIsOmittedWhenNoEndpointIsSelected() =
+        runTest {
+            val vm = vm(cause = consensusMismatch(), endpoint = null)
+            backgroundScope.launch { vm.state.collect {} }
+
+            val facts = assertNotNull(vm.state.value.diagnostics).facts
+            assertEquals(
+                listOf(
+                    fact(R.string.sync_error_detail_expected_branch, "0x$CLIENT_BRANCH_ID"),
+                    fact(R.string.sync_error_detail_server_branch, "0x$SERVER_BRANCH_ID"),
+                    fact(R.string.sync_error_detail_error_type, "MismatchedConsensusBranch")
+                ),
+                facts
+            )
+        }
+
+    @Test
+    fun networkMismatchOmitsASideThatTheSdkCouldNotName() =
+        runTest {
+            val vm =
+                vm(
+                    cause =
+                        CompactBlockProcessorException.MismatchedNetwork(
+                            clientNetwork = "mainnet",
+                            serverNetwork = null
+                        )
+                )
+            backgroundScope.launch { vm.state.collect {} }
+
+            assertEquals(
+                listOf(
+                    fact(R.string.sync_error_detail_server, "zec.rocks:443"),
+                    fact(R.string.sync_error_detail_expected_network, "mainnet"),
+                    fact(R.string.sync_error_detail_error_type, "MismatchedNetwork")
+                ),
+                assertNotNull(vm.state.value.diagnostics).facts
+            )
+        }
+
+    @Test
+    fun switchServerRoutesToTheServerPickerAndNoButtonIsAdded() =
+        runTest {
+            val router = mockk<NavigationRouter>(relaxed = true)
+            val vm = vm(cause = consensusMismatch(), router = router)
+            backgroundScope.launch { vm.state.collect {} }
+
+            val state = vm.state.value
+            // The remedy already existed; this change must not introduce another button.
+            assertEquals(stringRes(R.string.sync_error_switch_server), state.switchServer.text)
+            assertEquals(stringRes(R.string.sync_error_contact_support), state.support.text)
+            assertNull(state.disableTor)
+
+            state.switchServer.onClick()
+            verify(exactly = 1) { router.forward(ChooseServerArgs) }
+        }
+
+    private fun vm(
+        cause: Throwable?,
+        endpoint: LightWalletEndpoint? = LightWalletEndpoint("zec.rocks", 443, true),
+        router: NavigationRouter = mockk(relaxed = true)
+    ): SyncErrorVM {
+        val isTorEnabled = mockk<IsTorEnabledUseCase>()
+        every { isTorEnabled.observe() } returns flowOf(false)
+        val getSelectedEndpoint = mockk<GetSelectedEndpointUseCase>()
+        every { getSelectedEndpoint.observe() } returns flowOf(endpoint)
+
+        return SyncErrorVM(
+            args = ErrorArgs.SyncError(SynchronizerError.Processor(cause)),
+            navigationRouter = router,
+            sendEmailUseCase = mockk<SendEmailUseCase>(relaxed = true),
+            synchronizerProvider = mockk<SynchronizerProvider>(relaxed = true),
+            getSelectedEndpointUseCase = getSelectedEndpoint,
+            isTorEnabledUseCase = isTorEnabled
+        )
+    }
+}
+
+private fun consensusMismatch() =
+    CompactBlockProcessorException.MismatchedConsensusBranch(
+        clientBranchId = CLIENT_BRANCH_ID,
+        serverBranchId = SERVER_BRANCH_ID
+    )
+
+private fun fact(
+    titleRes: Int,
+    value: String
+) = SimpleListItemState(title = stringRes(titleRes), text = stringRes(value))
+
+// NU6.2, which the SDK expects, and NU6.3/Ironwood, observed on a server ahead of the app.
+private const val CLIENT_BRANCH_ID = "5437f330"
+private const val SERVER_BRANCH_ID = "37a5165b"

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/error/SyncErrorVMTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/error/SyncErrorVMTest.kt
@@ -52,7 +52,7 @@ class SyncErrorVMTest {
     fun genericSyncErrorShowsNoDiagnostics() =
         runTest {
             val vm = vm(cause = IOException("connection reset"))
-            backgroundScope.launch { vm.state.collect {} }
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect {} }
 
             assertNull(vm.state.value.diagnostics)
         }
@@ -61,7 +61,7 @@ class SyncErrorVMTest {
     fun consensusBranchMismatchExplainsItselfWithoutBlamingEitherSide() =
         runTest {
             val vm = vm(cause = consensusMismatch())
-            backgroundScope.launch { vm.state.collect {} }
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect {} }
 
             val diagnostics = assertNotNull(vm.state.value.diagnostics)
             assertEquals(stringRes(R.string.sync_error_incompatible_consensus_message), diagnostics.explanation)
@@ -71,7 +71,7 @@ class SyncErrorVMTest {
     fun consensusBranchMismatchNamesTheServerAndBothBranchIds() =
         runTest {
             val vm = vm(cause = consensusMismatch())
-            backgroundScope.launch { vm.state.collect {} }
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect {} }
 
             assertEquals(
                 listOf(
@@ -88,7 +88,7 @@ class SyncErrorVMTest {
     fun serverLineIsOmittedWhenNoEndpointIsSelected() =
         runTest {
             val vm = vm(cause = consensusMismatch(), endpoint = null)
-            backgroundScope.launch { vm.state.collect {} }
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect {} }
 
             val facts = assertNotNull(vm.state.value.diagnostics).facts
             assertEquals(
@@ -112,7 +112,7 @@ class SyncErrorVMTest {
                             serverNetwork = null
                         )
                 )
-            backgroundScope.launch { vm.state.collect {} }
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect {} }
 
             assertEquals(
                 listOf(
@@ -129,7 +129,7 @@ class SyncErrorVMTest {
         runTest {
             val router = mockk<NavigationRouter>(relaxed = true)
             val vm = vm(cause = consensusMismatch(), router = router)
-            backgroundScope.launch { vm.state.collect {} }
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect {} }
 
             val state = vm.state.value
             // The remedy already existed; this change must not introduce another button.


### PR DESCRIPTION
Android counterpart of zodl-ios#1948 / zodl-ios#1947.

## The scenario

A lightwalletd server publishes a consensus branch ID the app doesn't expect — in practice a server on NU6.3/Ironwood (`0x37a5165b`) while the SDK expects NU6.2 (`0x5437f330`). Sync can never progress.

Branch IDs are unordered constants, so the error itself cannot say which side is stale. **In the observed case the app was behind, not the server**, so neither the copy nor the code blames the server.

## The gap this fixes

Android's gap was the inverse of iOS's. The SDK's message was already fine — already hex, already naming both remedies — but the user was shown none of it.

Two problems, and the second was the bigger one:

1. **The sheet showed nothing specific.** `SyncErrorView` rendered a generic `sync_error_message` ("check your connection, restart the app") plus four buttons. That copy is actively wrong here: restarting cannot help.
2. **These failures never reached that sheet at all.** `NavigateToErrorUseCase.isSyncError()` matched only `ResponseException` 5xx, code 3200 transport errors, and `UninitializedTorClientException`. `MismatchedConsensusBranch` is a `CompactBlockProcessorException`, so it fell through to the generic error bottom sheet — a truncated stack trace with **no Switch server button**, i.e. no route to the one remedy that works.

Support also received only `getStackTrace(null)`, with the useful sentence buried in a Java trace.

## What changed

- **Routing** — the server-compatibility family (`MismatchedConsensusBranch`, `MismatchedNetwork`, `MismatchedSaplingActivationHeight`) now routes to the Sync Error sheet, where **Switch server already exists**. No button was added.
- **Sheet** — for this family only, the generic message is replaced by a written explanation, followed by one labelled fact per line: the selected server, both sides of the disagreement, and the error type. Generic and transient sync errors are untouched and gain no detail, since retrying is the correct remedy there.
- **Support report** — leads with the same facts in readable form, above the stack trace (which is kept). Unlocalized, matching `AppInfo`/`EnvironmentInfo` in the existing report, since support staff read it.
- New `ServerCompatibilityError` is the single source of truth shared by the routing gate, the sheet and the email.

Values are read off the SDK exception's **properties**, not parsed out of its message — that wording is not a contract.

## Design

`ZashiSimpleListItem` (the existing label/value row, already used for fact lists in Swap and Review Transaction) inside the existing sheet structure. It wraps values in a `SelectionContainer`, so users can copy a branch ID straight into a support message. Only `ZashiColors`/`ZashiTypography`/`Spacer(dp)` tokens; no new components, no hardcoded colors. Strings in `values/` and `values-es/`. A second `@PreviewScreens` preview covers the diagnostics variant.

## Not built on

`Synchronizer.validateConsensusBranch()` (broken, [SDK#1405](https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/issues/1405)) and `ext/ConsensusBranchId.kt` (hardcoded enum stopping at CANOPY — `fromHex("37a5165b")` returns null and both sides read as "unknown").

## Verification

Run against the SDK change composite-built in (`-PSDK_INCLUDED_BUILD_PATH`), on JDK 21.

**`./gradlew :ui-lib:testZcashmainnetStoreDebugUnitTest` — passing, exit code 0.**

```
471 tests, 0 failed, 0 skipped

NavigateToErrorUseCaseTest:    5 tests, 0 failed
ServerCompatibilityErrorTest:  7 tests, 0 failed
SyncErrorVMTest:               6 tests, 0 failed
```

**`./gradlew ktlint detektAll` — passing, exit code 0.**

18 new tests cover: reading the mismatch off each of the three exception types, finding it through a wrapped cause chain, ignoring unrelated errors, the routing decision for each type (and that unrelated failures are still left alone), the rendered fact list including the server line, omission of the server line when no endpoint is selected, omission of a side the SDK could not name, and that Switch server still routes to `ChooseServerArgs` with no button added.

**`./gradlew :ui-lib:pixel2TargetZcashmainnetStoreDebugAndroidTest` — passing, exit code 0.**

```
Starting 4 tests on pixel2Target
Finished 4 tests on pixel2Target
BUILD SUCCESSFUL
```

`SyncErrorViewTest` renders `SyncErrorContent` directly on a Gradle managed device (Pixel 2, API 36, Google APIs ARM64) and asserts the generic sheet keeps its default message with no detail rows, the explanation replaces that message for an incompatible server, the server and both branch IDs render, and Switch server is present with no extra button.

BEFORE/AFTER screenshots are attached in a comment below.

## ⛔ Still blocked on the SDK

Depends on zcash/zcash-android-wallet-sdk#2053, which promotes those constructor params to `val`s. That PR targets `maint/v2.5.x` and merges forward; since this app tracks `ZCASH_SDK_VERSION=2.6.5-SNAPSHOT`, it will pick the change up with **no version bump**.

The passing run above used a local composite build of that SDK branch. **CI here will fail until #2053 merges forward and a snapshot publishes** — hence still draft.


## UI changes 

### Before
<img width="1080" height="1017" alt="sync-error-BEFORE-generic" src="https://github.com/user-attachments/assets/56a241f0-bb1c-40fc-87e5-cfaf259dfc18" />

### After 
<img width="1080" height="1367" alt="sync-error-AFTER-incompatible-server" src="https://github.com/user-attachments/assets/ab8d9c30-d6d2-4b89-bea9-b9dad2a12c16" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
