### PR TITLE
fix: keep expired transactions terminal during sync (MOB-1577)

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/TransactionRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/TransactionRepository.kt
@@ -82,6 +82,7 @@ class TransactionRepositoryImpl(
                                                     transactionState =
                                                         createTransactionState(
                                                             minedHeight = it.minedHeight,
+                                                            transactionState = it.transactionState,
                                                             isSyncing = status == Synchronizer.Status.SYNCING
                                                         ) ?: it.transactionState
                                                 )
@@ -239,9 +240,14 @@ class TransactionRepositoryImpl(
             }
         }
 
-    private fun createTransactionState(minedHeight: BlockHeight?, isSyncing: Boolean): TransactionState? =
+    internal fun createTransactionState(
+        minedHeight: BlockHeight?,
+        transactionState: TransactionState,
+        isSyncing: Boolean
+    ): TransactionState? =
         when {
             minedHeight != null -> Confirmed
+            transactionState == Expired -> null
             isSyncing -> Pending
             else -> null
         }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/TransactionStateNormalizationTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/TransactionStateNormalizationTest.kt
@@ -1,0 +1,98 @@
+package co.electriccoin.zcash.ui.common.repository
+
+import cash.z.ecc.android.sdk.model.BlockHeight
+import cash.z.ecc.android.sdk.model.TransactionState.Confirmed
+import cash.z.ecc.android.sdk.model.TransactionState.Expired
+import cash.z.ecc.android.sdk.model.TransactionState.Pending
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Regression coverage for MOB-1577: expired-unmined transactions were flipping between
+ * "Sending..." and "Sending failed" once per sync cycle because `createTransactionState`
+ * overrode the terminal `Expired` SDK state with `Pending` whenever a sync round was in
+ * progress. The fix makes `Expired` sticky by never normalizing it away.
+ */
+class TransactionStateNormalizationTest {
+    private val repository = TransactionRepositoryImpl(mockk(relaxed = true), mockk(relaxed = true))
+
+    private val minedHeight = BlockHeight.new(1_000_000L)
+
+    @Test
+    fun expiredAndSyncingStaysExpired() {
+        val result =
+            repository.createTransactionState(
+                minedHeight = null,
+                transactionState = Expired,
+                isSyncing = true
+            )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun expiredAndNotSyncingStaysExpired() {
+        val result =
+            repository.createTransactionState(
+                minedHeight = null,
+                transactionState = Expired,
+                isSyncing = false
+            )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun unminedPendingAndSyncingBecomesPending() {
+        val result =
+            repository.createTransactionState(
+                minedHeight = null,
+                transactionState = Pending,
+                isSyncing = true
+            )
+
+        assertEquals(Pending, result)
+    }
+
+    @Test
+    fun unminedPendingAndNotSyncingStaysUnchanged() {
+        val result =
+            repository.createTransactionState(
+                minedHeight = null,
+                transactionState = Pending,
+                isSyncing = false
+            )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun minedTransactionBecomesConfirmedRegardlessOfStateOrSyncFlag() {
+        assertEquals(
+            Confirmed,
+            repository.createTransactionState(
+                minedHeight = minedHeight,
+                transactionState = Pending,
+                isSyncing = true
+            )
+        )
+        assertEquals(
+            Confirmed,
+            repository.createTransactionState(
+                minedHeight = minedHeight,
+                transactionState = Expired,
+                isSyncing = false
+            )
+        )
+        assertEquals(
+            Confirmed,
+            repository.createTransactionState(
+                minedHeight = minedHeight,
+                transactionState = Confirmed,
+                isSyncing = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes [MOB-1577](https://linear.app/zodl/issue/MOB-1577/expired-transactions-flip-between-sending-and-sending-failed-during): expired-unmined transactions flipped between "Sending…" and "Sending failed" roughly once per sync cycle, even though the wallet DB state was stable and correct (`expired_unmined = 1`).

## Root cause

`TransactionRepositoryImpl.createTransactionState` overrode every unmined sent transaction to `Pending` ("Sending…") whenever `Synchronizer.Status == SYNCING`, then fell back to the SDK's terminal `Expired` state ("Sending failed") between sync rounds. On testnet (a block every ~minute) the label never settled.

## Fix

`Expired` is now sticky: the sync-driven normalization never overrides a terminal `Expired` SDK state — only `Confirmed` (mined) can supersede it. The SDK will not rebroadcast expired transactions, so this was purely a display-state bug, but a dangerous one: users could act on a transient "Sending failed" and re-send.

## Testing

- New `TransactionStateNormalizationTest` covers the full normalization matrix (expired stays expired while syncing and idle, unmined pending shows Pending during sync, mined is always Confirmed).
- Regression case verified to fail against the pre-fix implementation.
- `./gradlew :ui-lib:testZcashmainnetStoreDebugUnitTest`, `ktlint`, `detektAll` all green.

## Note for maintainers

Based on `maint/v3.8.x` per the maintenance-branch model; merge forward to `main` after landing. iOS parity is tracked as MOB-1578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)