### PR TITLE
Merge release/v3.8.1 (2027) back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [3.8.1 (2027)] - 2026-07-30
+
+### Fixed:
+- Corrected several issues affecting how balances and transaction details were displayed. Your funds are safe, this only fixes how the wallet shows the values.
+
 ## [3.8.1 (2025)] - 2026-07-29
 
 ### Fixed:

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.8.1 (2027)] - 2026-07-30
+
+### Fixed:
+- Corrected several issues affecting how balances and transaction details were displayed. Your funds are safe, this only fixes how the wallet shows the values.
+
 ## [3.8.1 (2025)] - 2026-07-29
 
 ### Fixed:

--- a/docs/whatsNew/WHATS_NEW_ES.md
+++ b/docs/whatsNew/WHATS_NEW_ES.md
@@ -12,6 +12,11 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.8.1 (2027)] - 2026-07-30
+
+### Corregido:
+- Corregimos varios problemas que afectaban a la visualización del saldo y los detalles de las transacciones. Tus fondos están seguros: esto solo corrige cómo la billetera muestra los valores.
+
 ## [3.8.1 (2025)] - 2026-07-29
 
 ### Corregido:

--- a/fastlane/metadata/android/en-US/changelogs/2027.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2027.txt
@@ -1,0 +1,2 @@
+Fixed:
+- Corrected several issues affecting how balances and transaction details were displayed. Your funds are safe, this only fixes how the wallet shows the values.

--- a/fastlane/metadata/android/es/changelogs/2027.txt
+++ b/fastlane/metadata/android/es/changelogs/2027.txt
@@ -1,0 +1,2 @@
+Corregido:
+- Corregimos varios problemas que afectaban a la visualización del saldo y los detalles de las transacciones. Tus fondos están seguros: esto solo corrige cómo la billetera muestra los valores.

--- a/gradle.properties
+++ b/gradle.properties
@@ -211,7 +211,7 @@ KTOR_VERSION =3.4.0
 # WARNING: Ensure a non-snapshot version is used before releasing to production
 ZCASH_BIP39_VERSION=1.0.9
 # WARNING: Ensure a non-snapshot version is used before releasing to production
-ZCASH_SDK_VERSION=2.8.0-rc.2-SNAPSHOT
+ZCASH_SDK_VERSION=2.8.0-rc.3-SNAPSHOT
 
 # Toolchain is the Java version used to build the application, which is separate from the
 # Java version used to run the application.


### PR DESCRIPTION
Brings the 3.8.1 (2027) release preparation back to `main`: the `[3.8.1 (2027)]` changelog/whatsNew sections, fastlane `2027.txt` changelogs, and the `ZCASH_SDK_VERSION` bump to `2.8.0-rc.3-SNAPSHOT`.

Follow-up to https://github.com/zodl-inc/zodl-android/pull/2380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)