### PR TITLE
[MOB-1587] Restrict Android 12+ device-to-device transfer to address book and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed:
+- Transferring to a new phone via device-to-device setup no longer copies the app's local data, including the undecryptable encrypted preferences file, which previously forced a manual seed re-restore on the new device. Only the address book and metadata backups are carried over, matching cloud backup.
+
 ## [3.8.1 (2025)] - 2026-07-29
 
 ### Fixed:

--- a/app/src/main/res/xml/auto_backup_config_android_12.xml
+++ b/app/src/main/res/xml/auto_backup_config_android_12.xml
@@ -8,4 +8,12 @@
             domain="file"
             path="metadata/." />
     </cloud-backup>
+    <device-transfer>
+        <include
+            domain="file"
+            path="address_book/." />
+        <include
+            domain="file"
+            path="metadata/." />
+    </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
## Summary

On Android 12+, `dataExtractionRules` controls both cloud backup **and** the device-to-device (D2D) migration wizard used when setting up a new phone from an old one. `app/src/main/res/xml/auto_backup_config_android_12.xml` only declared a `<cloud-backup>` section; with `<device-transfer>` omitted, the system defaults to transferring essentially all app data during D2D setup.

In practice this meant the encrypted SharedPreferences file (the seed store) was copied to the new device, arrived undecryptable there (its key is bound to the old device's hardware Keystore), and was wiped — forcing users into a manual seed re-restore flow, with a birthday-truncation hazard. Stale standard preferences also leaked across devices this way.

This PR adds an explicit `<device-transfer>` section mirroring the existing `<cloud-backup>` includes (`address_book/.`, `metadata/.`), so D2D transfer is restricted to the same two paths already used for cloud backup. The pre-Android-12 config (`auto_backup_config.xml`) already restricts to these same paths and needs no change.

Linear: https://linear.app/zodl/issue/MOB-1587/android-d2d-device-transfer-copies-encrypted-prefs-seed-store-missing

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)