### PR TITLE
MOB-1664: retain last known wallet balance across synchronizer swaps

### DIFF
--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
@@ -6,6 +6,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.filters.SmallTest
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletInitMode
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.PersistableWallet
 import cash.z.ecc.android.sdk.model.SeedPhrase
@@ -43,6 +45,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -333,6 +336,7 @@ private class FakeWalletRepository(
 private class FakeSynchronizerProvider : SynchronizerProvider {
     override val error = MutableStateFlow<SynchronizerError?>(null)
     override val synchronizer = MutableStateFlow<Synchronizer?>(MockSynchronizer(ServerValidation.Valid))
+    override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = checkNotNull(synchronizer.value)
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -295,7 +295,7 @@ class AccountDataSourceImpl(
             }
 
         val balanceFlow =
-            synchronizer.walletBalances
+            synchronizerProvider.walletBalances
                 .map {
                     it
                         ?.get(sdkAccount.accountUuid)
@@ -316,7 +316,7 @@ class AccountDataSourceImpl(
                 delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                 true
             }
-        return combine(transparentAddress, synchronizer.walletBalances) { address, balances ->
+        return combine(transparentAddress, synchronizerProvider.walletBalances) { address, balances ->
             val balance = balances?.get(sdkAccount.accountUuid)
             TransparentInfo(address = address, balance = balance?.unshielded ?: Zatoshi.ZERO)
         }
@@ -333,7 +333,7 @@ class AccountDataSourceImpl(
                     delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                     true
                 }
-            combine(saplingAddress, synchronizer.walletBalances) { address, balances ->
+            combine(saplingAddress, synchronizerProvider.walletBalances) { address, balances ->
                 val balance = balances?.get(sdkAccount.accountUuid)
                 SaplingInfo(address = address, balance = balance?.sapling ?: createEmptyWalletBalance())
             }
@@ -342,7 +342,7 @@ class AccountDataSourceImpl(
     // Ironwood shares the same unified address as Orchard (no address of its own to observe) —
     // just its balance.
     private fun observeIronwoodBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance> =
-        synchronizer.walletBalances.map { balances ->
+        synchronizerProvider.walletBalances.map { balances ->
             balances?.get(sdkAccount.accountUuid)?.ironwood ?: createEmptyWalletBalance()
         }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
@@ -2,6 +2,8 @@ package co.electriccoin.zcash.ui.common.provider
 
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletCoordinator
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountUuid
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.migration.MigrationSyncedHook
 import co.electriccoin.zcash.ui.common.model.SynchronizerError
@@ -20,7 +22,9 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -30,6 +34,19 @@ interface SynchronizerProvider {
     val error: StateFlow<SynchronizerError?>
 
     val synchronizer: StateFlow<Synchronizer?>
+
+    /**
+     * MOB-1664: [Synchronizer.walletBalances] is per-synchronizer-instance state that resets to
+     * `null` every time the synchronizer is rebuilt (e.g. an automatic server switch tears down
+     * and reconstructs the whole engine), which would otherwise flash every balance display
+     * (top-line, per-pool breakdown) to 0.000 for the few seconds the new instance takes to
+     * re-establish itself. This retains the last known non-null value across that gap so
+     * consumers never observe a spurious drop to zero. Central here (rather than patched into
+     * each consumer) since [AccountDataSource], [co.electriccoin.zcash.ui.common.usecase.GetBalancePoolsUseCase],
+     * [co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase] and
+     * [co.electriccoin.zcash.ui.common.viewmodel.WalletViewModel] all read this independently.
+     */
+    val walletBalances: Flow<Map<AccountUuid, AccountBalance>?>
 
     /**
      * Get synchronizer and wait for it to be ready.
@@ -89,6 +106,14 @@ class SynchronizerProviderImpl(
                 started = SharingStarted.Lazily,
                 initialValue = walletCoordinator.synchronizer.value
             )
+
+    private val lastKnownWalletBalances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
+
+    override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> =
+        synchronizer
+            .flatMapLatest { it?.walletBalances ?: flowOf(null) }
+            .onEach { if (it != null) lastKnownWalletBalances.value = it }
+            .map { it ?: lastKnownWalletBalances.value }
 
     init {
         scope.launch {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
@@ -52,7 +52,7 @@ class GetBalancePoolsUseCase(
             if (synchronizer == null || account == null) {
                 flowOf(null)
             } else {
-                synchronizer.walletBalances.map { balances ->
+                synchronizerProvider.walletBalances.map { balances ->
                     val balance = balances?.get(account.sdkAccount.accountUuid)
                     val orchard = (balance?.orchard?.total ?: Zatoshi.ZERO) + (balance?.orchard?.locked ?: Zatoshi.ZERO)
                     val sapling = (balance?.sapling?.total ?: Zatoshi.ZERO) + (balance?.sapling?.locked ?: Zatoshi.ZERO)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
@@ -29,9 +29,9 @@ class GetOrchardBalanceUseCase(
     private val accountDataSource: AccountDataSource,
 ) {
     suspend operator fun invoke(): Zatoshi {
-        val synchronizer = synchronizerProvider.getSynchronizer()
+        synchronizerProvider.getSynchronizer()
         val account = accountDataSource.getSelectedAccount()
-        val balances = synchronizer.walletBalances.filterNotNull().first()
+        val balances = synchronizerProvider.walletBalances.filterNotNull().first()
         return balances[account.sdkAccount.accountUuid]?.orchard?.available ?: Zatoshi.ZERO
     }
 
@@ -46,7 +46,7 @@ class GetOrchardBalanceUseCase(
             if (synchronizer == null || account == null) {
                 flowOf(null)
             } else {
-                synchronizer.walletBalances.map { balances ->
+                synchronizerProvider.walletBalances.map { balances ->
                     balances?.get(account.sdkAccount.accountUuid)?.orchard?.available
                 }
             }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
@@ -44,7 +44,7 @@ class WalletViewModel(
                 } else {
                     combine(
                         synchronizer.fullyScannedHeight,
-                        synchronizer.walletBalances,
+                        synchronizerProvider.walletBalances,
                         walletRepository.isIronwoodAnnouncementShown,
                     ) { scannedHeight, balances, isShown ->
                         val activationHeight = IronwoodActivation.heightFor(synchronizer.network)

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
@@ -5,6 +5,8 @@ import cash.z.ecc.android.sdk.fixture.AccountFixture
 import cash.z.ecc.android.sdk.fixture.WalletAddressFixture
 import cash.z.ecc.android.sdk.fixture.WalletBalanceFixture
 import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
@@ -220,6 +222,7 @@ private class FakeSynchronizerProvider(
 
     override val error: StateFlow<SynchronizerError?> = MutableStateFlow(null)
     override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(fakeSynchronizer)
+    override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = fakeSynchronizer
 


### PR DESCRIPTION
## Summary
- Fixes [MOB-1664](https://linear.app/zodl/issue/MOB-1664/inaccurate-transaction-statuses-on-automatic-server-switch): the "top balance drops to 0.000" / "pool breakdown all zeros" symptom reported alongside the transaction status flicker (SDK fix in a companion PR).
- `Synchronizer.walletBalances` is per-synchronizer-instance state that resets to `null` every time the synchronizer is rebuilt (e.g. an automatic server switch tears down and reconstructs the whole engine), so every balance display briefly flashed to 0.000 for the few seconds the new instance takes to re-establish itself.
- Centralized the fix in `SynchronizerProvider.walletBalances` (retains the last non-null value across the swap) since `AccountDataSource`, `GetBalancePoolsUseCase`, `GetOrchardBalanceUseCase`, and `WalletViewModel` each read the raw `Synchronizer.walletBalances` independently and all needed the same treatment — one shared fix instead of four separately patched call sites.

## Test plan
- [x] `ui-lib` unit test suite: 678/678 green
- [x] `feature-migration` unit test suite: 834/834 green
- [x] Live-verified on an emulator: manual server switch (background/foreground) no longer produces a visible balance drop to 0.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)