### PR TITLE
Release 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [3.8.1 (2025)] - 2026-07-29
+
+### Fixed:
+- Corrected several issues affecting how balances and transaction details were displayed. Your funds are safe, this only fixes how the wallet shows the values.
+
 ## [3.8.0 (2023)] - 2026-07-27
 
 ### Changed:

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.8.1 (2025)] - 2026-07-29
+
+### Fixed:
+- Corrected several issues affecting how balances and transaction details were displayed. Your funds are safe, this only fixes how the wallet shows the values.
+
 ## [3.8.0 (2023)] - 2026-07-27
 
 ### Added:

--- a/docs/whatsNew/WHATS_NEW_ES.md
+++ b/docs/whatsNew/WHATS_NEW_ES.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.8.1 (2025)] - 2026-07-29
+
+### Corregido:
+- Corregimos varios problemas que afectaban a la visualización del saldo y los detalles de las transacciones. Tus fondos están seguros: esto solo corrige cómo la billetera muestra los valores.
+
 ## [3.8.0 (2023)] - 2026-07-27
 
 ### Añadido:

--- a/fastlane/metadata/android/en-US/changelogs/2025.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2025.txt
@@ -1,0 +1,2 @@
+Fixed:
+- Corrected several issues affecting how balances and transaction details were displayed. Your funds are safe, this only fixes how the wallet shows the values.

--- a/fastlane/metadata/android/es/changelogs/2025.txt
+++ b/fastlane/metadata/android/es/changelogs/2025.txt
@@ -1,0 +1,2 @@
+Corregido:
+- Corregimos varios problemas que afectaban a la visualización del saldo y los detalles de las transacciones. Tus fondos están seguros: esto solo corrige cómo la billetera muestra los valores.

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ NDK_DEBUG_SYMBOL_LEVEL=symbol_table
 # VERSION_CODE is effectively ignored. VERSION_NAME is suffixed with the version code.
 # If not using automated Google Play deployment, then these serve as the actual version numbers.
 ZCASH_VERSION_CODE=1
-ZCASH_VERSION_NAME=3.8.0
+ZCASH_VERSION_NAME=3.8.1
 
 # Set these fields, as you need them (e.g. with values "Zcash X" and "co.electriccoin.zcash.x")
 # to distinguish a different release build that can be installed alongside the official version
@@ -211,7 +211,7 @@ KTOR_VERSION =3.4.0
 # WARNING: Ensure a non-snapshot version is used before releasing to production
 ZCASH_BIP39_VERSION=1.0.9
 # WARNING: Ensure a non-snapshot version is used before releasing to production
-ZCASH_SDK_VERSION=2.8.0-rc.1-SNAPSHOT
+ZCASH_SDK_VERSION=2.8.0-rc.2-SNAPSHOT
 
 # Toolchain is the Java version used to build the application, which is separate from the
 # Java version used to run the application.


### PR DESCRIPTION
Closes #2376

## Changes

## [3.8.1 (2025)] - 2026-07-29

### Fixed:
- Corrected several issues affecting how balances and transaction details were displayed. Your funds are safe, this only fixes how the wallet shows the values.

Also updates `ZCASH_SDK_VERSION` to `2.8.0-rc.2-SNAPSHOT`.