### PR TITLE
ci(e2e): restore Android Smoke E2E coverage

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -91,6 +91,32 @@ jobs:
           name: zodl-android-debug-apk
           path: apk
 
+      # Fail before starting the emulator when the shared E2E wallet
+      # configuration is incomplete. Do not print any secret values.
+      - name: Validate smoke wallet configuration
+        env:
+          ZODL_TEST_SEED_ANDROID: ${{ secrets.ZODL_TEST_SEED_ANDROID }}
+          ZODL_TEST_BIRTHDAY_ANDROID: ${{ secrets.ZODL_TEST_BIRTHDAY_ANDROID }}
+          ZODL_TEST_ADDRESS_ANDROID: ${{ secrets.ZODL_TEST_ADDRESS_ANDROID }}
+          ZODL_TEST_SEED_IOS: ${{ secrets.ZODL_TEST_SEED_IOS }}
+          ZODL_TEST_BIRTHDAY_IOS: ${{ secrets.ZODL_TEST_BIRTHDAY_IOS }}
+          ZODL_TEST_ADDRESS_IOS: ${{ secrets.ZODL_TEST_ADDRESS_IOS }}
+        run: |
+          required=(
+            ZODL_TEST_SEED_ANDROID
+            ZODL_TEST_BIRTHDAY_ANDROID
+            ZODL_TEST_ADDRESS_ANDROID
+            ZODL_TEST_SEED_IOS
+            ZODL_TEST_BIRTHDAY_IOS
+            ZODL_TEST_ADDRESS_IOS
+          )
+          for name in "${required[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::$name is not configured"
+              exit 1
+            fi
+          done
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules


### PR DESCRIPTION
## What changed

- Validates the Android and iOS E2E wallet seed, birthday, and address configuration before starting the Android emulator.
- Does not print or otherwise expose secret values.
- Uses this PR to exercise the Android Smoke E2E suite against the newly funded Android test wallet, with follow-up fixes added from observed CI failures.

## Why

The Android Smoke E2E suite depends on shared mainnet wallet configuration. Missing or stale configuration was previously detected only after the expensive emulator setup and inside the external QA wrapper, making failures slow and less obvious.

## Validation

- `git diff --check`
- GitHub Actions Smoke E2E run on this PR (pending)
