### PR TITLE
Extract migration UI strings + Spanish translation

### DIFF
--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationPreparationDetails.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationPreparationDetails.kt
@@ -30,6 +30,14 @@ data class MigrationPreparationStepDetail(
     val isDone: Boolean = false,
 )
 
+// NOTE: these helpers deliberately stay ByString literals (not Android string resources) — they're
+// unit-tested in plain JVM tests (MigrationPreparationDetailsTest, MigrationProgressVMTest,
+// MigrationReviewPlanShapeTest) via a StringResource.ByString-only reflection helper with no
+// Android Context available to resolve a real resource. Converting them would either throw in
+// those tests or require reworking that shared test harness — tracked as a known gap: these
+// specific dynamic status words are not localized. See migrationSetup_title etc. for the
+// resource-backed pattern used everywhere else in this module.
+
 /** "Transaction N of M" — shared so both screens render identical copy. */
 fun preparationStepTitle(number: Int, stepCount: Int): StringResource = stringRes("Transaction $number of $stepCount")
 

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationTransferFailureState.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationTransferFailureState.kt
@@ -1,9 +1,12 @@
 package co.electriccoin.zcash.ui.common.model.migration
 
 import cash.z.ecc.android.sdk.TransferResult
+import co.electriccoin.zcash.ui.design.util.StringResource
+import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 data class MigrationTransferFailureState(
-    val message: String,
+    val message: StringResource,
     // Null when the failure isn't safely resubmittable (e.g. a non-retryable SubmitResult) — the
     // shared bottom sheet omits the Retry button entirely in that case rather than silently
     // wiring it to mean "go back".
@@ -11,10 +14,10 @@ data class MigrationTransferFailureState(
     val onDismiss: () -> Unit,
 )
 
-fun migrationFailureMessage(result: TransferResult): String =
+fun migrationFailureMessage(result: TransferResult): StringResource =
     when (result) {
-        is TransferResult.NetworkError -> "Couldn't reach the network. Check your connection and try again."
-        TransferResult.InvalidNote -> "This transfer's note was already spent elsewhere. Reschedule to plan a new one."
-        TransferResult.Expired -> "This transfer's anchor expired. Reschedule to plan a new one."
+        is TransferResult.NetworkError -> stringRes(DesignR.string.migrationFailureMessage_networkError)
+        TransferResult.InvalidNote -> stringRes(DesignR.string.migrationFailureMessage_invalidNote)
+        TransferResult.Expired -> stringRes(DesignR.string.migrationFailureMessage_expired)
         is TransferResult.Success -> error("migrationFailureMessage called with a Success result")
     }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/battery/MigrationBatteryScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/battery/MigrationBatteryScreen.kt
@@ -41,12 +41,14 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.scaffoldPadding
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Serializable
 data object MigrationBatteryArgs
@@ -126,34 +128,34 @@ fun MigrationBatteryView(state: MigrationBatteryState) {
                     .scaffoldPadding(padding),
         ) {
             Text(
-                text = "Allow Background Delivery",
+                text = stringRes(DesignR.string.migrationBattery_title).getValue(),
                 style = ZashiTypography.header6,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "To send migration transfers at their scheduled times, Zodl needs to keep running in the background. Allow background activity for Zodl in your device settings.",
+                text = stringRes(DesignR.string.migrationBattery_body).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
             Spacer(Modifier.height(24.dp))
             BatteryFeatureItem(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_battery_clock_check,
-                title = "Transfers send at their scheduled windows",
-                body = "Zodl wakes up and sends each transfer at its scheduled time — no action needed.",
+                title = stringRes(DesignR.string.migrationBattery_scheduledWindowsTitle).getValue(),
+                body = stringRes(DesignR.string.migrationBattery_scheduledWindowsBody).getValue(),
             )
             Spacer(Modifier.height(16.dp))
             BatteryFeatureItem(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_battery_face_smile,
-                title = "No need to open the app for each send",
-                body = "Once the schedule is committed, all transfers are sent in the background.",
+                title = stringRes(DesignR.string.migrationBattery_noNeedToOpenTitle).getValue(),
+                body = stringRes(DesignR.string.migrationBattery_noNeedToOpenBody).getValue(),
             )
             Spacer(Modifier.height(16.dp))
             BatteryFeatureItem(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_battery_check_heart,
-                title = "Sends on a fixed schedule, not your activity",
-                body = "Transfers go out at set network-wide times, so they're not linked to when you open Zodl.",
+                title = stringRes(DesignR.string.migrationBattery_fixedScheduleTitle).getValue(),
+                body = stringRes(DesignR.string.migrationBattery_fixedScheduleBody).getValue(),
             )
             Spacer(Modifier.weight(1f))
             Row(modifier = Modifier.fillMaxWidth()) {
@@ -165,14 +167,14 @@ fun MigrationBatteryView(state: MigrationBatteryState) {
                 )
                 Spacer(Modifier.width(12.dp))
                 Text(
-                    text = "Without this permission, you'll need to open Zodl manually at each scheduled time to send.",
+                    text = stringRes(DesignR.string.migrationBattery_withoutPermissionHint).getValue(),
                     style = ZashiTypography.textXs,
                     color = ZashiColors.Utility.WarningYellow.utilityOrange700,
                 )
             }
             Spacer(Modifier.height(24.dp))
             ZashiButton(
-                state = ButtonState(text = stringRes("Skip"), onClick = state.onSkip),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_skip), onClick = state.onSkip),
                 modifier = Modifier.fillMaxWidth(),
                 defaultPrimaryColors =
                     ZashiButtonDefaults.destructive1Colors(
@@ -183,7 +185,7 @@ fun MigrationBatteryView(state: MigrationBatteryState) {
             )
             Spacer(Modifier.height(12.dp))
             ZashiButton(
-                state = ButtonState(text = stringRes("Allow"), onClick = state.onAllow),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_allow), onClick = state.onAllow),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
@@ -50,6 +50,7 @@ import co.electriccoin.zcash.ui.screen.common.PrivacyDisclaimerCard
 import co.electriccoin.zcash.ui.screen.migration.component.MigrationFailureBottomSheet
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 data class MigrationCompleteState(
     val totalTransferred: StringResource,
@@ -124,7 +125,7 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                 )
                 Spacer(Modifier.height(24.dp))
                 Text(
-                    text = "Migration Complete",
+                    text = stringRes(DesignR.string.migrationComplete_title).getValue(),
                     style = ZashiTypography.header5,
                     fontWeight = FontWeight.SemiBold,
                     color = ZashiColors.Text.textPrimary,
@@ -132,7 +133,7 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = "Your ZEC is now in the Ironwood pool.",
+                    text = stringRes(DesignR.string.migrationComplete_subtitle).getValue(),
                     style = ZashiTypography.textSm,
                     color = ZashiColors.Text.textTertiary,
                     textAlign = TextAlign.Center,
@@ -147,18 +148,30 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                             .padding(20.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    SummaryRow(label = "Total transferred", value = state.totalTransferred.getValue())
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationComplete_totalTransferredLabel).getValue(),
+                        value = state.totalTransferred.getValue(),
+                    )
                     state.remainingDust?.let { dust ->
-                        SummaryRow(label = "Remaining dust", value = dust.getValue())
+                        SummaryRow(
+                            label = stringRes(DesignR.string.migrationComplete_remainingDustLabel).getValue(),
+                            value = dust.getValue(),
+                        )
                     }
-                    SummaryRow(label = "Transfers", value = state.transfersProgress.getValue())
-                    SummaryRow(label = "Duration", value = state.duration.getValue())
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationComplete_transfersLabel).getValue(),
+                        value = state.transfersProgress.getValue(),
+                    )
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationComplete_durationLabel).getValue(),
+                        value = state.duration.getValue(),
+                    )
                 }
             }
             when {
                 state.remainingDust == null -> {
                     ZashiButton(
-                        state = ButtonState(text = stringRes("Got it"), onClick = state.onDone),
+                        state = ButtonState(text = stringRes(DesignR.string.migration_common_gotIt), onClick = state.onDone),
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -168,7 +181,7 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                     LockedDisclaimer(dustAmount = state.remainingDust.getValue())
                     Spacer(Modifier.height(20.dp))
                     ZashiButton(
-                        state = ButtonState(text = stringRes("Got it"), onClick = state.onDone),
+                        state = ButtonState(text = stringRes(DesignR.string.migration_common_gotIt), onClick = state.onDone),
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -176,17 +189,25 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                 else -> {
                     Spacer(Modifier.height(20.dp))
                     PrivacyDisclaimerCard(
-                        title = "Orchard balance remaining",
+                        title = stringRes(DesignR.string.migrationComplete_orchardBalanceRemainingTitle).getValue(),
                         body =
-                            "${state.remainingDust.getValue()} stayed in Orchard. An amount this " +
-                                "specific can identify you on the network. To protect your privacy, we " +
-                                "recommend locking this balance rather than migrating it.",
+                            stringRes(
+                                DesignR.string.migrationComplete_orchardBalanceRemainingBody,
+                                state.remainingDust.getValue()
+                            ).getValue(),
                     )
                     Spacer(Modifier.height(20.dp))
                     ZashiButton(
                         state =
                             ButtonState(
-                                text = stringRes(if (state.isMigrating) "Migrating…" else "Migrate anyway"),
+                                text =
+                                    stringRes(
+                                        if (state.isMigrating) {
+                                            DesignR.string.migrationComplete_migrating
+                                        } else {
+                                            DesignR.string.migrationComplete_migrateAnyway
+                                        }
+                                    ),
                                 onClick = state.onMigrateAnyway,
                                 isEnabled = !state.isMigrating && !state.isLocking,
                                 isLoading = state.isMigrating,
@@ -202,7 +223,14 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                     ZashiButton(
                         state =
                             ButtonState(
-                                text = stringRes(if (state.isLocking) "Locking balance…" else "Lock balance"),
+                                text =
+                                    stringRes(
+                                        if (state.isLocking) {
+                                            DesignR.string.migrationComplete_lockingBalance
+                                        } else {
+                                            DesignR.string.migrationComplete_lockBalance
+                                        }
+                                    ),
                                 onClick = state.onLockBalance,
                                 isEnabled = !state.isMigrating && !state.isLocking,
                                 isLoading = state.isLocking,
@@ -249,16 +277,14 @@ private fun LockedDisclaimer(dustAmount: String) {
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = "Orchard balance locked",
+                text = stringRes(DesignR.string.migrationComplete_orchardBalanceLockedTitle).getValue(),
                 style = ZashiTypography.textSm,
                 fontWeight = FontWeight.Medium,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text =
-                    "$dustAmount is now locked in Orchard. Locking keeps this amount unspendable to " +
-                        "protect your privacy.",
+                text = stringRes(DesignR.string.migrationComplete_orchardBalanceLockedBody, dustAmount).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
@@ -33,6 +33,7 @@ import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
 import co.electriccoin.zcash.ui.common.usecase.LockOrchardBalanceUseCase
+import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.migration.lockexplainer.MigrationLockExplainerArgs
 import co.electriccoin.zcash.ui.screen.migration.success.MigrationSuccessArgs
@@ -44,6 +45,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationCompleteVM(
     private val getOrchardBalance: GetOrchardBalanceUseCase,
@@ -152,7 +154,7 @@ class MigrationCompleteVM(
             totalTransferred = stringRes(Zatoshi(summary.totalTransferred)),
             remainingDust = if (summary.dustZatoshi > 0L) stringRes(Zatoshi(summary.dustZatoshi)) else null,
             isDustLocked = isLocked,
-            transfersProgress = stringRes("${summary.totalCount} of ${summary.totalCount} sent"),
+            transfersProgress = stringRes(DesignR.string.migrationComplete_transfersProgress, summary.totalCount, summary.totalCount),
             duration = stringRes(formatMigrationDuration(summary.lastAt - summary.firstAt)),
             isMigrating = isMigrating,
             isLocking = isLocking,
@@ -180,12 +182,12 @@ class MigrationCompleteVM(
                 },
         )
 
-    private fun migrateAnywaySubmitFailureMessage(result: SubmitResult): String =
+    private fun migrateAnywaySubmitFailureMessage(result: SubmitResult): StringResource =
         when (result) {
-            is SubmitResult.GrpcFailure -> "Couldn't reach the network. Check your connection and try again."
-            is SubmitResult.Failure -> "The network rejected this transaction. Please contact support."
-            is SubmitResult.Error -> "Something went wrong while sending. Please contact support."
-            is SubmitResult.Partial -> "Some but not all of this transaction's parts were sent. Please contact support."
+            is SubmitResult.GrpcFailure -> stringRes(DesignR.string.migrationComplete_migrateAnywayFailureNetworkError)
+            is SubmitResult.Failure -> stringRes(DesignR.string.migrationComplete_migrateAnywayFailureRejected)
+            is SubmitResult.Error -> stringRes(DesignR.string.migrationComplete_migrateAnywayFailureError)
+            is SubmitResult.Partial -> stringRes(DesignR.string.migrationComplete_migrateAnywayFailurePartial)
             is SubmitResult.Success -> error("migrateAnywaySubmitFailureMessage called with a Success result")
         }
 

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationFailureBottomSheet.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationFailureBottomSheet.kt
@@ -18,7 +18,9 @@ import co.electriccoin.zcash.ui.design.component.ZashiButtonDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiModalBottomSheet
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 // Shared across migration screens (Progress, Sending, NoteSplit) so Retry/Dismiss failure
 // handling stays visually and behaviorally consistent everywhere a broadcast can fail.
@@ -29,14 +31,14 @@ fun MigrationFailureBottomSheet(state: MigrationTransferFailureState?) {
     ZashiModalBottomSheet(onDismissRequest = state.onDismiss) {
         Column(modifier = Modifier.padding(24.dp)) {
             Text(
-                text = "Couldn't Send",
+                text = stringRes(DesignR.string.migrationFailureSheet_title).getValue(),
                 style = ZashiTypography.header6,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = state.message,
+                text = state.message.getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
@@ -44,13 +46,13 @@ fun MigrationFailureBottomSheet(state: MigrationTransferFailureState?) {
             val onRetry = state.onRetry
             if (onRetry != null) {
                 ZashiButton(
-                    state = ButtonState(text = stringRes("Retry"), onClick = onRetry),
+                    state = ButtonState(text = stringRes(DesignR.string.migration_common_retry), onClick = onRetry),
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Spacer(Modifier.height(8.dp))
             }
             ZashiButton(
-                state = ButtonState(text = stringRes("Dismiss"), onClick = state.onDismiss),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_dismiss), onClick = state.onDismiss),
                 modifier = Modifier.fillMaxWidth(),
                 defaultPrimaryColors = ZashiButtonDefaults.secondaryColors(),
             )

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationPreparationDetailsBottomSheet.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationPreparationDetailsBottomSheet.kt
@@ -34,6 +34,7 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 /**
  * "Prepare Your Balance" detail sheet — Figma "PR App Designs Q3'26", node 5207:16023
@@ -63,16 +64,14 @@ fun MigrationPreparationDetailsBottomSheet(details: MigrationPreparationDetails?
                     .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                text = "Prepare Your Balance",
+                text = stringRes(DesignR.string.migrationPreparationDetails_title).getValue(),
                 style = ZashiTypography.header5,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(Modifier.height(8.dp))
             Text(
-                text =
-                    "Your balance needs to be split into transfer-sized notes across ${details.stepCount} steps " +
-                        "before your scheduled transfers begin.",
+                text = stringRes(DesignR.string.migrationPreparationDetails_body, details.stepCount).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
@@ -85,7 +84,7 @@ fun MigrationPreparationDetailsBottomSheet(details: MigrationPreparationDetails?
                         .padding(16.dp),
             ) {
                 Text(
-                    text = "Preparation Steps",
+                    text = stringRes(DesignR.string.migrationPreparationDetails_stepsTitle).getValue(),
                     style = ZashiTypography.textMd,
                     fontWeight = FontWeight.SemiBold,
                     color = ZashiColors.Text.textPrimary,
@@ -108,7 +107,7 @@ fun MigrationPreparationDetailsBottomSheet(details: MigrationPreparationDetails?
                         .padding(12.dp),
             ) {
                 Text(
-                    text = "Amount Being Split",
+                    text = stringRes(DesignR.string.migrationPreparationDetails_amountBeingSplitTitle).getValue(),
                     style = ZashiTypography.textXs,
                     color = ZashiColors.Text.textTertiary,
                     modifier = Modifier.weight(1f),
@@ -122,7 +121,7 @@ fun MigrationPreparationDetailsBottomSheet(details: MigrationPreparationDetails?
             }
             Spacer(Modifier.height(24.dp))
             ZashiButton(
-                state = ButtonState(text = stringRes("Got it"), onClick = details.onDismiss),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_gotIt), onClick = details.onDismiss),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/customservertor/MigrationCustomServerTorScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/customservertor/MigrationCustomServerTorScreen.kt
@@ -31,6 +31,7 @@ import co.electriccoin.zcash.ui.design.theme.dimensions.ZashiDimensions
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.R as DesignR
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -65,7 +66,7 @@ fun MigrationCustomServerTorView(
                     .padding(start = 24.dp, end = 24.dp, bottom = contentPadding.calculateBottomPadding()),
         ) {
             Text(
-                text = "Your Server Doesn't Support Tor",
+                text = stringRes(DesignR.string.migrationCustomServerTor_title).getValue(),
                 style = ZashiTypography.textXl,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
@@ -78,18 +79,22 @@ fun MigrationCustomServerTorView(
             )
             Spacer(24.dp)
             RiskCard(
-                title = "What are the risks?",
+                title = stringRes(DesignR.string.migration_common_whatAreTheRisks).getValue(),
                 body = innerState.riskBody.getValue(),
             )
             Spacer(32.dp)
             ZashiButton(
-                state = ButtonState(text = stringRes("Continue without Tor"), onClick = innerState.onContinueWithoutTor),
+                state =
+                    ButtonState(
+                        text = stringRes(DesignR.string.migration_common_continueWithoutTor),
+                        onClick = innerState.onContinueWithoutTor
+                    ),
                 modifier = Modifier.fillMaxWidth(),
                 defaultPrimaryColors = ZashiButtonDefaults.destructive1Colors(),
             )
             Spacer(8.dp)
             ZashiButton(
-                state = ButtonState(text = stringRes("Switch Server"), onClick = innerState.onSwitchServer),
+                state = ButtonState(text = stringRes(DesignR.string.migrationCustomServerTor_switchServer), onClick = innerState.onSwitchServer),
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -127,16 +132,8 @@ private fun Preview() =
         MigrationCustomServerTorView(
             state =
                 MigrationCustomServerTorState(
-                    body =
-                        stringRes(
-                            "Migration transactions can't be broadcast over Tor when you're using a custom " +
-                                "server. If you continue, these transactions will be sent without Tor's IP protection."
-                        ),
-                    riskBody =
-                        stringRes(
-                            "Without Tor, your IP address is exposed to the custom server and could be linked " +
-                                "to the migration amounts."
-                        ),
+                    body = stringRes(DesignR.string.migrationCustomServerTor_bodyAutomatic),
+                    riskBody = stringRes(DesignR.string.migrationCustomServerTor_riskBodyAutomatic),
                     onContinueWithoutTor = {},
                     onSwitchServer = {},
                     onBack = {},

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/customservertor/MigrationCustomServerTorVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/customservertor/MigrationCustomServerTorVM.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationCustomServerTorVM(
     private val args: MigrationCustomServerTorArgs,
@@ -26,35 +27,15 @@ class MigrationCustomServerTorVM(
         flowOf(
             MigrationCustomServerTorState(
                 body =
-                    stringRes(
-                        when (args.mode) {
-                            MigrationMode.IMMEDIATE -> {
-                                "The migration transaction can't be broadcast over Tor when you're using a " +
-                                    "custom server. If you continue, this transaction will be sent without " +
-                                    "Tor's IP protection."
-                            }
-
-                            MigrationMode.AUTOMATIC -> {
-                                "Migration transactions can't be broadcast over Tor when you're using a " +
-                                    "custom server. If you continue, these transactions will be sent without " +
-                                    "Tor's IP protection."
-                            }
-                        }
-                    ),
+                    when (args.mode) {
+                        MigrationMode.IMMEDIATE -> stringRes(DesignR.string.migrationCustomServerTor_bodyImmediate)
+                        MigrationMode.AUTOMATIC -> stringRes(DesignR.string.migrationCustomServerTor_bodyAutomatic)
+                    },
                 riskBody =
-                    stringRes(
-                        when (args.mode) {
-                            MigrationMode.IMMEDIATE -> {
-                                "Without Tor, your IP address is exposed to the custom server and could be " +
-                                    "linked to your full balance."
-                            }
-
-                            MigrationMode.AUTOMATIC -> {
-                                "Without Tor, your IP address is exposed to the custom server and could be " +
-                                    "linked to the migration amounts."
-                            }
-                        }
-                    ),
+                    when (args.mode) {
+                        MigrationMode.IMMEDIATE -> stringRes(DesignR.string.migrationCustomServerTor_riskBodyImmediate)
+                        MigrationMode.AUTOMATIC -> stringRes(DesignR.string.migrationCustomServerTor_riskBodyAutomatic)
+                    },
                 onContinueWithoutTor = ::onContinueWithoutTor,
                 onSwitchServer = ::onSwitchServer,
                 onBack = ::onBack,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/howitworks/MigrationHowItWorksScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/howitworks/MigrationHowItWorksScreen.kt
@@ -34,10 +34,12 @@ import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.scaffoldPadding
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Serializable
 data object MigrationHowItWorksArgs
@@ -73,48 +75,40 @@ fun MigrationHowItWorksView(state: MigrationHowItWorksState) {
                     .scaffoldPadding(padding),
         ) {
             Text(
-                text = "How This Works",
+                text = stringRes(DesignR.string.migrationHowItWorks_title).getValue(),
                 style = ZashiTypography.header6,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text =
-                    "Moving funds between Zcash pools reveals the amount of each transfer. Here's how we " +
-                        "protect your privacy during migration.",
+                text = stringRes(DesignR.string.migrationHowItWorks_subtitle).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
             Spacer(Modifier.height(32.dp))
             HowItWorksStep(
                 icon = co.electriccoin.zcash.ui.R.drawable.ic_migration_coins_swap,
-                title = "Split and schedule",
-                description =
-                    "Your balance is divided into smaller amounts and spaced out over time, so " +
-                        "they’re harder to link together.",
+                title = stringRes(DesignR.string.migrationHowItWorks_splitScheduleTitle).getValue(),
+                description = stringRes(DesignR.string.migrationHowItWorks_splitScheduleDescription).getValue(),
             )
             Spacer(Modifier.height(16.dp))
             HowItWorksStep(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_check_square_broken,
-                title = "Approve once",
-                description =
-                    "Zodl handles the rest, sending each transfer automatically in its scheduled " +
-                        "window while the app runs in the background.",
+                title = stringRes(DesignR.string.migrationHowItWorks_approveOnceTitle).getValue(),
+                description = stringRes(DesignR.string.migrationHowItWorks_approveOnceDescription).getValue(),
             )
             Spacer(Modifier.height(16.dp))
             HowItWorksStep(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_notif_bell_ringing,
-                title = "If something fails",
-                description = "We’ll notify you so you can complete it manually.",
+                title = stringRes(DesignR.string.migrationHowItWorks_ifSomethingFailsTitle).getValue(),
+                description = stringRes(DesignR.string.migrationHowItWorks_ifSomethingFailsDescription).getValue(),
             )
             Spacer(Modifier.height(16.dp))
             HowItWorksStep(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_calendar,
-                title = "Large balance",
-                description =
-                    "If your wallet holds large balance or many small notes, migration may run " +
-                        "across multiple scheduled rounds.",
+                title = stringRes(DesignR.string.migrationHowItWorks_largeBalanceTitle).getValue(),
+                description = stringRes(DesignR.string.migrationHowItWorks_largeBalanceDescription).getValue(),
             )
             Spacer(Modifier.weight(1f))
             Spacer(Modifier.height(32.dp))
@@ -127,16 +121,14 @@ fun MigrationHowItWorksView(state: MigrationHowItWorksState) {
                 )
                 Spacer(Modifier.width(12.dp))
                 Text(
-                    text =
-                        "Choosing this option may require a small amount (less than 0.01 ZEC) to be " +
-                            "left in the Orchard pool, and which won’t be transferred.",
+                    text = stringRes(DesignR.string.migrationHowItWorks_disclaimer).getValue(),
                     style = ZashiTypography.textXs,
                     color = ZashiColors.Text.textTertiary,
                 )
             }
             Spacer(Modifier.height(20.dp))
             ZashiButton(
-                state = ButtonState(text = stringRes("Continue"), onClick = state.onContinue),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_continue), onClick = state.onContinue),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/invalid/MigrationTransferInvalidScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/invalid/MigrationTransferInvalidScreen.kt
@@ -41,6 +41,7 @@ import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Serializable
 data object MigrationTransferInvalidArgs
@@ -82,23 +83,31 @@ fun MigrationTransferInvalidView(state: MigrationTransferInvalidState) {
                 when (state.kind) {
                     MigrationAttentionKind.PLAN_UPDATE -> {
                         Triple(
-                            "Update Migration Plan",
-                            "Some Orchard notes were spent outside the migration flow, which invalidated " +
-                                "the pre-signed transfer plan. The plan needs to be re-created for the " +
-                                "remaining balance. No funds are lost — only the pre-signed transactions " +
-                                "are discarded.",
-                            "The invalidated transfer is discarded",
+                            stringRes(DesignR.string.migrationTransferInvalid_planUpdateTitle).getValue(),
+                            stringRes(DesignR.string.migrationTransferInvalid_planUpdateBody).getValue(),
+                            stringRes(DesignR.string.migrationTransferInvalid_planUpdateFirstStep).getValue(),
                         )
                     }
 
                     MigrationAttentionKind.TRANSFER_EXPIRED -> {
+                        val isPlural = state.remainingCount > 1
                         Triple(
-                            "Transfer No Longer Valid",
-                            "Transfer ${state.invalidRange.getValue()} expired without being sent — the app " +
-                                "wasn't opened in time to broadcast ${if (state.remainingCount > 1) "them" else "it"}. " +
-                                "The migration plan needs to be re-created for the remaining balance. No " +
-                                "funds are lost — only the pre-signed transactions are discarded.",
-                            "Expired transfer${if (state.remainingCount > 1) "s are" else " is"} discarded",
+                            stringRes(DesignR.string.migrationTransferInvalid_transferExpiredTitle).getValue(),
+                            stringRes(
+                                if (isPlural) {
+                                    DesignR.string.migrationTransferInvalid_transferExpiredBodyPlural
+                                } else {
+                                    DesignR.string.migrationTransferInvalid_transferExpiredBodySingular
+                                },
+                                state.invalidRange.getValue()
+                            ).getValue(),
+                            stringRes(
+                                if (isPlural) {
+                                    DesignR.string.migrationTransferInvalid_expiredStepLabelPlural
+                                } else {
+                                    DesignR.string.migrationTransferInvalid_expiredStepLabelSingular
+                                }
+                            ).getValue(),
                         )
                     }
                 }
@@ -116,7 +125,7 @@ fun MigrationTransferInvalidView(state: MigrationTransferInvalidState) {
             )
             Spacer(Modifier.height(24.dp))
             Text(
-                text = "What Happens Next",
+                text = stringRes(DesignR.string.migrationTransferInvalid_whatHappensNextTitle).getValue(),
                 style = ZashiTypography.textSm,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
@@ -128,15 +137,20 @@ fun MigrationTransferInvalidView(state: MigrationTransferInvalidState) {
             )
             WhatHappensNextItem(
                 number = 2,
-                text = "Remaining balance is re-proposed",
+                text = stringRes(DesignR.string.migrationTransferInvalid_remainingBalanceReproposed).getValue(),
             )
             WhatHappensNextItem(
                 number = 3,
-                text = "${state.completedCount} of ${state.totalCount} transfers done; migration will continue.",
+                text =
+                    stringRes(
+                        DesignR.string.migrationTransferInvalid_transfersDoneProgress,
+                        state.completedCount,
+                        state.totalCount
+                    ).getValue(),
             )
             Spacer(Modifier.weight(1f))
             ZashiButton(
-                state = ButtonState(text = stringRes("Continue"), onClick = state.onContinue),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_continue), onClick = state.onContinue),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonescan/MigrationKeystoneScanVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonescan/MigrationKeystoneScanVM.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationKeystoneScanVM(
     private val args: MigrationKeystoneScanArgs,
@@ -39,7 +40,7 @@ class MigrationKeystoneScanVM(
         MutableStateFlow(
             ScanKeystoneState(
                 progress = null,
-                message = stringRes("Scan the QR code shown on your Keystone device after signing."),
+                message = stringRes(DesignR.string.migrationKeystoneScan_instructions),
             )
         )
 
@@ -99,9 +100,7 @@ class MigrationKeystoneScanVM(
                         isProcessing = false
                         failureSheet.update {
                             MigrationTransferFailureState(
-                                message =
-                                    "Your Keystone firmware doesn't support migration yet. " +
-                                        "Update your Keystone device, then come back to retry.",
+                                message = stringRes(DesignR.string.migrationKeystoneScan_firmwareUnsupported),
                                 // Nothing to retry without a physical firmware update — both actions
                                 // just dismiss and back out, unlike the network-failure sheet below.
                                 onRetry = {
@@ -228,7 +227,7 @@ class MigrationKeystoneScanVM(
                 isProcessing = false
                 failureSheet.update {
                     MigrationTransferFailureState(
-                        message = "Something went wrong while processing that scan. Please try again.",
+                        message = stringRes(DesignR.string.migrationKeystoneScan_errorMessage),
                         onRetry = { failureSheet.value = null },
                         onDismiss = {
                             failureSheet.value = null

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.nio.ByteBuffer
 import java.util.UUID
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationKeystoneSignVM(
     private val args: MigrationKeystoneSignArgs,
@@ -171,7 +172,7 @@ class MigrationKeystoneSignVM(
             }.onFailure {
                 failureSheet.update {
                     MigrationTransferFailureState(
-                        message = "Couldn't prepare the migration for signing. Try again.",
+                        message = stringRes(DesignR.string.migrationKeystoneSign_prepareErrorMessage),
                         onRetry = {
                             failureSheet.value = null
                             buildBatch()
@@ -201,29 +202,31 @@ class MigrationKeystoneSignVM(
             }
             // Only surfaced for a migration too large for one Keystone QR round trip — invisible
             // (empty suffix) in the common single-round case.
-            val roundSuffix = round?.let { (index, total) -> if (total > 1) " (${index + 1} of $total)" else "" }.orEmpty()
+            val roundSuffix =
+                round
+                    ?.let { (index, total) ->
+                        if (total > 1) stringRes(DesignR.string.migrationKeystoneSign_roundSuffix, index + 1, total) else stringRes("")
+                    }
+                    ?: stringRes("")
             SignKeystoneTransactionState(
-                barTitle = stringRes("Sign Transaction"),
-                title = stringRes("Scan with your Keystone wallet$roundSuffix"),
-                subtitle =
-                    stringRes(
-                        "After you have signed with Keystone, tap on the Get Signature button below."
-                    ),
+                barTitle = stringRes(DesignR.string.migrationKeystoneSign_barTitle),
+                title = stringRes(DesignR.string.migrationKeystoneSign_scanWithKeystone, roundSuffix),
+                subtitle = stringRes(DesignR.string.migrationKeystoneSign_subtitle),
                 accountInfo =
                     ZashiAccountInfoListItemState(
                         icon = account.icon,
                         title = account.name,
                         subtitle = stringRes("${account.unified.address.address.take(ADDRESS_MAX_LENGTH)}..."),
                     ),
-                badgeText = stringRes("Hardware"),
+                badgeText = stringRes(DesignR.string.migrationKeystoneSign_badgeHardware),
                 generateNextQrCode = {
                     val size = parts?.size ?: 1
                     qrFrameIndex.value = (frameIndex + 1) % size
                 },
                 qrData = parts?.getOrNull(frameIndex),
                 secondaryButton = null,
-                positiveButton = ButtonState(text = stringRes("Get Signature"), onClick = ::onGetSignature),
-                negativeButton = ButtonState(text = stringRes("Reject"), onClick = ::onReject),
+                positiveButton = ButtonState(text = stringRes(DesignR.string.migrationKeystoneSign_getSignature), onClick = ::onGetSignature),
+                negativeButton = ButtonState(text = stringRes(DesignR.string.migrationKeystoneSign_reject), onClick = ::onReject),
                 onBack = ::onReject,
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/lockexplainer/MigrationLockExplainerScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/lockexplainer/MigrationLockExplainerScreen.kt
@@ -26,9 +26,11 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Serializable
 data object MigrationLockExplainerArgs
@@ -58,40 +60,47 @@ fun MigrationLockExplainerView(
                     .padding(start = 24.dp, end = 24.dp, bottom = contentPadding.calculateBottomPadding()),
         ) {
             Text(
-                text = "What does locking do?",
+                text = stringRes(DesignR.string.migrationLockExplainer_title).getValue(),
                 style = ZashiTypography.textXl,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(4.dp)
+            val bullet1Prefix = stringRes(DesignR.string.migrationLockExplainer_bullet1Prefix).getValue()
+            val bullet1Bold = stringRes(DesignR.string.migrationLockExplainer_bullet1Bold).getValue()
+            val bullet1Suffix = stringRes(DesignR.string.migrationLockExplainer_bullet1Suffix).getValue()
             LockExplainerBullet(
                 buildAnnotatedString {
-                    append("Locking marks this balance as ")
-                    withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) { append("unspendable") }
-                    append(", so it can't compromise your privacy in future transactions.")
+                    append(bullet1Prefix)
+                    withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) { append(bullet1Bold) }
+                    append(bullet1Suffix)
                 }
             )
             Spacer(16.dp)
+            val bullet2Bold = stringRes(DesignR.string.migrationLockExplainer_bullet2Bold).getValue()
+            val bullet2Suffix = stringRes(DesignR.string.migrationLockExplainer_bullet2Suffix).getValue()
             LockExplainerBullet(
                 buildAnnotatedString {
                     withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                        append("The lock lives on this Zodl/Keystone instance only.")
+                        append(bullet2Bold)
                     }
-                    append(" Restoring your wallet won't carry it over.")
+                    append(bullet2Suffix)
                 }
             )
             Spacer(16.dp)
+            val bullet3Prefix = stringRes(DesignR.string.migrationLockExplainer_bullet3Prefix).getValue()
+            val bullet3Bold = stringRes(DesignR.string.migrationLockExplainer_bullet3Bold).getValue()
             LockExplainerBullet(
                 buildAnnotatedString {
-                    append("A future release will let you ")
-                    withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) { append("unlock this balance.") }
+                    append(bullet3Prefix)
+                    withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) { append(bullet3Bold) }
                 }
             )
             Spacer(32.dp)
             ZashiButton(
                 state =
                     ButtonState(
-                        text = stringRes("Got it"),
+                        text = stringRes(DesignR.string.migration_common_gotIt),
                         onClick = innerState.onGotIt,
                     ),
                 modifier = Modifier.fillMaxWidth(),

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/notification/MigrationNotificationScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/notification/MigrationNotificationScreen.kt
@@ -40,11 +40,13 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.scaffoldPadding
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Serializable
 data object MigrationNotificationArgs
@@ -104,38 +106,34 @@ fun MigrationNotificationView(state: MigrationNotificationState) {
                     .scaffoldPadding(padding),
         ) {
             Text(
-                text = "Allow Notifications",
+                text = stringRes(DesignR.string.migrationNotifPermission_title).getValue(),
                 style = ZashiTypography.header6,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text =
-                    "If a scheduled transfer is missed or a background submission fails, we can " +
-                        "send you a local notification and prompt you to open Zodl. Get notified about:",
+                text = stringRes(DesignR.string.migrationNotifPermission_subtitle).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
             Spacer(Modifier.height(24.dp))
             NotificationFeatureItem(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_notif_annotation_check,
-                title = "Migration Status",
-                body = "We will inform you whenever your funds are fully migrated to Ironwood.",
+                title = stringRes(DesignR.string.migrationNotifPermission_statusTitle).getValue(),
+                body = stringRes(DesignR.string.migrationNotifPermission_statusBody).getValue(),
             )
             Spacer(Modifier.height(16.dp))
             NotificationFeatureItem(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_notif_bell_ringing,
-                title = "Action Needed",
-                body = "If we miss a window, we will prompt you to open the app and send a transfer manually.",
+                title = stringRes(DesignR.string.migrationNotifPermission_actionNeededTitle).getValue(),
+                body = stringRes(DesignR.string.migrationNotifPermission_actionNeededBody).getValue(),
             )
             Spacer(Modifier.height(16.dp))
             NotificationFeatureItem(
                 icon = co.electriccoin.zcash.migration.R.drawable.ic_migration_notif_announcement,
-                title = "Transfer Plan Changes",
-                body =
-                    "If allocated funds are spent or a scheduled transfer can no longer be sent, " +
-                        "we'll let you know.",
+                title = stringRes(DesignR.string.migrationNotifPermission_planChangesTitle).getValue(),
+                body = stringRes(DesignR.string.migrationNotifPermission_planChangesBody).getValue(),
             )
             Spacer(Modifier.weight(1f))
             Row(modifier = Modifier.fillMaxWidth()) {
@@ -147,16 +145,14 @@ fun MigrationNotificationView(state: MigrationNotificationState) {
                 )
                 Spacer(Modifier.width(12.dp))
                 Text(
-                    text =
-                        "Without notifications, you'll need to open Zodl to check migration " +
-                            "progress and approve any manual transfers yourself.",
+                    text = stringRes(DesignR.string.migrationNotifPermission_warningHint).getValue(),
                     style = ZashiTypography.textXs,
                     color = ZashiColors.Utility.WarningYellow.utilityOrange700,
                 )
             }
             Spacer(Modifier.height(24.dp))
             ZashiButton(
-                state = ButtonState(text = stringRes("Skip"), onClick = state.onSkip),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_skip), onClick = state.onSkip),
                 modifier = Modifier.fillMaxWidth(),
                 defaultPrimaryColors =
                     ZashiButtonDefaults.secondaryColors(
@@ -166,7 +162,7 @@ fun MigrationNotificationView(state: MigrationNotificationState) {
             )
             Spacer(Modifier.height(12.dp))
             ZashiButton(
-                state = ButtonState(text = stringRes("Allow"), onClick = state.onAllow),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_allow), onClick = state.onAllow),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/privacy/MigrationPrivacyScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/privacy/MigrationPrivacyScreen.kt
@@ -49,6 +49,7 @@ import co.electriccoin.zcash.ui.design.util.stringRes
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Serializable
 data class MigrationPrivacyArgs(
@@ -86,7 +87,7 @@ fun MigrationPrivacyView(
             )
             Spacer(16.dp)
             Text(
-                text = "Enable Tor Protection",
+                text = stringRes(DesignR.string.migration_common_enableTorProtectionTitle).getValue(),
                 style = ZashiTypography.textXl,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
@@ -101,7 +102,7 @@ fun MigrationPrivacyView(
             TorToggleCard(innerState.checkbox)
             Spacer(32.dp)
             ZashiButton(
-                state = ButtonState(text = stringRes("Got it"), onClick = innerState.onConfirm),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_gotIt), onClick = innerState.onConfirm),
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -185,20 +186,11 @@ private fun Preview() =
         MigrationPrivacyView(
             state =
                 MigrationPrivacyState(
-                    body =
-                        stringRes(
-                            "If Tor is available in your region, we strongly recommend enabling it to prevent " +
-                                "linking the migration amounts to your IP address. You can also use a trusted VPN " +
-                                "if Tor is unavailable in your region."
-                        ),
+                    body = stringRes(DesignR.string.migrationPrivacy_bodyAutomatic),
                     checkbox =
                         CheckboxState(
-                            title = stringRes("Enable Tor Protection"),
-                            subtitle =
-                                stringRes(
-                                    "Routes your connection through the Tor network for enhanced anonymity and " +
-                                        "privacy protection."
-                                ),
+                            title = stringRes(DesignR.string.migration_common_enableTorProtectionTitle),
+                            subtitle = stringRes(DesignR.string.migration_common_torCheckboxSubtitle),
                             isChecked = true,
                             onClick = {},
                         ),

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/privacy/MigrationPrivacyVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/privacy/MigrationPrivacyVM.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationPrivacyVM(
     private val args: MigrationPrivacyArgs,
@@ -34,29 +35,14 @@ class MigrationPrivacyVM(
             .map { tor ->
                 MigrationPrivacyState(
                     body =
-                        stringRes(
-                            when (args.mode) {
-                                MigrationMode.IMMEDIATE -> {
-                                    "If Tor is available in your region, we strongly recommend enabling it to " +
-                                        "prevent linking your balance to your IP address. You can also use a " +
-                                        "trusted VPN if Tor is unavailable in your region."
-                                }
-
-                                MigrationMode.AUTOMATIC -> {
-                                    "If Tor is available in your region, we strongly recommend enabling it to " +
-                                        "prevent linking the migration amounts to your IP address. You can also " +
-                                        "use a trusted VPN if Tor is unavailable in your region."
-                                }
-                            }
-                        ),
+                        when (args.mode) {
+                            MigrationMode.IMMEDIATE -> stringRes(DesignR.string.migrationPrivacy_bodyImmediate)
+                            MigrationMode.AUTOMATIC -> stringRes(DesignR.string.migrationPrivacy_bodyAutomatic)
+                        },
                     checkbox =
                         CheckboxState(
-                            title = stringRes("Enable Tor Protection"),
-                            subtitle =
-                                stringRes(
-                                    "Routes your connection through the Tor network for enhanced anonymity and " +
-                                        "privacy protection."
-                                ),
+                            title = stringRes(DesignR.string.migration_common_enableTorProtectionTitle),
+                            subtitle = stringRes(DesignR.string.migration_common_torCheckboxSubtitle),
                             isChecked = tor,
                             onClick = { onTorToggle(!tor) },
                         ),

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressScreen.kt
@@ -53,6 +53,7 @@ import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import co.electriccoin.zcash.ui.screen.migration.component.MigrationPreparationDetailsBottomSheet
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Composable
 fun MigrationProgressScreen() {
@@ -119,7 +120,7 @@ fun MigrationProgressView(state: MigrationProgressState) {
                     // Figma shows the total amount on this collapsed row too (unlike the
                     // superseded inline-expand design, which omitted it as "internal plumbing").
                     TransferProgressTimelineRow(
-                        title = "Split Balance",
+                        title = stringRes(DesignR.string.migration_common_splitBalanceTitle).getValue(),
                         statusLabel = summary.statusLabel,
                         isReadyNow = summary.isReadyNow,
                         amount = state.totalAmount,
@@ -142,7 +143,7 @@ fun MigrationProgressView(state: MigrationProgressState) {
                                 else -> TransferRowState.IDLE
                             }
                         TransferProgressTimelineRow(
-                            title = "Split balance ${prep.number}",
+                            title = stringRes(DesignR.string.migration_common_splitBalanceNumbered, prep.number).getValue(),
                             statusLabel = prep.statusLabel,
                             isReadyNow = prep.isReadyNow,
                             amount = null,
@@ -163,7 +164,7 @@ fun MigrationProgressView(state: MigrationProgressState) {
                             else -> TransferRowState.IDLE
                         }
                     TransferProgressTimelineRow(
-                        title = "Transfer ${transfer.index}",
+                        title = stringRes(DesignR.string.migration_common_transferTitle, transfer.index).getValue(),
                         statusLabel = transfer.statusLabel,
                         isReadyNow = transfer.isReadyNow,
                         amount = transfer.amount,
@@ -184,7 +185,7 @@ fun MigrationProgressView(state: MigrationProgressState) {
             if (state.isComplete) {
                 state.onDone?.let { done ->
                     ZashiButton(
-                        state = ButtonState(text = stringRes("Got it"), onClick = done),
+                        state = ButtonState(text = stringRes(DesignR.string.migration_common_gotIt), onClick = done),
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -215,7 +216,7 @@ private fun MigrationBalanceTrackerCard(tracker: MigrationProgressBalanceTracker
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = "Orchard",
+                text = stringRes(DesignR.string.migrationProgress_orchardLabel).getValue(),
                 style = ZashiTypography.textXs,
                 fontWeight = FontWeight.Medium,
                 color = ZashiColors.Text.textTertiary,
@@ -248,7 +249,7 @@ private fun MigrationBalanceTrackerCard(tracker: MigrationProgressBalanceTracker
             horizontalAlignment = Alignment.End,
         ) {
             Text(
-                text = "Ironwood",
+                text = stringRes(DesignR.string.migrationProgress_ironwoodLabel).getValue(),
                 style = ZashiTypography.textXs,
                 fontWeight = FontWeight.Medium,
                 color = ZashiColors.Text.textTertiary,
@@ -404,7 +405,7 @@ private fun TransferProgressTimelineRow(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "Show details",
+                        text = stringRes(DesignR.string.migration_common_showDetails).getValue(),
                         style = ZashiTypography.textXs,
                         fontWeight = FontWeight.SemiBold,
                         color = ZashiColors.Text.textPrimary,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVM.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import java.math.BigDecimal
 import java.math.MathContext
+import co.electriccoin.zcash.ui.design.R as DesignR
 import kotlin.time.Clock
 import kotlin.time.Instant
 
@@ -107,7 +108,7 @@ class MigrationProgressVM(
         val totalZatoshi = snapshot.transfers.sumOf { it.amountZatoshi }
         val totalAmount = stringRes(Zatoshi(totalZatoshi))
         return MigrationProgressState(
-            title = stringRes("Migration Progress"),
+            title = stringRes(DesignR.string.migration_common_progressTitle),
             subtitle = stringRes(subtitle),
             totalAmount = totalAmount,
             totalFiatAmount = fiatAmount(Zatoshi(totalZatoshi), exchangeRateState),

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/restart/MigrationRestartView.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/restart/MigrationRestartView.kt
@@ -172,21 +172,14 @@ private fun Preview() =
             state =
                 MigrationRestartState(
                     onBack = {},
-                    body =
-                        stringRes(
-                            "If your migration looks stuck, you can restart it safely. This creates a new " +
-                                "plan for your remaining funds. Completed transfers are not affected."
-                        ),
-                    migratedLabel = stringRes("Migrated"),
-                    migratedValue = stringRes("7 of 11 transfers"),
-                    remainingLabel = stringRes("Remaining balance"),
+                    body = stringRes(DesignR.string.restartMigration_body),
+                    migratedLabel = stringRes(DesignR.string.restartMigration_summaryMigratedLabel),
+                    migratedValue = stringRes(DesignR.string.restartMigration_summaryMigratedValue, 7, 11),
+                    remainingLabel = stringRes(DesignR.string.restartMigration_summaryRemainingLabel),
                     remainingValue = stringRes("3.070 ZEC"),
-                    warning = stringRes("This cancels the current migration plan. It cannot be undone once confirmed."),
-                    support =
-                        stringRes(
-                            "If restarting doesn't resolve the issue, please reach out to Zodl Support via Send Feedback."
-                        ),
-                    nextButton = ButtonState(text = stringRes("Next"), onClick = {}),
+                    warning = stringRes(DesignR.string.restartMigration_warning),
+                    support = stringRes(DesignR.string.restartMigration_support),
+                    nextButton = ButtonState(text = stringRes(DesignR.string.restartMigration_next), onClick = {}),
                     confirmationDialog = null,
                 )
         )

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/review/MigrationReviewScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/review/MigrationReviewScreen.kt
@@ -66,6 +66,7 @@ import co.electriccoin.zcash.ui.screen.migration.component.MigrationFailureBotto
 import co.electriccoin.zcash.ui.screen.migration.component.MigrationPreparationDetailsBottomSheet
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Composable
 fun MigrationReviewScreen(args: MigrationReviewArgs) {
@@ -141,16 +142,14 @@ private fun ImmediateReviewContent(state: MigrationReviewState) {
             )
             Spacer(Modifier.height(16.dp))
             Text(
-                text = "Review Transfer",
+                text = stringRes(DesignR.string.migrationReview_title).getValue(),
                 style = ZashiTypography.header6,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text =
-                    "Your full Orchard balance will be transferred to Ironwood in a single on-chain transfer. " +
-                        "Once confirmed, this transfer cannot be cancelled.",
+                text = stringRes(DesignR.string.migrationReview_immediateBody).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
@@ -161,7 +160,10 @@ private fun ImmediateReviewContent(state: MigrationReviewState) {
         ZashiButton(
             state =
                 ButtonState(
-                    text = stringRes(if (state.isConfirming) "Signing..." else "Confirm"),
+                    text =
+                        stringRes(
+                            if (state.isConfirming) DesignR.string.migrationReview_signing else DesignR.string.migrationReview_confirm
+                        ),
                     isEnabled = !state.isConfirming,
                     isLoading = state.isConfirming,
                     onClick = state.onConfirm,
@@ -178,7 +180,7 @@ internal fun ImmediateDetailsCard(
     // Overridable so callers whose [fee] is a placeholder (no real per-transfer fee field exists
     // on TransferProposal — see MigrationTransferReviewVM) can be honest that it's an estimate,
     // without relabeling the real, exact fee IMMEDIATE mode shows (Proposal.totalFeeRequired()).
-    feeLabel: String = "Fee",
+    feeLabel: String = stringRes(DesignR.string.migrationReview_feeLabel).getValue(),
 ) {
     Column(
         modifier =
@@ -186,7 +188,7 @@ internal fun ImmediateDetailsCard(
                 .fillMaxWidth()
                 .background(ZashiColors.Surfaces.bgSecondary, RoundedCornerShape(16.dp)),
     ) {
-        ImmediateDetailsRow(label = "Amount", value = amount.getValue())
+        ImmediateDetailsRow(label = stringRes(DesignR.string.migrationReview_amountLabel).getValue(), value = amount.getValue())
         Box(
             modifier =
                 Modifier
@@ -229,7 +231,7 @@ private fun PrivacyReviewContent(
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         Text(
-            text = "Confirm Transfer Plan",
+            text = stringRes(DesignR.string.migrationReview_confirmTransferPlanTitle).getValue(),
             style = ZashiTypography.header6,
             fontWeight = FontWeight.SemiBold,
             color = ZashiColors.Text.textPrimary,
@@ -237,17 +239,18 @@ private fun PrivacyReviewContent(
         Spacer(Modifier.height(4.dp))
         Text(
             text =
-                "Your balance splits into ${state.transfers.size} transfers over " +
-                    "${state.estimatedDuration.getValue()}. Approve once and " +
-                    "we'll handle the rest — just keep the app running in the background. Amounts are randomized " +
-                    "for privacy. If we miss a window, Zodl will prompt you on next open.",
+                stringRes(
+                    DesignR.string.migrationReview_privacyBody,
+                    state.transfers.size,
+                    state.estimatedDuration.getValue()
+                ).getValue(),
             style = ZashiTypography.textSm,
             color = ZashiColors.Text.textTertiary,
         )
         Spacer(Modifier.height(24.dp))
         state.keystoneRound?.let { round ->
             Text(
-                text = "Round ${round.current} of ${round.total}",
+                text = stringRes(DesignR.string.migrationReview_roundOfTotal, round.current, round.total).getValue(),
                 style = ZashiTypography.textMd,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
@@ -265,7 +268,7 @@ private fun PrivacyReviewContent(
                 // other row does.
                 item {
                     TransferTimelineRow(
-                        title = "Split Balance",
+                        title = stringRes(DesignR.string.migration_common_splitBalanceTitle).getValue(),
                         subtitle = state.preparationsSummarySubtitle ?: stringRes(""),
                         amount = state.totalAmount,
                         fiatAmount = state.totalFiatAmount,
@@ -283,7 +286,7 @@ private fun PrivacyReviewContent(
                 // row as before.
                 items(state.preparations) { prep ->
                     TransferTimelineRow(
-                        title = "Split balance ${prep.number}",
+                        title = stringRes(DesignR.string.migration_common_splitBalanceNumbered, prep.number).getValue(),
                         subtitle = prep.scheduledLabel,
                         amount = null,
                         fiatAmount = null,
@@ -297,7 +300,7 @@ private fun PrivacyReviewContent(
                 // row as a fallback so no regression on zero-preparations plans.
                 item {
                     TransferTimelineRow(
-                        title = "Split Balance",
+                        title = stringRes(DesignR.string.migration_common_splitBalanceTitle).getValue(),
                         subtitle = stringRes("Ready now"),
                         amount = state.totalAmount,
                         fiatAmount = state.totalFiatAmount,
@@ -309,7 +312,7 @@ private fun PrivacyReviewContent(
             }
             items(state.transfers) { transfer ->
                 TransferTimelineRow(
-                    title = "Transfer ${transfer.index}",
+                    title = stringRes(DesignR.string.migration_common_transferTitle, transfer.index).getValue(),
                     subtitle = transfer.scheduledLabel,
                     amount = transfer.amount,
                     fiatAmount = transfer.fiatAmount,
@@ -325,7 +328,14 @@ private fun PrivacyReviewContent(
                 ButtonState(
                     // Figma node 5596:55122: "Start Migration" for the idle state (AUTOMATIC
                     // mode only — ImmediateReviewContent's "Confirm" is a different screen/copy).
-                    text = stringRes(if (state.isConfirming) "Signing..." else "Start Migration"),
+                    text =
+                        stringRes(
+                            if (state.isConfirming) {
+                                DesignR.string.migrationReview_signing
+                            } else {
+                                DesignR.string.migrationReview_startMigration
+                            }
+                        ),
                     isEnabled = !state.isConfirming,
                     isLoading = state.isConfirming,
                     onClick = state.onConfirm,
@@ -453,7 +463,7 @@ private fun TransferTimelineRow(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "Show details",
+                        text = stringRes(DesignR.string.migration_common_showDetails).getValue(),
                         style = ZashiTypography.textXs,
                         fontWeight = FontWeight.SemiBold,
                         color = ZashiColors.Text.textPrimary,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/review/MigrationReviewVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/review/MigrationReviewVM.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import java.math.BigDecimal
 import java.math.MathContext
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationReviewVM(
     private val args: MigrationReviewArgs,
@@ -296,7 +297,7 @@ class MigrationReviewVM(
                         totalCount = 1,
                         amount = stringRes(proposal.amountZatoshi),
                         fiatAmount = fiatAmount(proposal.amountZatoshi, exchangeRateState),
-                        scheduledLabel = stringRes("Send immediately"),
+                        scheduledLabel = stringRes(DesignR.string.migrationReview_sendImmediately),
                     )
                 ),
             fee = stringRes(fee),

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledScreen.kt
@@ -43,6 +43,7 @@ import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import co.electriccoin.zcash.ui.screen.migration.component.MigrationFailureBottomSheet
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 data class MigrationScheduledState(
     val totalAmount: StringResource,
@@ -99,7 +100,7 @@ private fun MigrationSchedulingView() {
                 )
                 Spacer(Modifier.height(24.dp))
                 Text(
-                    text = "Scheduling...",
+                    text = stringRes(DesignR.string.migrationScheduled_schedulingTitle).getValue(),
                     style = ZashiTypography.header5,
                     fontWeight = FontWeight.SemiBold,
                     color = ZashiColors.Text.textPrimary,
@@ -107,7 +108,7 @@ private fun MigrationSchedulingView() {
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = "Your ZEC migration schedule is getting confirmed.",
+                    text = stringRes(DesignR.string.migrationScheduled_schedulingSubtitle).getValue(),
                     style = ZashiTypography.textSm,
                     color = ZashiColors.Text.textTertiary,
                     textAlign = TextAlign.Center,
@@ -122,16 +123,16 @@ private fun MigrationSchedulingView() {
                             .padding(20.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    SkeletonSummaryRow(label = "Total to transfer")
-                    SkeletonSummaryRow(label = "Pool")
-                    SkeletonSummaryRow(label = "Transfers")
-                    SkeletonSummaryRow(label = "Duration")
+                    SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_totalToTransferLabel).getValue())
+                    SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_poolLabel).getValue())
+                    SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_transfersLabel).getValue())
+                    SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_durationLabel).getValue())
                 }
             }
             ZashiButton(
                 state =
                     ButtonState(
-                        text = stringRes("Scheduling..."),
+                        text = stringRes(DesignR.string.migrationScheduled_schedulingTitle),
                         isEnabled = false,
                         isLoading = true,
                         onClick = {},
@@ -189,7 +190,7 @@ fun MigrationScheduledView(state: MigrationScheduledState) {
                 )
                 Spacer(Modifier.height(24.dp))
                 Text(
-                    text = "Migration Scheduled",
+                    text = stringRes(DesignR.string.migrationScheduled_doneTitle).getValue(),
                     style = ZashiTypography.header5,
                     fontWeight = FontWeight.SemiBold,
                     color = ZashiColors.Text.textPrimary,
@@ -197,7 +198,7 @@ fun MigrationScheduledView(state: MigrationScheduledState) {
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = "Your ZEC will be migrated to the Ironwood pool based on the schedule you approved.",
+                    text = stringRes(DesignR.string.migrationScheduled_doneSubtitle).getValue(),
                     style = ZashiTypography.textSm,
                     color = ZashiColors.Text.textTertiary,
                     textAlign = TextAlign.Center,
@@ -212,10 +213,22 @@ fun MigrationScheduledView(state: MigrationScheduledState) {
                             .padding(20.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    SummaryRow(label = "Total to transfer", value = state.totalAmount.getValue())
-                    SummaryRow(label = "Pool", value = "Orchard → Ironwood")
-                    SummaryRow(label = "Transfers", value = state.transfersProgress.getValue())
-                    SummaryRow(label = "Duration", value = state.duration.getValue())
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationScheduled_totalToTransferLabel).getValue(),
+                        value = state.totalAmount.getValue(),
+                    )
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationScheduled_poolLabel).getValue(),
+                        value = stringRes(DesignR.string.migrationScheduled_poolValue).getValue(),
+                    )
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationScheduled_transfersLabel).getValue(),
+                        value = state.transfersProgress.getValue(),
+                    )
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationScheduled_durationLabel).getValue(),
+                        value = state.duration.getValue(),
+                    )
                 }
                 state.backgroundHint?.let {
                     Spacer(Modifier.height(12.dp))
@@ -227,7 +240,7 @@ fun MigrationScheduledView(state: MigrationScheduledState) {
                 }
             }
             ZashiButton(
-                state = ButtonState(text = stringRes("Done"), onClick = state.onDone),
+                state = ButtonState(text = stringRes(DesignR.string.migration_status_done), onClick = state.onDone),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledVM.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Suppress("LongParameterList")
 class MigrationScheduledVM(
@@ -135,7 +136,7 @@ class MigrationScheduledVM(
             migrationLog("MigrationScheduled: finalizeIfPendingKeystoneBatch failed: $e")
             failureSheet.update {
                 MigrationTransferFailureState(
-                    message = "Something went wrong finalizing your migration schedule. Please try again.",
+                    message = stringRes(DesignR.string.migrationScheduled_finalizeErrorMessage),
                     onRetry = {
                         failureSheet.value = null
                         viewModelScope.launch { finalizeIfPendingKeystoneBatch() }
@@ -164,13 +165,13 @@ class MigrationScheduledVM(
                     ).inWholeSeconds
                 val backgroundHint =
                     if (!isBackgroundExecutionAvailableProvider.isAvailable()) {
-                        stringRes("Transfers run when you open the app — enable background activity in Settings for automatic sending.")
+                        stringRes(DesignR.string.migrationScheduled_backgroundActivityHint)
                     } else {
                         null
                     }
                 MigrationScheduledState(
                     totalAmount = stringRes(Zatoshi(total)),
-                    transfersProgress = stringRes("0 of $count"),
+                    transfersProgress = stringRes(DesignR.string.migrationScheduled_transfersProgressPending, count),
                     duration = stringRes(formatMigrationDuration(span)),
                     backgroundHint = backgroundHint,
                     onDone = ::onDone,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingScreen.kt
@@ -26,7 +26,9 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.orDark
+import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import co.electriccoin.zcash.ui.screen.migration.component.MigrationFailureBottomSheet
 import com.airbnb.lottie.compose.LottieAnimation
@@ -35,6 +37,7 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Composable
 fun MigrationSendingScreen() {
@@ -70,7 +73,7 @@ fun MigrationSendingView(state: MigrationSendingState) {
             SendingAnimation()
             Spacer(Modifier.height(24.dp))
             Text(
-                text = "Sending...",
+                text = stringRes(DesignR.string.migrationSending_title).getValue(),
                 style = ZashiTypography.header5,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
@@ -78,7 +81,7 @@ fun MigrationSendingView(state: MigrationSendingState) {
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "Your ZEC are being sent to\nIronwood...",
+                text = stringRes(DesignR.string.migrationSending_subtitle).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
                 textAlign = TextAlign.Center,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVM.kt
@@ -33,6 +33,9 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
+import co.electriccoin.zcash.ui.design.util.StringResource
+import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationSendingVM(
     private val getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase,
@@ -56,10 +59,10 @@ class MigrationSendingVM(
         data object NotReady : SendFailure
     }
 
-    private fun SendFailure.message(): String =
+    private fun SendFailure.message(): StringResource =
         when (this) {
             is SendFailure.Engine -> migrationFailureMessage(result)
-            SendFailure.NotReady -> "This transfer isn't ready to send yet. Please try again in a moment."
+            SendFailure.NotReady -> stringRes(DesignR.string.migrationSending_notReady)
         }
 
     init {

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/setup/MigrationSetupScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/setup/MigrationSetupScreen.kt
@@ -61,6 +61,7 @@ import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import co.electriccoin.zcash.ui.screen.common.WalletHeaderIcons
 import co.electriccoin.zcash.ui.screen.common.WalletHeaderIconsState
 import org.koin.androidx.compose.koinViewModel
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Composable
 fun MigrationSetupScreen() {
@@ -100,7 +101,7 @@ fun MigrationSetupView(state: MigrationSetupState) {
             )
             Spacer(Modifier.height(16.dp))
             Text(
-                text = "Move to Ironwood",
+                text = stringRes(DesignR.string.migrationSetup_title).getValue(),
                 style = ZashiTypography.header6,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
@@ -117,7 +118,7 @@ fun MigrationSetupView(state: MigrationSetupState) {
                 color = ZashiColors.Text.textTertiary,
             )
             Text(
-                text = "Find out more",
+                text = stringRes(DesignR.string.migrationSetup_findOutMore).getValue(),
                 style = ZashiTypography.textSm.copy(textDecoration = TextDecoration.Underline),
                 fontWeight = FontWeight.Medium,
                 color = ZashiColors.Text.textPrimary,
@@ -133,14 +134,14 @@ fun MigrationSetupView(state: MigrationSetupState) {
             when (state.mode) {
                 MigrationMode.IMMEDIATE -> {
                     MigrationDisclaimerRow(
-                        text = "All funds transferred in this transaction will be revealed on-chain.",
+                        text = stringRes(DesignR.string.migrationSetup_immediateWarning).getValue(),
                         tint = ZashiColors.Utility.WarningYellow.utilityOrange700,
                     )
                 }
 
                 MigrationMode.AUTOMATIC -> {
                     MigrationDisclaimerRow(
-                        text = "The amount of an individual transfer across pools is revealed on-chain.",
+                        text = stringRes(DesignR.string.migrationSetup_automaticWarning).getValue(),
                         tint = ZashiColors.Text.textTertiary,
                     )
                 }
@@ -149,7 +150,7 @@ fun MigrationSetupView(state: MigrationSetupState) {
             ZashiButton(
                 state =
                     ButtonState(
-                        text = stringRes("Next"),
+                        text = stringRes(DesignR.string.general_next),
                         onClick = state.onConfirm,
                     ),
                 modifier = Modifier.fillMaxWidth(),
@@ -160,17 +161,22 @@ fun MigrationSetupView(state: MigrationSetupState) {
 
 // MOB-1620 (Figma node 3925:16408): the balance figure is a distinct, brighter emphasis color
 // against the rest of this muted sentence, not just bold-in-the-same-tertiary-gray.
-private fun buildMigrationBodyText(zecAmount: String, fiatAmount: String?, emphasisColor: Color) =
-    buildAnnotatedString {
-        append("Latest Zcash network upgrade requires moving your ")
+@Composable
+private fun buildMigrationBodyText(zecAmount: String, fiatAmount: String?, emphasisColor: Color): androidx.compose.ui.text.AnnotatedString {
+    val prefix = stringRes(DesignR.string.migrationSetup_bodyPrefix).getValue()
+    val fiatSuffix = fiatAmount?.let { stringRes(DesignR.string.migrationSetup_bodyFiatSuffix, it).getValue() }
+    val suffix = stringRes(DesignR.string.migrationSetup_bodySuffix).getValue()
+    return buildAnnotatedString {
+        append(prefix)
         withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = emphasisColor)) {
             append(zecAmount)
         }
-        if (fiatAmount != null) {
-            append(" ($fiatAmount)")
+        if (fiatSuffix != null) {
+            append(fiatSuffix)
         }
-        append(" from the Orchard pool to the new Ironwood pool. Your funds are safe.")
+        append(suffix)
     }
+}
 
 @Composable
 private fun MigrationDisclaimerRow(
@@ -209,16 +215,16 @@ private fun MigrationModeSelector(
     ) {
         MigrationModeOption(
             mode = MigrationMode.AUTOMATIC,
-            title = "Migrate with Privacy",
-            subtitle = "Split transfers over time · Scheduled in background · Maximum privacy",
+            title = stringRes(DesignR.string.migrationSetup_automaticTitle).getValue(),
+            subtitle = stringRes(DesignR.string.migrationSetup_automaticSubtitle).getValue(),
             isWarning = false,
             selected = selected,
             onSelect = onSelect,
         )
         MigrationModeOption(
             mode = MigrationMode.IMMEDIATE,
-            title = "Migrate Immediately",
-            subtitle = "Single transfer · Sends now · Less privacy",
+            title = stringRes(DesignR.string.migrationSetup_immediateTitle).getValue(),
+            subtitle = stringRes(DesignR.string.migrationSetup_immediateSubtitle).getValue(),
             isWarning = true,
             selected = selected,
             onSelect = onSelect,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/success/MigrationSuccessScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/success/MigrationSuccessScreen.kt
@@ -32,9 +32,11 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.scaffoldPadding
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 data class MigrationSuccessState(
     val onViewTransaction: (() -> Unit)?,
@@ -81,7 +83,7 @@ fun MigrationSuccessView(state: MigrationSuccessState) {
                 )
                 Spacer(Modifier.height(24.dp))
                 Text(
-                    text = "Sent!",
+                    text = stringRes(DesignR.string.migrationSuccess_title).getValue(),
                     style = ZashiTypography.header5,
                     fontWeight = FontWeight.SemiBold,
                     color = ZashiColors.Text.textPrimary,
@@ -89,7 +91,7 @@ fun MigrationSuccessView(state: MigrationSuccessState) {
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = "Your ZEC were successfully\nsent to Ironwood.",
+                    text = stringRes(DesignR.string.migrationSuccess_subtitle).getValue(),
                     style = ZashiTypography.textSm,
                     color = ZashiColors.Text.textTertiary,
                     textAlign = TextAlign.Center,
@@ -97,14 +99,14 @@ fun MigrationSuccessView(state: MigrationSuccessState) {
             }
             state.onViewTransaction?.let { onView ->
                 ZashiButton(
-                    state = ButtonState(text = stringRes("View Transaction"), onClick = onView),
+                    state = ButtonState(text = stringRes(DesignR.string.migrationSuccess_viewTransaction), onClick = onView),
                     modifier = Modifier.fillMaxWidth(),
                     defaultPrimaryColors = ZashiButtonDefaults.secondaryColors(),
                 )
                 Spacer(Modifier.height(8.dp))
             }
             ZashiButton(
-                state = ButtonState(text = stringRes("Close"), onClick = state.onClose),
+                state = ButtonState(text = stringRes(DesignR.string.general_close), onClick = state.onClose),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/torfailure/MigrationTorFailureScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/torfailure/MigrationTorFailureScreen.kt
@@ -28,7 +28,9 @@ import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.dimensions.ZashiDimensions
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
+import co.electriccoin.zcash.ui.design.R as DesignR
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 
@@ -60,35 +62,35 @@ fun MigrationTorFailureView(
                     .padding(start = 24.dp, end = 24.dp, bottom = contentPadding.calculateBottomPadding()),
         ) {
             Text(
-                text = "Couldn't Connect to Tor",
+                text = stringRes(DesignR.string.migrationTorFailure_title).getValue(),
                 style = ZashiTypography.textXl,
                 fontWeight = FontWeight.SemiBold,
                 color = ZashiColors.Text.textPrimary,
             )
             Spacer(4.dp)
             Text(
-                text =
-                    "We couldn't establish a Tor connection. You can proceed without Tor protection, " +
-                        "or cancel and try again.",
+                text = stringRes(DesignR.string.migrationTorFailure_body).getValue(),
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
             Spacer(24.dp)
             RiskCard(
-                title = "What are the risks?",
-                body =
-                    "Without Tor, your IP address is exposed to the server and could be linked to " +
-                        "the migration amounts.",
+                title = stringRes(DesignR.string.migration_common_whatAreTheRisks).getValue(),
+                body = stringRes(DesignR.string.migrationTorFailure_riskBody).getValue(),
             )
             Spacer(32.dp)
             ZashiButton(
-                state = ButtonState(text = stringRes("Continue without Tor"), onClick = innerState.onContinueWithoutTor),
+                state =
+                    ButtonState(
+                        text = stringRes(DesignR.string.migration_common_continueWithoutTor),
+                        onClick = innerState.onContinueWithoutTor
+                    ),
                 modifier = Modifier.fillMaxWidth(),
                 defaultPrimaryColors = ZashiButtonDefaults.destructive1Colors(),
             )
             Spacer(8.dp)
             ZashiButton(
-                state = ButtonState(text = stringRes("Try again"), onClick = innerState.onTryAgain),
+                state = ButtonState(text = stringRes(DesignR.string.migration_common_tryAgain), onClick = innerState.onTryAgain),
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVMTest.kt
@@ -16,7 +16,9 @@ import co.electriccoin.zcash.ui.common.repository.PendingKeystoneMigrationPcztsR
 import co.electriccoin.zcash.ui.common.repository.PendingMigrationScheduleRepositoryImpl
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
+import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.screen.migration.keystonescan.MigrationKeystoneScanArgs
+import co.electriccoin.zcash.ui.design.R as DesignR
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -121,16 +123,14 @@ class MigrationKeystoneSignVMTest {
             val state = vm.state.value
             assertNotNull(state)
             // Positive button says "Get Signature".
-            assertTrue(
-                state.positiveButton.text
-                    .toString()
-                    .contains("Get Signature")
+            assertEquals(
+                DesignR.string.migrationKeystoneSign_getSignature,
+                (state.positiveButton.text as? StringResource.ByResource)?.resource,
             )
             // Negative button says "Reject".
-            assertTrue(
-                state.negativeButton.text
-                    .toString()
-                    .contains("Reject")
+            assertEquals(
+                DesignR.string.migrationKeystoneSign_reject,
+                (state.negativeButton.text as? StringResource.ByResource)?.resource,
             )
 
             collectJob.cancel()
@@ -151,11 +151,13 @@ class MigrationKeystoneSignVMTest {
 
             advanceUntilIdle()
 
-            val title =
-                vm.state.value
-                    ?.title
-                    ?.toString() ?: ""
-            assertTrue(!title.contains(" of "), "Single-round title should not contain a round suffix, got: $title")
+            val title = vm.state.value?.title
+            assertEquals(DesignR.string.migrationKeystoneSign_scanWithKeystone, (title as? StringResource.ByResource)?.resource)
+            val roundSuffix = title?.roundSuffixArg()
+            assertTrue(
+                roundSuffix is StringResource.ByString && roundSuffix.value.isEmpty(),
+                "Single-round title should not contain a round suffix, got: $roundSuffix"
+            )
 
             collectJob.cancel()
         }
@@ -188,12 +190,15 @@ class MigrationKeystoneSignVMTest {
 
             advanceUntilIdle()
 
-            // Title should contain "(1 of 2)" since roundIndex=0, totalRounds=2.
-            val title =
-                vm.state.value
-                    ?.title
-                    ?.toString() ?: ""
-            assertTrue(title.contains("(1 of 2)"), "Multi-round title should contain round suffix, got: $title")
+            // Title should carry a "(1 of 2)" round suffix since roundIndex=0, totalRounds=2.
+            val title = vm.state.value?.title
+            val roundSuffix = title?.roundSuffixArg()
+            assertEquals(
+                DesignR.string.migrationKeystoneSign_roundSuffix,
+                (roundSuffix as? StringResource.ByResource)?.resource,
+                "Multi-round title should contain round suffix, got: $roundSuffix"
+            )
+            assertEquals(listOf(1, 2), (roundSuffix as? StringResource.ByResource)?.args)
 
             collectJob.cancel()
         }
@@ -224,11 +229,14 @@ class MigrationKeystoneSignVMTest {
 
             advanceUntilIdle()
 
-            val title =
-                vm.state.value
-                    ?.title
-                    ?.toString() ?: ""
-            assertTrue(title.contains("(2 of 2)"), "Round-1 title should say '(2 of 2)', got: $title")
+            val title = vm.state.value?.title
+            val roundSuffix = title?.roundSuffixArg()
+            assertEquals(
+                DesignR.string.migrationKeystoneSign_roundSuffix,
+                (roundSuffix as? StringResource.ByResource)?.resource,
+                "Round-1 title should carry a round suffix, got: $roundSuffix"
+            )
+            assertEquals(listOf(2, 2), (roundSuffix as? StringResource.ByResource)?.args)
 
             collectJob.cancel()
         }
@@ -260,7 +268,7 @@ class MigrationKeystoneSignVMTest {
 
             val sheet = vm.failureSheet.value
             assertNotNull(sheet, "Failure sheet must appear when buildBatch throws")
-            assertTrue(sheet.message.isNotBlank())
+            assertTrue(!sheet.message.isEmpty())
             // A retry callback must exist (the sheet re-runs buildBatch on retry).
             assertNotNull(sheet.onRetry)
         }
@@ -690,6 +698,12 @@ class MigrationKeystoneSignVMTest {
 
         override fun observePipeline(): Flow<BaseNavigationCommand> = emptyFlow()
     }
+
+    // The title is DesignR.string.migrationKeystoneSign_scanWithKeystone with the round suffix as
+    // its single %1$s arg — this pulls that nested StringResource back out for structural assertions
+    // (a resource-backed StringResource carries no resolvable text without an Android Context).
+    private fun StringResource.roundSuffixArg(): StringResource? =
+        (this as? StringResource.ByResource)?.args?.singleOrNull() as? StringResource
 }
 
 // 96 actions / 3 actions-per-transfer with no split in the round (engine signing_rounds constants).

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVMTest.kt
@@ -15,9 +15,11 @@ import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetMigrationSnapshotUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.ScheduleNextMigrationWindowUseCase
+import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.screen.migration.success.MigrationSuccessArgs
 import co.electriccoin.zcash.ui.screen.migration.torfailure.MigrationTorFailureArgs
 import co.electriccoin.zcash.work.MigrationDriveOnce
+import co.electriccoin.zcash.ui.design.R as DesignR
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -71,8 +73,8 @@ class MigrationSendingVMTest {
                     ?.failureSheet
             collectJob.cancel()
             assertEquals(
-                "This transfer's note was already spent elsewhere. Reschedule to plan a new one.",
-                sheet?.message,
+                DesignR.string.migrationFailureMessage_invalidNote,
+                (sheet?.message as? StringResource.ByResource)?.resource,
             )
             assertTrue(sheet != null)
         }
@@ -90,10 +92,12 @@ class MigrationSendingVMTest {
 
             coVerify(exactly = 3) { sdk.executeNextPendingTransfer(any(), any()) }
             assertEquals(
-                "This transfer isn't ready to send yet. Please try again in a moment.",
-                vm.state.value.content
-                    ?.failureSheet
-                    ?.message,
+                DesignR.string.migrationSending_notReady,
+                (
+                    vm.state.value.content
+                        ?.failureSheet
+                        ?.message as? StringResource.ByResource
+                )?.resource,
             )
             collectJob.cancel()
         }
@@ -112,10 +116,12 @@ class MigrationSendingVMTest {
 
             coVerify(exactly = 3) { sdk.executeNextPendingTransfer(any(), any()) }
             assertEquals(
-                "This transfer isn't ready to send yet. Please try again in a moment.",
-                vm.state.value.content
-                    ?.failureSheet
-                    ?.message,
+                DesignR.string.migrationSending_notReady,
+                (
+                    vm.state.value.content
+                        ?.failureSheet
+                        ?.message as? StringResource.ByResource
+                )?.resource,
             )
             collectJob.cancel()
         }

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -971,5 +971,207 @@
 
     <!-- ===== whats_new ===== -->
     <string name="whats_new_title">Novedades</string>
-    
+
+    <!-- Restart Migration -->
+    <string name="restartMigration_settingsItem">Reiniciar migración</string>
+    <string name="restartMigration_title">Reiniciar migración</string>
+    <string name="restartMigration_body">Si tu migración parece atascada, puedes reiniciarla de forma segura. Esto crea un nuevo plan para tus fondos restantes. Las transferencias completadas no se ven afectadas.</string>
+    <string name="restartMigration_summaryMigratedLabel">Migrado</string>
+    <string name="restartMigration_summaryMigratedValue">%1$d de %2$d transferencias</string>
+    <string name="restartMigration_summaryRemainingLabel">Saldo restante</string>
+    <string name="restartMigration_warning">Esto cancela el plan de migración actual. No se puede deshacer una vez confirmado.</string>
+    <string name="restartMigration_support">Si reiniciar no resuelve el problema, contacta al soporte de Zodl a través de Enviar comentarios.</string>
+    <string name="restartMigration_next">Siguiente</string>
+    <string name="restartMigration_confirmTitle">¿Reiniciar esta migración?</string>
+    <string name="restartMigration_confirmMessage">Se creará un nuevo plan para tu saldo restante de %1$s. Las %2$d transferencias ya completadas se mantienen como están y no se repetirán.</string>
+    <string name="restartMigration_confirmPrimary">Confirmar reinicio</string>
+
+    <!-- ===== migration (feature-migration screens UI copy) ===== -->
+    <string name="migration_common_gotIt">Entendido</string>
+    <string name="migration_common_skip">Omitir</string>
+    <string name="migration_common_allow">Permitir</string>
+    <string name="migration_common_continue">Continuar</string>
+    <string name="migration_common_retry">Reintentar</string>
+    <string name="migration_common_dismiss">Descartar</string>
+    <string name="migration_common_continueWithoutTor">Continuar sin Tor</string>
+    <string name="migration_common_tryAgain">Intentar de nuevo</string>
+    <string name="migration_common_whatAreTheRisks">¿Cuáles son los riesgos?</string>
+    <string name="migration_common_splitBalanceTitle">División de saldo</string>
+    <string name="migration_common_splitBalanceNumbered">División de saldo %1$d</string>
+    <string name="migration_common_transferTitle">Transferencia %1$d</string>
+    <string name="migration_common_showDetails">Ver detalles</string>
+    <string name="migration_common_progressTitle">Progreso de la migración</string>
+    <string name="migration_common_enableTorProtectionTitle">Activar protección Tor</string>
+    <string name="migration_common_torCheckboxSubtitle">Enruta tu conexión a través de la red Tor para mayor anonimato y protección de la privacidad.</string>
+
+    <string name="migration_status_done">Listo</string>
+
+    <string name="migrationPrivacy_bodyImmediate">Si Tor está disponible en tu región, te recomendamos encarecidamente activarlo para evitar vincular tu saldo con tu dirección IP. También puedes usar una VPN de confianza si Tor no está disponible en tu región.</string>
+    <string name="migrationPrivacy_bodyAutomatic">Si Tor está disponible en tu región, te recomendamos encarecidamente activarlo para evitar vincular los montos de la migración con tu dirección IP. También puedes usar una VPN de confianza si Tor no está disponible en tu región.</string>
+
+    <string name="migrationKeystoneScan_instructions">Escanea el código QR que aparece en tu dispositivo Keystone después de firmar.</string>
+    <string name="migrationKeystoneScan_errorMessage">Ocurrió un error al procesar ese escaneo. Inténtalo de nuevo.</string>
+    <string name="migrationKeystoneScan_firmwareUnsupported">El firmware de tu Keystone todavía no admite la migración. Actualiza tu dispositivo Keystone y vuelve a intentarlo.</string>
+
+    <string name="migrationSuccess_title">¡Enviado!</string>
+    <string name="migrationSuccess_subtitle">Tus ZEC se enviaron\ncorrectamente a Ironwood.</string>
+    <string name="migrationSuccess_viewTransaction">Ver transacción</string>
+
+    <string name="migrationSending_title">Enviando...</string>
+    <string name="migrationSending_subtitle">Tus ZEC se están enviando a\nIronwood...</string>
+
+    <string name="migrationProgress_subtitleComplete">Las %1$d transferencias están completas.</string>
+    <string name="migrationProgress_subtitlePreStart">Tu saldo se divide en %1$d transferencias a lo largo de %2$s. Quedan %3$d transferencias.</string>
+    <string name="migrationProgress_subtitleInProgressRemaining">Tu saldo se divide en %1$d transferencias. Quedan aproximadamente %2$s. Quedan %3$d transferencias.</string>
+    <string name="migrationProgress_subtitleInProgressLate">Tu saldo se divide en %1$d transferencias. Terminando… Quedan %2$d transferencias.</string>
+    <string name="migrationProgress_orchardLabel">Orchard</string>
+    <string name="migrationProgress_ironwoodLabel">Ironwood</string>
+
+    <string name="migrationComplete_title">Migración completa</string>
+    <string name="migrationComplete_subtitle">Tus ZEC ya están en el pool de Ironwood.</string>
+    <string name="migrationComplete_totalTransferredLabel">Total transferido</string>
+    <string name="migrationComplete_remainingDustLabel">Polvo restante</string>
+    <string name="migrationComplete_transfersLabel">Transferencias</string>
+    <string name="migrationComplete_durationLabel">Duración</string>
+    <string name="migrationComplete_orchardBalanceRemainingTitle">Saldo restante en Orchard</string>
+    <string name="migrationComplete_orchardBalanceRemainingBody">%1$s permaneció en Orchard. Un monto tan específico puede identificarte en la red. Para proteger tu privacidad, te recomendamos bloquear este saldo en lugar de migrarlo.</string>
+    <string name="migrationComplete_migrateAnyway">Migrar de todas formas</string>
+    <string name="migrationComplete_migrating">Migrando…</string>
+    <string name="migrationComplete_lockBalance">Bloquear saldo</string>
+    <string name="migrationComplete_lockingBalance">Bloqueando saldo…</string>
+    <string name="migrationComplete_orchardBalanceLockedTitle">Saldo de Orchard bloqueado</string>
+    <string name="migrationComplete_orchardBalanceLockedBody">%1$s ahora está bloqueado en Orchard. El bloqueo hace que este monto no se pueda gastar para proteger tu privacidad.</string>
+    <string name="migrationComplete_transfersProgress">%1$d de %2$d enviadas</string>
+    <string name="migrationComplete_migrateAnywayFailureNetworkError">No se pudo conectar a la red. Revisa tu conexión e inténtalo de nuevo.</string>
+    <string name="migrationComplete_migrateAnywayFailureRejected">La red rechazó esta transacción. Contacta con soporte.</string>
+    <string name="migrationComplete_migrateAnywayFailureError">Ocurrió un error al enviar. Contacta con soporte.</string>
+    <string name="migrationComplete_migrateAnywayFailurePartial">Se enviaron algunas partes de esta transacción, pero no todas. Contacta con soporte.</string>
+
+    <string name="migrationNotifPermission_title">Permitir notificaciones</string>
+    <string name="migrationNotifPermission_subtitle">Si se pierde una transferencia programada o falla un envío en segundo plano, podemos enviarte una notificación local para que abras Zodl. Recibe avisos sobre:</string>
+    <string name="migrationNotifPermission_statusTitle">Estado de la migración</string>
+    <string name="migrationNotifPermission_statusBody">Te avisaremos cuando tus fondos se hayan migrado por completo a Ironwood.</string>
+    <string name="migrationNotifPermission_actionNeededTitle">Acción necesaria</string>
+    <string name="migrationNotifPermission_actionNeededBody">Si se pierde una ventana de envío, te pediremos que abras la app y envíes una transferencia manualmente.</string>
+    <string name="migrationNotifPermission_planChangesTitle">Cambios en el plan de transferencias</string>
+    <string name="migrationNotifPermission_planChangesBody">Si se gastan los fondos asignados o una transferencia programada ya no se puede enviar, te lo haremos saber.</string>
+    <string name="migrationNotifPermission_warningHint">Sin notificaciones, tendrás que abrir Zodl para revisar el progreso de la migración y aprobar tú mismo cualquier transferencia manual.</string>
+
+    <string name="migrationCustomServerTor_title">Tu servidor no admite Tor</string>
+    <string name="migrationCustomServerTor_bodyImmediate">La transacción de migración no se puede transmitir por Tor cuando usas un servidor personalizado. Si continúas, esta transacción se enviará sin la protección de IP de Tor.</string>
+    <string name="migrationCustomServerTor_bodyAutomatic">Las transacciones de migración no se pueden transmitir por Tor cuando usas un servidor personalizado. Si continúas, estas transacciones se enviarán sin la protección de IP de Tor.</string>
+    <string name="migrationCustomServerTor_riskBodyImmediate">Sin Tor, tu dirección IP queda expuesta al servidor personalizado y podría vincularse con tu saldo completo.</string>
+    <string name="migrationCustomServerTor_riskBodyAutomatic">Sin Tor, tu dirección IP queda expuesta al servidor personalizado y podría vincularse con los montos de la migración.</string>
+    <string name="migrationCustomServerTor_switchServer">Cambiar servidor</string>
+
+    <string name="migrationTorFailure_title">No se pudo conectar a Tor</string>
+    <string name="migrationTorFailure_body">No pudimos establecer una conexión Tor. Puedes continuar sin la protección de Tor, o cancelar e intentarlo de nuevo.</string>
+    <string name="migrationTorFailure_riskBody">Sin Tor, tu dirección IP queda expuesta al servidor y podría vincularse con los montos de la migración.</string>
+
+    <string name="migrationSetup_title">Pasar a Ironwood</string>
+    <string name="migrationSetup_bodyPrefix">La última actualización de la red Zcash requiere mover tu </string>
+    <string name="migrationSetup_bodyFiatSuffix"> (%1$s)</string>
+    <string name="migrationSetup_bodySuffix"> del pool de Orchard al nuevo pool de Ironwood. Tus fondos están seguros.</string>
+    <string name="migrationSetup_findOutMore">Más información</string>
+    <string name="migrationSetup_immediateWarning">Todos los fondos transferidos en esta transacción se revelarán en la cadena de bloques.</string>
+    <string name="migrationSetup_automaticWarning">El monto de cada transferencia individual entre pools se revela en la cadena de bloques.</string>
+    <string name="migrationSetup_automaticTitle">Migrar con privacidad</string>
+    <string name="migrationSetup_automaticSubtitle">Transferencias divididas en el tiempo · Programadas en segundo plano · Máxima privacidad</string>
+    <string name="migrationSetup_immediateTitle">Migrar de inmediato</string>
+    <string name="migrationSetup_immediateSubtitle">Transferencia única · Se envía ahora · Menor privacidad</string>
+
+    <string name="migrationLockExplainer_title">¿Qué hace el bloqueo?</string>
+    <string name="migrationLockExplainer_bullet1Prefix">Bloquear marca este saldo como </string>
+    <string name="migrationLockExplainer_bullet1Bold">no gastable</string>
+    <string name="migrationLockExplainer_bullet1Suffix">, así no podrá comprometer tu privacidad en futuras transacciones.</string>
+    <string name="migrationLockExplainer_bullet2Bold">El bloqueo existe solo en esta instancia de Zodl/Keystone.</string>
+    <string name="migrationLockExplainer_bullet2Suffix"> Restaurar tu wallet no lo trasladará.</string>
+    <string name="migrationLockExplainer_bullet3Prefix">Una futura versión te permitirá </string>
+    <string name="migrationLockExplainer_bullet3Bold">desbloquear este saldo.</string>
+
+    <string name="migrationFailureSheet_title">No se pudo enviar</string>
+    <string name="migrationFailureMessage_networkError">No se pudo conectar a la red. Revisa tu conexión e inténtalo de nuevo.</string>
+    <string name="migrationFailureMessage_invalidNote">La nota de esta transferencia ya se gastó en otro lugar. Reprográmala para planear una nueva.</string>
+    <string name="migrationFailureMessage_expired">El anchor de esta transferencia caducó. Reprográmala para planear una nueva.</string>
+    <string name="migrationSending_notReady">Esta transferencia todavía no está lista para enviarse. Inténtalo de nuevo en un momento.</string>
+
+    <string name="migrationPreparationDetails_title">Preparar tu saldo</string>
+    <string name="migrationPreparationDetails_body">Tu saldo debe dividirse en notas del tamaño de una transferencia en %1$d pasos antes de que comiencen tus transferencias programadas.</string>
+    <string name="migrationPreparationDetails_stepsTitle">Pasos de preparación</string>
+    <string name="migrationPreparationDetails_amountBeingSplitTitle">Monto en división</string>
+
+    <string name="migrationTransferInvalid_planUpdateTitle">Actualizar plan de migración</string>
+    <string name="migrationTransferInvalid_planUpdateBody">Algunas notas de Orchard se gastaron fuera del flujo de migración, lo que invalidó el plan de transferencias prefirmado. El plan debe volver a crearse para el saldo restante. No se pierden fondos: solo se descartan las transacciones prefirmadas.</string>
+    <string name="migrationTransferInvalid_planUpdateFirstStep">Se descarta la transferencia invalidada</string>
+    <string name="migrationTransferInvalid_transferExpiredTitle">La transferencia ya no es válida</string>
+    <string name="migrationTransferInvalid_transferExpiredBodyPlural">La transferencia %1$s caducó sin enviarse: la app no se abrió a tiempo para transmitirlas. El plan de migración debe volver a crearse para el saldo restante. No se pierden fondos: solo se descartan las transacciones prefirmadas.</string>
+    <string name="migrationTransferInvalid_transferExpiredBodySingular">La transferencia %1$s caducó sin enviarse: la app no se abrió a tiempo para transmitirla. El plan de migración debe volver a crearse para el saldo restante. No se pierden fondos: solo se descartan las transacciones prefirmadas.</string>
+    <string name="migrationTransferInvalid_expiredStepLabelPlural">Se descartan las transferencias caducadas</string>
+    <string name="migrationTransferInvalid_expiredStepLabelSingular">Se descarta la transferencia caducada</string>
+    <string name="migrationTransferInvalid_whatHappensNextTitle">Qué sucede a continuación</string>
+    <string name="migrationTransferInvalid_remainingBalanceReproposed">El saldo restante se vuelve a proponer</string>
+    <string name="migrationTransferInvalid_transfersDoneProgress">%1$d de %2$d transferencias completadas; la migración continuará.</string>
+
+    <string name="migrationHowItWorks_title">Cómo funciona</string>
+    <string name="migrationHowItWorks_subtitle">Mover fondos entre pools de Zcash revela el monto de cada transferencia. Así protegemos tu privacidad durante la migración.</string>
+    <string name="migrationHowItWorks_splitScheduleTitle">Dividir y programar</string>
+    <string name="migrationHowItWorks_splitScheduleDescription">Tu saldo se divide en montos más pequeños y se distribuye en el tiempo, lo que dificulta vincularlos entre sí.</string>
+    <string name="migrationHowItWorks_approveOnceTitle">Aprueba una vez</string>
+    <string name="migrationHowItWorks_approveOnceDescription">Zodl se encarga del resto, enviando cada transferencia automáticamente en su ventana programada mientras la app se ejecuta en segundo plano.</string>
+    <string name="migrationHowItWorks_ifSomethingFailsTitle">Si algo falla</string>
+    <string name="migrationHowItWorks_ifSomethingFailsDescription">Te avisaremos para que puedas completarla manualmente.</string>
+    <string name="migrationHowItWorks_largeBalanceTitle">Saldo grande</string>
+    <string name="migrationHowItWorks_largeBalanceDescription">Si tu wallet tiene un saldo grande o muchas notas pequeñas, la migración puede ejecutarse en varias rondas programadas.</string>
+    <string name="migrationHowItWorks_disclaimer">Elegir esta opción puede requerir dejar una pequeña cantidad (menos de 0.01 ZEC) en el pool de Orchard, que no se transferirá.</string>
+
+    <string name="migrationReview_title">Revisar transferencia</string>
+    <string name="migrationReview_immediateBody">Todo tu saldo de Orchard se transferirá a Ironwood en una sola transferencia en cadena. Una vez confirmada, esta transferencia no se puede cancelar.</string>
+    <string name="migrationReview_feeLabel">Comisión</string>
+    <string name="migrationReview_amountLabel">Monto</string>
+    <string name="migrationReview_signing">Firmando...</string>
+    <string name="migrationReview_confirm">Confirmar</string>
+    <string name="migrationReview_confirmTransferPlanTitle">Confirmar plan de transferencias</string>
+    <string name="migrationReview_privacyBody">Tu saldo se divide en %1$d transferencias a lo largo de %2$s. Apruébalo una vez y nosotros nos encargamos del resto: solo mantén la app ejecutándose en segundo plano. Los montos se aleatorizan por privacidad. Si se pierde una ventana de envío, Zodl te avisará la próxima vez que abras la app.</string>
+    <string name="migrationReview_roundOfTotal">Ronda %1$d de %2$d</string>
+    <string name="migrationReview_startMigration">Iniciar migración</string>
+    <string name="migrationReview_sendImmediately">Enviar de inmediato</string>
+
+    <string name="migrationKeystoneSign_prepareErrorMessage">No se pudo preparar la migración para firmar. Inténtalo de nuevo.</string>
+    <string name="migrationKeystoneSign_barTitle">Firmar transacción</string>
+    <string name="migrationKeystoneSign_scanWithKeystone">Escanea con tu wallet Keystone%1$s</string>
+    <string name="migrationKeystoneSign_roundSuffix"> (%1$d de %2$d)</string>
+    <string name="migrationKeystoneSign_subtitle">Después de firmar con Keystone, toca el botón Obtener firma que aparece abajo.</string>
+    <string name="migrationKeystoneSign_badgeHardware">Hardware</string>
+    <string name="migrationKeystoneSign_getSignature">Obtener firma</string>
+    <string name="migrationKeystoneSign_reject">Rechazar</string>
+
+    <string name="migrationBattery_title">Permitir envío en segundo plano</string>
+    <string name="migrationBattery_body">Para enviar las transferencias de migración en sus horarios programados, Zodl necesita seguir ejecutándose en segundo plano. Permite la actividad en segundo plano para Zodl en la configuración de tu dispositivo.</string>
+    <string name="migrationBattery_scheduledWindowsTitle">Las transferencias se envían en sus ventanas programadas</string>
+    <string name="migrationBattery_scheduledWindowsBody">Zodl se activa y envía cada transferencia en el horario programado, sin que tengas que hacer nada.</string>
+    <string name="migrationBattery_noNeedToOpenTitle">No hace falta abrir la app para cada envío</string>
+    <string name="migrationBattery_noNeedToOpenBody">Una vez confirmado el calendario, todas las transferencias se envían en segundo plano.</string>
+    <string name="migrationBattery_fixedScheduleTitle">Se envían en un horario fijo, no según tu actividad</string>
+    <string name="migrationBattery_fixedScheduleBody">Las transferencias se envían en horarios fijos de la red, por lo que no están vinculadas a cuándo abres Zodl.</string>
+    <string name="migrationBattery_withoutPermissionHint">Sin este permiso, tendrás que abrir Zodl manualmente en cada horario programado para enviar.</string>
+
+    <string name="migrationScheduled_schedulingTitle">Programando...</string>
+    <string name="migrationScheduled_schedulingSubtitle">Se está confirmando el calendario de migración de tus ZEC.</string>
+    <string name="migrationScheduled_totalToTransferLabel">Total a transferir</string>
+    <string name="migrationScheduled_poolLabel">Pool</string>
+    <string name="migrationScheduled_poolValue">Orchard → Ironwood</string>
+    <string name="migrationScheduled_transfersLabel">Transferencias</string>
+    <string name="migrationScheduled_durationLabel">Duración</string>
+    <string name="migrationScheduled_doneTitle">Migración programada</string>
+    <string name="migrationScheduled_doneSubtitle">Tus ZEC se migrarán al pool de Ironwood según el calendario que aprobaste.</string>
+    <string name="migrationScheduled_finalizeErrorMessage">Ocurrió un error al finalizar el calendario de migración. Inténtalo de nuevo.</string>
+    <string name="migrationScheduled_backgroundActivityHint">Las transferencias se ejecutan cuando abres la app. Activa la actividad en segundo plano en Configuración para el envío automático.</string>
+    <string name="migrationScheduled_transfersProgressPending">0 de %1$d</string>
+
+    <string name="migrationHome_completeTitle">Migración completa</string>
+    <string name="migrationHome_requiredTitle">Migración necesaria</string>
+    <string name="migrationHome_readyToSendTitle">Transferencia lista</string>
+    <string name="migrationHome_attentionTitle">La migración necesita atención</string>
+    <string name="migrationHome_defaultSubtitle">Mueve tus fondos a Ironwood.</string>
+
 </resources>

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -1043,9 +1043,9 @@
     <string name="migrationComplete_orchardBalanceLockedBody">%1$s ahora está bloqueado en Orchard. El bloqueo hace que este monto no se pueda gastar para proteger tu privacidad.</string>
     <string name="migrationComplete_transfersProgress">%1$d de %2$d enviadas</string>
     <string name="migrationComplete_migrateAnywayFailureNetworkError">No se pudo conectar a la red. Revisa tu conexión e inténtalo de nuevo.</string>
-    <string name="migrationComplete_migrateAnywayFailureRejected">La red rechazó esta transacción. Contacta con soporte.</string>
-    <string name="migrationComplete_migrateAnywayFailureError">Ocurrió un error al enviar. Contacta con soporte.</string>
-    <string name="migrationComplete_migrateAnywayFailurePartial">Se enviaron algunas partes de esta transacción, pero no todas. Contacta con soporte.</string>
+    <string name="migrationComplete_migrateAnywayFailureRejected">La red rechazó esta transacción. Comunícate con el soporte.</string>
+    <string name="migrationComplete_migrateAnywayFailureError">Ocurrió un error al enviar. Comunícate con el soporte.</string>
+    <string name="migrationComplete_migrateAnywayFailurePartial">Se enviaron algunas partes de esta transacción, pero no todas. Comunícate con el soporte.</string>
 
     <string name="migrationNotifPermission_title">Permitir notificaciones</string>
     <string name="migrationNotifPermission_subtitle">Si se pierde una transferencia programada o falla un envío en segundo plano, podemos enviarte una notificación local para que abras Zodl. Recibe avisos sobre:</string>
@@ -1068,7 +1068,7 @@
     <string name="migrationTorFailure_body">No pudimos establecer una conexión Tor. Puedes continuar sin la protección de Tor, o cancelar e intentarlo de nuevo.</string>
     <string name="migrationTorFailure_riskBody">Sin Tor, tu dirección IP queda expuesta al servidor y podría vincularse con los montos de la migración.</string>
 
-    <string name="migrationSetup_title">Pasar a Ironwood</string>
+    <string name="migrationSetup_title">Mover a Ironwood</string>
     <string name="migrationSetup_bodyPrefix">La última actualización de la red Zcash requiere mover tu </string>
     <string name="migrationSetup_bodyFiatSuffix"> (%1$s)</string>
     <string name="migrationSetup_bodySuffix"> del pool de Orchard al nuevo pool de Ironwood. Tus fondos están seguros.</string>
@@ -1098,13 +1098,13 @@
     <string name="migrationPreparationDetails_title">Preparar tu saldo</string>
     <string name="migrationPreparationDetails_body">Tu saldo debe dividirse en notas del tamaño de una transferencia en %1$d pasos antes de que comiencen tus transferencias programadas.</string>
     <string name="migrationPreparationDetails_stepsTitle">Pasos de preparación</string>
-    <string name="migrationPreparationDetails_amountBeingSplitTitle">Monto en división</string>
+    <string name="migrationPreparationDetails_amountBeingSplitTitle">Monto a dividir</string>
 
     <string name="migrationTransferInvalid_planUpdateTitle">Actualizar plan de migración</string>
     <string name="migrationTransferInvalid_planUpdateBody">Algunas notas de Orchard se gastaron fuera del flujo de migración, lo que invalidó el plan de transferencias prefirmado. El plan debe volver a crearse para el saldo restante. No se pierden fondos: solo se descartan las transacciones prefirmadas.</string>
     <string name="migrationTransferInvalid_planUpdateFirstStep">Se descarta la transferencia invalidada</string>
     <string name="migrationTransferInvalid_transferExpiredTitle">La transferencia ya no es válida</string>
-    <string name="migrationTransferInvalid_transferExpiredBodyPlural">La transferencia %1$s caducó sin enviarse: la app no se abrió a tiempo para transmitirlas. El plan de migración debe volver a crearse para el saldo restante. No se pierden fondos: solo se descartan las transacciones prefirmadas.</string>
+    <string name="migrationTransferInvalid_transferExpiredBodyPlural">Las transferencias %1$s caducaron sin enviarse: la app no se abrió a tiempo para transmitirlas. El plan de migración debe volver a crearse para el saldo restante. No se pierden fondos: solo se descartan las transacciones prefirmadas.</string>
     <string name="migrationTransferInvalid_transferExpiredBodySingular">La transferencia %1$s caducó sin enviarse: la app no se abrió a tiempo para transmitirla. El plan de migración debe volver a crearse para el saldo restante. No se pierden fondos: solo se descartan las transacciones prefirmadas.</string>
     <string name="migrationTransferInvalid_expiredStepLabelPlural">Se descartan las transferencias caducadas</string>
     <string name="migrationTransferInvalid_expiredStepLabelSingular">Se descarta la transferencia caducada</string>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -1290,4 +1290,199 @@ Your vote can no longer be submitted.</string>
     <string name="restartMigration_confirmMessage">A new plan will be created for your remaining %1$s. The %2$d transfers already completed stay as they are and won\'t be repeated.</string>
     <string name="restartMigration_confirmPrimary">Confirm restart</string>
 
+    <!-- ===== migration (feature-migration screens UI copy) ===== -->
+    <string name="migration_common_gotIt">Got it</string>
+    <string name="migration_common_skip">Skip</string>
+    <string name="migration_common_allow">Allow</string>
+    <string name="migration_common_continue">Continue</string>
+    <string name="migration_common_retry">Retry</string>
+    <string name="migration_common_dismiss">Dismiss</string>
+    <string name="migration_common_continueWithoutTor">Continue without Tor</string>
+    <string name="migration_common_tryAgain">Try again</string>
+    <string name="migration_common_whatAreTheRisks">What are the risks?</string>
+    <string name="migration_common_splitBalanceTitle">Split Balance</string>
+    <string name="migration_common_splitBalanceNumbered">Split balance %1$d</string>
+    <string name="migration_common_transferTitle">Transfer %1$d</string>
+    <string name="migration_common_showDetails">Show details</string>
+    <string name="migration_common_progressTitle">Migration Progress</string>
+    <string name="migration_common_enableTorProtectionTitle">Enable Tor Protection</string>
+    <string name="migration_common_torCheckboxSubtitle">Routes your connection through the Tor network for enhanced anonymity and privacy protection.</string>
+
+    <!-- Only this one status word is resource-backed: it's a plain button label (Scheduled
+         screen), not one of the dynamic per-row status functions in MigrationProgressVM /
+         MigrationPreparationDetails / MigrationReviewVM. Those stay English-literal ByString on
+         purpose — they're unit-tested in plain JVM tests via a StringResource.ByString-only
+         reflection helper with no Android Context available to resolve a real resource
+         (MigrationPreparationDetailsTest, MigrationProgressVMTest, MigrationReviewPlanShapeTest).
+         Localizing them needs that test harness reworked first; tracked as a known gap. -->
+    <string name="migration_status_done">Done</string>
+
+    <string name="migrationPrivacy_bodyImmediate">If Tor is available in your region, we strongly recommend enabling it to prevent linking your balance to your IP address. You can also use a trusted VPN if Tor is unavailable in your region.</string>
+    <string name="migrationPrivacy_bodyAutomatic">If Tor is available in your region, we strongly recommend enabling it to prevent linking the migration amounts to your IP address. You can also use a trusted VPN if Tor is unavailable in your region.</string>
+
+    <string name="migrationKeystoneScan_instructions">Scan the QR code shown on your Keystone device after signing.</string>
+    <string name="migrationKeystoneScan_errorMessage">Something went wrong while processing that scan. Please try again.</string>
+    <string name="migrationKeystoneScan_firmwareUnsupported">Your Keystone firmware doesn\'t support migration yet. Update your Keystone device, then come back to retry.</string>
+
+    <string name="migrationSuccess_title">Sent!</string>
+    <string name="migrationSuccess_subtitle">Your ZEC were successfully\nsent to Ironwood.</string>
+    <string name="migrationSuccess_viewTransaction">View Transaction</string>
+
+    <string name="migrationSending_title">Sending...</string>
+    <string name="migrationSending_subtitle">Your ZEC are being sent to\nIronwood...</string>
+
+    <string name="migrationProgress_subtitleComplete">All %1$d transfers are complete.</string>
+    <string name="migrationProgress_subtitlePreStart">Your balance splits into %1$d transfers over %2$s. There are %3$d remaining transfers.</string>
+    <string name="migrationProgress_subtitleInProgressRemaining">Your balance splits into %1$d transfers. About %2$s remaining. There are %3$d remaining transfers.</string>
+    <string name="migrationProgress_subtitleInProgressLate">Your balance splits into %1$d transfers. Finishing up… There are %2$d remaining transfers.</string>
+    <string name="migrationProgress_orchardLabel">Orchard</string>
+    <string name="migrationProgress_ironwoodLabel">Ironwood</string>
+
+    <string name="migrationComplete_title">Migration Complete</string>
+    <string name="migrationComplete_subtitle">Your ZEC is now in the Ironwood pool.</string>
+    <string name="migrationComplete_totalTransferredLabel">Total transferred</string>
+    <string name="migrationComplete_remainingDustLabel">Remaining dust</string>
+    <string name="migrationComplete_transfersLabel">Transfers</string>
+    <string name="migrationComplete_durationLabel">Duration</string>
+    <string name="migrationComplete_orchardBalanceRemainingTitle">Orchard balance remaining</string>
+    <string name="migrationComplete_orchardBalanceRemainingBody">%1$s stayed in Orchard. An amount this specific can identify you on the network. To protect your privacy, we recommend locking this balance rather than migrating it.</string>
+    <string name="migrationComplete_migrateAnyway">Migrate anyway</string>
+    <string name="migrationComplete_migrating">Migrating…</string>
+    <string name="migrationComplete_lockBalance">Lock balance</string>
+    <string name="migrationComplete_lockingBalance">Locking balance…</string>
+    <string name="migrationComplete_orchardBalanceLockedTitle">Orchard balance locked</string>
+    <string name="migrationComplete_orchardBalanceLockedBody">%1$s is now locked in Orchard. Locking keeps this amount unspendable to protect your privacy.</string>
+    <string name="migrationComplete_transfersProgress">%1$d of %2$d sent</string>
+    <string name="migrationComplete_migrateAnywayFailureNetworkError">Couldn\'t reach the network. Check your connection and try again.</string>
+    <string name="migrationComplete_migrateAnywayFailureRejected">The network rejected this transaction. Please contact support.</string>
+    <string name="migrationComplete_migrateAnywayFailureError">Something went wrong while sending. Please contact support.</string>
+    <string name="migrationComplete_migrateAnywayFailurePartial">Some but not all of this transaction\'s parts were sent. Please contact support.</string>
+
+    <string name="migrationNotifPermission_title">Allow Notifications</string>
+    <string name="migrationNotifPermission_subtitle">If a scheduled transfer is missed or a background submission fails, we can send you a local notification and prompt you to open Zodl. Get notified about:</string>
+    <string name="migrationNotifPermission_statusTitle">Migration Status</string>
+    <string name="migrationNotifPermission_statusBody">We will inform you whenever your funds are fully migrated to Ironwood.</string>
+    <string name="migrationNotifPermission_actionNeededTitle">Action Needed</string>
+    <string name="migrationNotifPermission_actionNeededBody">If we miss a window, we will prompt you to open the app and send a transfer manually.</string>
+    <string name="migrationNotifPermission_planChangesTitle">Transfer Plan Changes</string>
+    <string name="migrationNotifPermission_planChangesBody">If allocated funds are spent or a scheduled transfer can no longer be sent, we\'ll let you know.</string>
+    <string name="migrationNotifPermission_warningHint">Without notifications, you\'ll need to open Zodl to check migration progress and approve any manual transfers yourself.</string>
+
+    <string name="migrationCustomServerTor_title">Your Server Doesn\'t Support Tor</string>
+    <string name="migrationCustomServerTor_bodyImmediate">The migration transaction can\'t be broadcast over Tor when you\'re using a custom server. If you continue, this transaction will be sent without Tor\'s IP protection.</string>
+    <string name="migrationCustomServerTor_bodyAutomatic">Migration transactions can\'t be broadcast over Tor when you\'re using a custom server. If you continue, these transactions will be sent without Tor\'s IP protection.</string>
+    <string name="migrationCustomServerTor_riskBodyImmediate">Without Tor, your IP address is exposed to the custom server and could be linked to your full balance.</string>
+    <string name="migrationCustomServerTor_riskBodyAutomatic">Without Tor, your IP address is exposed to the custom server and could be linked to the migration amounts.</string>
+    <string name="migrationCustomServerTor_switchServer">Switch Server</string>
+
+    <string name="migrationTorFailure_title">Couldn\'t Connect to Tor</string>
+    <string name="migrationTorFailure_body">We couldn\'t establish a Tor connection. You can proceed without Tor protection, or cancel and try again.</string>
+    <string name="migrationTorFailure_riskBody">Without Tor, your IP address is exposed to the server and could be linked to the migration amounts.</string>
+
+    <string name="migrationSetup_title">Move to Ironwood</string>
+    <string name="migrationSetup_bodyPrefix">Latest Zcash network upgrade requires moving your </string>
+    <string name="migrationSetup_bodyFiatSuffix"> (%1$s)</string>
+    <string name="migrationSetup_bodySuffix"> from the Orchard pool to the new Ironwood pool. Your funds are safe.</string>
+    <string name="migrationSetup_findOutMore">Find out more</string>
+    <string name="migrationSetup_immediateWarning">All funds transferred in this transaction will be revealed on-chain.</string>
+    <string name="migrationSetup_automaticWarning">The amount of an individual transfer across pools is revealed on-chain.</string>
+    <string name="migrationSetup_automaticTitle">Migrate with Privacy</string>
+    <string name="migrationSetup_automaticSubtitle">Split transfers over time · Scheduled in background · Maximum privacy</string>
+    <string name="migrationSetup_immediateTitle">Migrate Immediately</string>
+    <string name="migrationSetup_immediateSubtitle">Single transfer · Sends now · Less privacy</string>
+
+    <string name="migrationLockExplainer_title">What does locking do?</string>
+    <string name="migrationLockExplainer_bullet1Prefix">Locking marks this balance as </string>
+    <string name="migrationLockExplainer_bullet1Bold">unspendable</string>
+    <string name="migrationLockExplainer_bullet1Suffix">, so it can\'t compromise your privacy in future transactions.</string>
+    <string name="migrationLockExplainer_bullet2Bold">The lock lives on this Zodl/Keystone instance only.</string>
+    <string name="migrationLockExplainer_bullet2Suffix"> Restoring your wallet won\'t carry it over.</string>
+    <string name="migrationLockExplainer_bullet3Prefix">A future release will let you </string>
+    <string name="migrationLockExplainer_bullet3Bold">unlock this balance.</string>
+
+    <string name="migrationFailureSheet_title">Couldn\'t Send</string>
+    <string name="migrationFailureMessage_networkError">Couldn\'t reach the network. Check your connection and try again.</string>
+    <string name="migrationFailureMessage_invalidNote">This transfer\'s note was already spent elsewhere. Reschedule to plan a new one.</string>
+    <string name="migrationFailureMessage_expired">This transfer\'s anchor expired. Reschedule to plan a new one.</string>
+    <string name="migrationSending_notReady">This transfer isn\'t ready to send yet. Please try again in a moment.</string>
+
+    <string name="migrationPreparationDetails_title">Prepare Your Balance</string>
+    <string name="migrationPreparationDetails_body">Your balance needs to be split into transfer-sized notes across %1$d steps before your scheduled transfers begin.</string>
+    <string name="migrationPreparationDetails_stepsTitle">Preparation Steps</string>
+    <string name="migrationPreparationDetails_amountBeingSplitTitle">Amount Being Split</string>
+
+    <string name="migrationTransferInvalid_planUpdateTitle">Update Migration Plan</string>
+    <string name="migrationTransferInvalid_planUpdateBody">Some Orchard notes were spent outside the migration flow, which invalidated the pre-signed transfer plan. The plan needs to be re-created for the remaining balance. No funds are lost — only the pre-signed transactions are discarded.</string>
+    <string name="migrationTransferInvalid_planUpdateFirstStep">The invalidated transfer is discarded</string>
+    <string name="migrationTransferInvalid_transferExpiredTitle">Transfer No Longer Valid</string>
+    <string name="migrationTransferInvalid_transferExpiredBodyPlural">Transfer %1$s expired without being sent — the app wasn\'t opened in time to broadcast them. The migration plan needs to be re-created for the remaining balance. No funds are lost — only the pre-signed transactions are discarded.</string>
+    <string name="migrationTransferInvalid_transferExpiredBodySingular">Transfer %1$s expired without being sent — the app wasn\'t opened in time to broadcast it. The migration plan needs to be re-created for the remaining balance. No funds are lost — only the pre-signed transactions are discarded.</string>
+    <string name="migrationTransferInvalid_expiredStepLabelPlural">Expired transfers are discarded</string>
+    <string name="migrationTransferInvalid_expiredStepLabelSingular">Expired transfer is discarded</string>
+    <string name="migrationTransferInvalid_whatHappensNextTitle">What Happens Next</string>
+    <string name="migrationTransferInvalid_remainingBalanceReproposed">Remaining balance is re-proposed</string>
+    <string name="migrationTransferInvalid_transfersDoneProgress">%1$d of %2$d transfers done; migration will continue.</string>
+
+    <string name="migrationHowItWorks_title">How This Works</string>
+    <string name="migrationHowItWorks_subtitle">Moving funds between Zcash pools reveals the amount of each transfer. Here\'s how we protect your privacy during migration.</string>
+    <string name="migrationHowItWorks_splitScheduleTitle">Split and schedule</string>
+    <string name="migrationHowItWorks_splitScheduleDescription">Your balance is divided into smaller amounts and spaced out over time, so they\'re harder to link together.</string>
+    <string name="migrationHowItWorks_approveOnceTitle">Approve once</string>
+    <string name="migrationHowItWorks_approveOnceDescription">Zodl handles the rest, sending each transfer automatically in its scheduled window while the app runs in the background.</string>
+    <string name="migrationHowItWorks_ifSomethingFailsTitle">If something fails</string>
+    <string name="migrationHowItWorks_ifSomethingFailsDescription">We\'ll notify you so you can complete it manually.</string>
+    <string name="migrationHowItWorks_largeBalanceTitle">Large balance</string>
+    <string name="migrationHowItWorks_largeBalanceDescription">If your wallet holds large balance or many small notes, migration may run across multiple scheduled rounds.</string>
+    <string name="migrationHowItWorks_disclaimer">Choosing this option may require a small amount (less than 0.01 ZEC) to be left in the Orchard pool, and which won\'t be transferred.</string>
+
+    <string name="migrationReview_title">Review Transfer</string>
+    <string name="migrationReview_immediateBody">Your full Orchard balance will be transferred to Ironwood in a single on-chain transfer. Once confirmed, this transfer cannot be cancelled.</string>
+    <string name="migrationReview_feeLabel">Fee</string>
+    <string name="migrationReview_amountLabel">Amount</string>
+    <string name="migrationReview_signing">Signing...</string>
+    <string name="migrationReview_confirm">Confirm</string>
+    <string name="migrationReview_confirmTransferPlanTitle">Confirm Transfer Plan</string>
+    <string name="migrationReview_privacyBody">Your balance splits into %1$d transfers over %2$s. Approve once and we\'ll handle the rest — just keep the app running in the background. Amounts are randomized for privacy. If we miss a window, Zodl will prompt you on next open.</string>
+    <string name="migrationReview_roundOfTotal">Round %1$d of %2$d</string>
+    <string name="migrationReview_startMigration">Start Migration</string>
+    <string name="migrationReview_sendImmediately">Send immediately</string>
+
+    <string name="migrationKeystoneSign_prepareErrorMessage">Couldn\'t prepare the migration for signing. Try again.</string>
+    <string name="migrationKeystoneSign_barTitle">Sign Transaction</string>
+    <string name="migrationKeystoneSign_scanWithKeystone">Scan with your Keystone wallet%1$s</string>
+    <string name="migrationKeystoneSign_roundSuffix"> (%1$d of %2$d)</string>
+    <string name="migrationKeystoneSign_subtitle">After you have signed with Keystone, tap on the Get Signature button below.</string>
+    <string name="migrationKeystoneSign_badgeHardware">Hardware</string>
+    <string name="migrationKeystoneSign_getSignature">Get Signature</string>
+    <string name="migrationKeystoneSign_reject">Reject</string>
+
+    <string name="migrationBattery_title">Allow Background Delivery</string>
+    <string name="migrationBattery_body">To send migration transfers at their scheduled times, Zodl needs to keep running in the background. Allow background activity for Zodl in your device settings.</string>
+    <string name="migrationBattery_scheduledWindowsTitle">Transfers send at their scheduled windows</string>
+    <string name="migrationBattery_scheduledWindowsBody">Zodl wakes up and sends each transfer at its scheduled time — no action needed.</string>
+    <string name="migrationBattery_noNeedToOpenTitle">No need to open the app for each send</string>
+    <string name="migrationBattery_noNeedToOpenBody">Once the schedule is committed, all transfers are sent in the background.</string>
+    <string name="migrationBattery_fixedScheduleTitle">Sends on a fixed schedule, not your activity</string>
+    <string name="migrationBattery_fixedScheduleBody">Transfers go out at set network-wide times, so they\'re not linked to when you open Zodl.</string>
+    <string name="migrationBattery_withoutPermissionHint">Without this permission, you\'ll need to open Zodl manually at each scheduled time to send.</string>
+
+    <string name="migrationScheduled_schedulingTitle">Scheduling...</string>
+    <string name="migrationScheduled_schedulingSubtitle">Your ZEC migration schedule is getting confirmed.</string>
+    <string name="migrationScheduled_totalToTransferLabel">Total to transfer</string>
+    <string name="migrationScheduled_poolLabel">Pool</string>
+    <string name="migrationScheduled_poolValue">Orchard → Ironwood</string>
+    <string name="migrationScheduled_transfersLabel">Transfers</string>
+    <string name="migrationScheduled_durationLabel">Duration</string>
+    <string name="migrationScheduled_doneTitle">Migration Scheduled</string>
+    <string name="migrationScheduled_doneSubtitle">Your ZEC will be migrated to the Ironwood pool based on the schedule you approved.</string>
+    <string name="migrationScheduled_finalizeErrorMessage">Something went wrong finalizing your migration schedule. Please try again.</string>
+    <string name="migrationScheduled_backgroundActivityHint">Transfers run when you open the app — enable background activity in Settings for automatic sending.</string>
+    <string name="migrationScheduled_transfersProgressPending">0 of %1$d</string>
+
+    <string name="migrationHome_completeTitle">Migration complete</string>
+    <string name="migrationHome_requiredTitle">Migration Required</string>
+    <string name="migrationHome_readyToSendTitle">Transfer Ready</string>
+    <string name="migrationHome_attentionTitle">Migration needs attention</string>
+    <string name="migrationHome_defaultSubtitle">Move your funds to Ironwood.</string>
+
 </resources>

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/migration/MigrationMessage.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/migration/MigrationMessage.kt
@@ -22,8 +22,10 @@ import co.electriccoin.zcash.ui.design.component.ZashiCircularProgressIndicatorB
 import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiLightColors
+import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.home.HomeMessageWrapper
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 @Composable
 fun MigrationMessage(
@@ -101,16 +103,16 @@ fun MigrationMessage(
         title = {
             Text(
                 state.title ?: when (state.phase) {
-                    MigrationBannerPhase.COMPLETE -> "Migration complete"
-                    MigrationBannerPhase.IN_PROGRESS -> "Migration Progress"
-                    MigrationBannerPhase.REQUIRED -> "Migration Required"
-                    MigrationBannerPhase.READY_TO_SEND -> "Transfer Ready"
-                    MigrationBannerPhase.ATTENTION -> "Migration needs attention"
+                    MigrationBannerPhase.COMPLETE -> stringRes(DesignR.string.migrationHome_completeTitle).getValue()
+                    MigrationBannerPhase.IN_PROGRESS -> stringRes(DesignR.string.migration_common_progressTitle).getValue()
+                    MigrationBannerPhase.REQUIRED -> stringRes(DesignR.string.migrationHome_requiredTitle).getValue()
+                    MigrationBannerPhase.READY_TO_SEND -> stringRes(DesignR.string.migrationHome_readyToSendTitle).getValue()
+                    MigrationBannerPhase.ATTENTION -> stringRes(DesignR.string.migrationHome_attentionTitle).getValue()
                 }
             )
         },
         subtitle = {
-            Text(state.progressLabel ?: "Move your funds to Ironwood.")
+            Text(state.progressLabel ?: stringRes(DesignR.string.migrationHome_defaultSubtitle).getValue())
         },
         end = {
             ZashiButton(


### PR DESCRIPTION
## Summary
- Extracts hardcoded migration UI copy (setup, privacy/Tor, review, progress, complete, success, sending, scheduled, battery permission, notifications, Keystone scan/sign, restart, lock explainer, how-it-works, transfer-invalid, failure sheets, home banner) into shared `strings.xml` resources instead of inline Kotlin literals.
- Adds Spanish translations for the newly extracted strings, plus the pre-existing `restartMigration_*` strings that had English text but no ES translation yet.
- A handful of dynamic status-word functions (Done/Ready now/Awaiting signature/the Progress-screen header sentence) intentionally stay as English literals — they're unit-tested in plain JVM tests via a `StringResource.ByString`-only reflection helper with no Android Context to resolve a real resource; converting them would break existing regression tests. Documented inline in `strings.xml`.

## Commits
- `bede08492` — string extraction (Kotlin + EN `strings.xml`)
- `c96a6e633` — ES translations (`values-es/strings.xml`)

## Test plan
- [x] `feature-migration`, `ui-lib`, `ui-design-lib` compile clean
- [x] `feature-migration` unit test suite: 301/301 passing
- [x] `ui-lib` migration/ironwood-related unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)