### PR TITLE
ci(deploy): raise Play Store upload step timeout to 25 minutes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -220,7 +220,7 @@ jobs:
         run: |
           unzip binaries.zip
       - name: Upload to Play Store
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           # TODO [#1033]: Use token-based authorization on Google Play for automated deployment
           # TODO [#1033]: https://github.com/Electric-Coin-Company/zashi-android/issues/1033


### PR DESCRIPTION
## Problem

Every Google Play release run reports failure even though the app actually reaches the Play track. Example: [run 30523111990](https://github.com/zodl-inc/zodl-android/actions/runs/30523111990) for `release/v3.8.1`:

```
##[error]The action 'Upload to Play Store' has timed out after 10 minutes.
```

## Cause

The **Upload to Play Store** step runs `./gradlew :app:publishToGooglePlay`, which rebuilds the release bundle inside the `deploy` job before the actual upload starts. On a cold Gradle cache the build alone takes ~9.5 of the step's 10 allotted minutes:

- 07:58:13 — `:app:bundleZcashmainnetStoreRelease` finishes
- 07:58:15 — `:app:publishToGooglePlay` starts (Play edit created)
- 07:58:23 — step killed at the 10-minute mark, mid-publish

The Play edit usually still lands, so the deploy "fails" in CI while succeeding in reality.

## Fix

Raise the step's `timeout-minutes` from 10 to 25, matching the budget of the equivalent **Build release artifacts** step in the `build` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)