### PR TITLE
fix: increase the resolution of the abbreviated transaction ID (MOB-1610)

### DIFF
--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/util/StringResource.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/util/StringResource.kt
@@ -411,11 +411,11 @@ private fun String.ellipsizeMiddle(size: Int): String {
 private fun String.ellipsizeEnd(size: Int) = "${this.take(size)}$DOTS"
 
 private fun StringResource.ByTransactionId.convertTransactionId(): String =
-    if (abbreviated) transactionId.ellipsizeMiddle(TRANSACTION_MAX_PREFIX_SUFFIX_LENGTH) else transactionId
+    if (abbreviated) transactionId.ellipsizeMiddle(TRANSACTION_MAX_LENGTH_ABBREVIATED) else transactionId
 
 private const val DOTS = "..."
 
-private const val TRANSACTION_MAX_PREFIX_SUFFIX_LENGTH = 5
+private const val TRANSACTION_MAX_LENGTH_ABBREVIATED = 10
 
 private const val ADDRESS_MAX_LENGTH_ABBREVIATED = 20
 


### PR DESCRIPTION
Closes [MOB-1610](https://linear.app/zodl/issue/MOB-1610/low-resolution-of-truncated-txid-on-android).

## Problem

The abbreviated transaction ID on the transaction detail screen renders as `13...a8` — only 2+2 characters. iOS shows 5+5 (`prefix(5)...suffix(5)`), which is what Neal flagged in [Slack](https://zodl.slack.com/archives/C0A8RHV7KEW/p1785338472896489?thread_ts=1785338430.655699&cid=C0A8RHV7KEW).

## Root cause

The `ellipsizeMiddle` rework in MOB-1001 (ec0572be0) changed the parameter semantics from *per-side* length (`take(size)...takeLast(size)`) to *total* length (`take(size/2)...takeLast(size/2)`), but the transaction ID call site kept passing `TRANSACTION_MAX_PREFIX_SUFFIX_LENGTH = 5` — so 5 became 2+2 via integer division. Addresses were unaffected because they pass 20 (→ 10+10).

## Fix

Renamed the constant to `TRANSACTION_MAX_LENGTH_ABBREVIATED` to match the total-length semantics and set it to 10, so the abbreviated transaction ID shows 5+5 characters — parity with iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)