### PR TITLE
MOB-1669: skip eager live-driver start after committing a migration plan

### DIFF
--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationPreparationDetails.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationPreparationDetails.kt
@@ -47,9 +47,17 @@ fun preparationStepTitle(number: Int, stepCount: Int): StringResource = stringRe
  * on EVERY row inside this sheet, including the one that's already due. [formatMigrationDuration]'s
  * own `coerceAtLeast` floor already turns a zero/negative [secondsUntil] into its network floor, so
  * no separate clamping is needed here.
+ *
+ * [fineGrained] forwards to [formatMigrationDuration] — exposed here (default unchanged: ambient
+ * [isTestnetBuildFlavor]) purely so a caller (a test) can pin it explicitly instead of depending on
+ * which Gradle flavor variant happened to compile the caller (MOB-1669 test-flakiness follow-up,
+ * 2026-08-09: this default silently resolved differently under `testZcashmainnetStoreDebugUnitTest`
+ * vs `testZcashtestnetStoreDebugUnitTest`, since both compile and run this same JVM test).
  */
-fun preparationStepTimeLabel(secondsUntil: Long): StringResource =
-    stringRes("in ${formatMigrationDuration(secondsUntil)}")
+fun preparationStepTimeLabel(
+    secondsUntil: Long,
+    fineGrained: Boolean = isTestnetBuildFlavor(),
+): StringResource = stringRes("in ${formatMigrationDuration(secondsUntil, fineGrained = fineGrained)}")
 
 /**
  * The Figma-matched status word for one preparation step, derived purely from its own

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/FinalizeMigrationScheduleUseCase.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/FinalizeMigrationScheduleUseCase.kt
@@ -26,6 +26,26 @@ import kotlin.time.Duration.Companion.seconds
  * behavior and by on-launch reconciliation
  * ([CheckMigrationRecoveryUseCase][co.electriccoin.zcash.ui.common.usecase.CheckMigrationRecoveryUseCase]),
  * not by a separate notify-only delivery mode.
+ *
+ * [startLiveDriverImmediately] (default `true`) lets a caller opt OUT of eagerly starting
+ * [MigrationLiveDriver] here (MOB-1669, 2026-08-09): whatever prep/note-split transactions are
+ * already prove-ready runs synchronously through one blocking `finalizeReadyTransfers` call inside
+ * the live driver's very first loop iteration — for a large committed plan (e.g. a big Keystone
+ * batch's whole note-split tree becoming prove-ready at once), up to several minutes, with no
+ * progress feedback across that JNI boundary (reported: 3.5 min on Android vs instant on iOS for a
+ * 3-round Keystone batch).
+ *
+ * iOS's equivalent commit steps — both `MigrationCommitPipeline.commitSoftware` (the hot-wallet
+ * lane) and the post-Keystone-scan `storeKeystoneSignedBatch` — never eagerly start their own
+ * drive loop here either: they store/sign the schedule, call a lightweight `reconcile()` (a
+ * state/gate read, no proving), and return; whatever background driver iOS has picks up proving on
+ * its own normal cadence. Both `MigrationScheduledVM` (post-Keystone-scan) and `MigrationReviewVM`
+ * (hot-wallet confirm) pass `false` to match: the `migrationScheduler.schedule(...)` call above
+ * already arms the WorkManager job for whenever the plan's first step is actually due, so
+ * proving+broadcasting still happens — just not forced to start synchronously in the same breath
+ * as the commit/ceremony finishing. The `true` default remains only for
+ * [DebugStartMigrationE2EUseCase][co.electriccoin.zcash.ui.common.usecase.DebugStartMigrationE2EUseCase],
+ * whose whole point is fast, immediately-observable end-to-end iteration.
  */
 class FinalizeMigrationScheduleUseCase(
     private val migrationScheduler: MigrationScheduler,
@@ -34,7 +54,11 @@ class FinalizeMigrationScheduleUseCase(
     private val synchronizerProvider: SynchronizerProvider,
     private val migrationLiveDriver: MigrationLiveDriver,
 ) {
-    suspend operator fun invoke(sched: MigrationSchedule, mode: MigrationMode) {
+    suspend operator fun invoke(
+        sched: MigrationSchedule,
+        mode: MigrationMode,
+        startLiveDriverImmediately: Boolean = true,
+    ) {
         // Measured block rate — the 75s constant grossly overestimates on the bursty testnet,
         // scheduling the first worker run far past the real due heights.
         val secondsPerBlock = getOrchardMigrationSdk().estimatedSecondsPerBlock()
@@ -55,7 +79,14 @@ class FinalizeMigrationScheduleUseCase(
         // first risks it entering syncRun (syncToTip) concurrently with the anchor-retention
         // restart, the exact mechanism that exists to prevent a permanent AnchorNotFound on the
         // plan's first bucket.
-        migrationLiveDriver.startIfNotRunning(accountKeyId)
+        if (startLiveDriverImmediately) {
+            migrationLiveDriver.startIfNotRunning(accountKeyId)
+        } else {
+            migrationLog(
+                "FinalizeMigrationSchedule: skipping eager live-driver start (MOB-1669) — " +
+                    "the scheduled WorkManager job will drive this plan forward instead."
+            )
+        }
     }
 
     /**

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationPreparationDetailsBottomSheet.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationPreparationDetailsBottomSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.common.model.migration.MigrationPreparationDetails
 import co.electriccoin.zcash.ui.common.model.migration.MigrationPreparationStepDetail
@@ -202,7 +203,7 @@ private fun PreparationStepRow(
             }
         }
         Spacer(Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
+        Column(modifier = Modifier.weight(TITLE_COLUMN_WEIGHT)) {
             Text(
                 text = step.title.getValue(),
                 style = ZashiTypography.textSm,
@@ -215,11 +216,24 @@ private fun PreparationStepRow(
                 color = ZashiColors.Text.textTertiary,
             )
         }
+        Spacer(Modifier.width(8.dp))
+        // Weighted like the title/time column above (not a bare Modifier.align) — a long
+        // dependency list ("Waits on steps 1, 2, ..., 14" for a big Keystone batch) previously had
+        // no width bound of its own, so Row gave it first claim on the available width and
+        // squeezed the weighted title column down to near-zero, wrapping "Transaction 15 of 16"
+        // one character per line. Bounding both columns by weight lets this text wrap within its
+        // own share instead of stealing the title's.
         Text(
             text = step.statusLabel.getValue(),
             style = ZashiTypography.textXs,
             color = ZashiColors.Text.textTertiary,
-            modifier = Modifier.align(Alignment.CenterVertically),
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f).align(Alignment.CenterVertically),
         )
     }
 }
+
+// Title column gets a larger share than the status column (weight 1f, above) — it's the primary
+// text, and the status column's worst case ("Waits on steps 1, 2, ..., 14") still wraps to a few
+// short lines at this ratio instead of squeezing the title down to near-zero width.
+private const val TITLE_COLUMN_WEIGHT = 1.3f

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVM.kt
@@ -13,6 +13,7 @@ import co.electriccoin.zcash.ui.common.model.migration.MigrationPreparationDetai
 import co.electriccoin.zcash.ui.common.model.migration.MigrationPreparationStepDetail
 import co.electriccoin.zcash.ui.common.model.migration.MigrationTransferBlocker
 import co.electriccoin.zcash.ui.common.model.migration.formatMigrationDuration
+import co.electriccoin.zcash.ui.common.model.migration.isTestnetBuildFlavor
 import co.electriccoin.zcash.ui.common.model.migration.preparationStepStatus
 import co.electriccoin.zcash.ui.common.model.migration.preparationStepTimeLabel
 import co.electriccoin.zcash.ui.common.model.migration.preparationStepTitle
@@ -325,6 +326,7 @@ internal fun orchardRemainingZatoshi(
 internal fun migrationProgressSubtitle(
     snapshot: LiveMigrationSnapshot,
     now: Instant,
+    fineGrained: Boolean = isTestnetBuildFlavor(),
 ): String {
     // Scheduled moments across preparations AND transfers, used for both the pre-start static
     // total-span estimate and the in-progress remaining-time countdown below.
@@ -342,7 +344,8 @@ internal fun migrationProgressSubtitle(
         snapshot.completedCount <= 0 -> {
             val span = (lastScheduled - firstScheduled).inWholeSeconds
             "Your balance splits into ${snapshot.totalCount} transfers over " +
-                "${formatMigrationDuration(span)}. There are $remainingCount remaining transfers."
+                "${formatMigrationDuration(span, fineGrained = fineGrained)}. There are " +
+                "$remainingCount remaining transfers."
         }
 
         // In progress: the header now counts down remaining time instead of showing a static total.
@@ -350,7 +353,7 @@ internal fun migrationProgressSubtitle(
             val remaining = (lastScheduled - now).inWholeSeconds
             if (remaining > 0) {
                 "Your balance splits into ${snapshot.totalCount} transfers. About " +
-                    "${formatMigrationDuration(remaining)} remaining. There are " +
+                    "${formatMigrationDuration(remaining, fineGrained = fineGrained)} remaining. There are " +
                     "$remainingCount remaining transfers."
             } else {
                 // Running late but healthy — never claim a duration here (see doc above).
@@ -402,6 +405,7 @@ internal fun transferRowDisplay(
     t: LiveMigrationTransfer,
     now: Instant,
     isLastRowOverall: Boolean,
+    fineGrained: Boolean = isTestnetBuildFlavor(),
 ): MigrationRowDisplay =
     when {
         t.blocker == MigrationTransferBlocker.EXPIRED -> {
@@ -421,7 +425,7 @@ internal fun transferRowDisplay(
         }
 
         t.isSent -> {
-            sentRowDisplay(t.minedAt, now)
+            sentRowDisplay(t.minedAt, now, fineGrained)
         }
 
         t.scheduledAt <= now -> {
@@ -429,7 +433,7 @@ internal fun transferRowDisplay(
         }
 
         else -> {
-            futureRowDisplay(t.scheduledAt, now, isLastRowOverall)
+            futureRowDisplay(t.scheduledAt, now, isLastRowOverall, fineGrained)
         }
     }
 
@@ -444,6 +448,7 @@ internal fun preparationRowDisplay(
     p: LiveMigrationPreparation,
     now: Instant,
     isLastRowOverall: Boolean,
+    fineGrained: Boolean = isTestnetBuildFlavor(),
 ): MigrationRowDisplay =
     when {
         p.isSent -> {
@@ -463,7 +468,7 @@ internal fun preparationRowDisplay(
         }
 
         else -> {
-            futureRowDisplay(p.scheduledAt, now, isLastRowOverall)
+            futureRowDisplay(p.scheduledAt, now, isLastRowOverall, fineGrained)
         }
     }
 
@@ -473,14 +478,22 @@ internal fun preparationRowDisplay(
  * height/time, so "Sent {relative} ago" is only shown once [minedAt] is known; until then this
  * reads plain "Sent" rather than inventing a broadcast time the model doesn't have.
  */
-internal fun sentRowDisplay(minedAt: Instant?, now: Instant): MigrationRowDisplay =
+internal fun sentRowDisplay(
+    minedAt: Instant?,
+    now: Instant,
+    fineGrained: Boolean = isTestnetBuildFlavor(),
+): MigrationRowDisplay =
     if (minedAt != null) {
         val secondsAgo = (now - minedAt).inWholeSeconds.coerceAtLeast(0L)
         // No privacy floor here (2026-08-06 revised decision) — see formatMigrationDuration's own
         // kdoc: an already-mined transfer's exact timing is already public on-chain, so flooring
         // this specific label has no privacy benefit left, only less-informative copy.
         MigrationRowDisplay(
-            stringRes("Sent ${formatMigrationDuration(secondsAgo, applyPrivacyFloor = false)} ago"),
+            stringRes(
+                "Sent ${
+                    formatMigrationDuration(secondsAgo, fineGrained = fineGrained, applyPrivacyFloor = false)
+                } ago"
+            ),
             isReadyNow = false
         )
     } else {
@@ -496,9 +509,10 @@ private fun futureRowDisplay(
     scheduledAt: Instant,
     now: Instant,
     isLastRowOverall: Boolean,
+    fineGrained: Boolean = isTestnetBuildFlavor(),
 ): MigrationRowDisplay {
     val secondsLeft = (scheduledAt - now).inWholeSeconds
-    val relative = formatMigrationDuration(secondsLeft)
+    val relative = formatMigrationDuration(secondsLeft, fineGrained = fineGrained)
     val label = if (isLastRowOverall) "in $relative" else relative
     return MigrationRowDisplay(stringRes(label), isReadyNow = false)
 }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/review/MigrationReviewVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/review/MigrationReviewVM.kt
@@ -413,7 +413,10 @@ class MigrationReviewVM(
             }
         try {
             sdk.signAndStoreMigrationSchedule(scheduleToSign, zashiSpendingKeyDataSource.getZashiSpendingKey())
-            finalizeMigrationSchedule(scheduleToSign, args.mode)
+            // startLiveDriverImmediately=false (MOB-1669): matches iOS's commitSoftware, which
+            // also never eagerly starts a drive loop right after signAndStoreMigrationSchedule —
+            // see FinalizeMigrationScheduleUseCase's doc.
+            finalizeMigrationSchedule(scheduleToSign, args.mode, startLiveDriverImmediately = false)
             navigationRouter.forward(MigrationScheduledArgs)
         } catch (e: RuntimeException) {
             val retryable =
@@ -431,7 +434,7 @@ class MigrationReviewVM(
             migrationLog("MigrationReview: StalePlan on commit — re-proposing once and retrying")
             val fresh = sdk.proposeMigrationTransfers()
             sdk.signAndStoreMigrationSchedule(fresh, zashiSpendingKeyDataSource.getZashiSpendingKey())
-            finalizeMigrationSchedule(fresh, args.mode)
+            finalizeMigrationSchedule(fresh, args.mode, startLiveDriverImmediately = false)
             navigationRouter.forward(MigrationScheduledArgs)
         }
     }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledVM.kt
@@ -123,7 +123,12 @@ class MigrationScheduledVM(
             )
             // Mode doesn't affect this use case's behavior (only routes IMMEDIATE vs AUTOMATIC
             // before it), and MigrationScheduledArgs is only ever reached on the AUTOMATIC path.
-            finalizeMigrationSchedule(sched, MigrationMode.AUTOMATIC)
+            // startLiveDriverImmediately=false (MOB-1669): a large Keystone batch's whole
+            // prove-ready note-split set would otherwise run through one blocking
+            // finalizeReadyTransfers call in the live driver's very first iteration, right as
+            // this Keystone ceremony finishes. The already-armed migrationScheduler job still
+            // drives this plan forward — just not synchronously forced open here.
+            finalizeMigrationSchedule(sched, MigrationMode.AUTOMATIC, startLiveDriverImmediately = false)
             pendingSchedule.clear()
             pendingKeystonePczts.clear()
             isFinalizing.value = false

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/setup/MigrationSetupScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/setup/MigrationSetupScreen.kt
@@ -117,6 +117,7 @@ fun MigrationSetupView(state: MigrationSetupState) {
                 style = ZashiTypography.textSm,
                 color = ZashiColors.Text.textTertiary,
             )
+            Spacer(Modifier.height(4.dp))
             Text(
                 text = stringRes(DesignR.string.migrationSetup_findOutMore).getValue(),
                 style = ZashiTypography.textSm.copy(textDecoration = TextDecoration.Underline),

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/MigrationPreparationDetailsTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/MigrationPreparationDetailsTest.kt
@@ -21,8 +21,12 @@ class MigrationPreparationDetailsTest {
         // Unlike the main timeline's last-row-only "in" rule, the sheet ALWAYS prefixes "in" —
         // including a step whose own schedule slot has already arrived (Figma shows "in ~0 hours"
         // for the immediately-due first step, never a bare "Ready to send" in this column).
-        assertEquals("in ~10 min", preparationStepTimeLabel(0L).asString())
-        assertEquals("in ~10 min", preparationStepTimeLabel(-100L).asString())
+        // fineGrained pinned explicitly (MOB-1669 test-flakiness follow-up, 2026-08-09) — this
+        // testnet-floor expectation must not depend on which Gradle flavor variant compiled this
+        // JVM test (isTestnetBuildFlavor()'s ambient BuildConfig.FLAVOR default resolves
+        // differently under testZcashmainnetStoreDebugUnitTest vs testZcashtestnetStoreDebugUnitTest).
+        assertEquals("in ~10 min", preparationStepTimeLabel(0L, fineGrained = true).asString())
+        assertEquals("in ~10 min", preparationStepTimeLabel(-100L, fineGrained = true).asString())
     }
 
     @Test

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/FinalizeMigrationScheduleUseCaseTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/FinalizeMigrationScheduleUseCaseTest.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.PreparationStep
 import cash.z.ecc.android.sdk.TransferProposal
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.model.migration.MigrationMode
+import co.electriccoin.zcash.work.MigrationLiveDriver
 import co.electriccoin.zcash.work.MigrationScheduler
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -31,17 +32,19 @@ class FinalizeMigrationScheduleUseCaseTest {
             proposalHandle = 0L,
         )
 
-    private fun useCase(scheduler: MigrationScheduler = mockk(relaxed = true)) =
-        FinalizeMigrationScheduleUseCase(
-            migrationScheduler = scheduler,
-            getOrchardMigrationSdk = mockk<GetOrchardMigrationSdkUseCase>(relaxed = true),
-            getSelectedWalletAccount =
-                mockk<GetSelectedWalletAccountUseCase> {
-                    coEvery { this@mockk() } returns mockk<ZashiAccount>(relaxed = true)
-                },
-            synchronizerProvider = mockk(relaxed = true),
-            migrationLiveDriver = mockk(relaxed = true),
-        )
+    private fun useCase(
+        scheduler: MigrationScheduler = mockk(relaxed = true),
+        migrationLiveDriver: MigrationLiveDriver = mockk(relaxed = true),
+    ) = FinalizeMigrationScheduleUseCase(
+        migrationScheduler = scheduler,
+        getOrchardMigrationSdk = mockk<GetOrchardMigrationSdkUseCase>(relaxed = true),
+        getSelectedWalletAccount =
+            mockk<GetSelectedWalletAccountUseCase> {
+                coEvery { this@mockk() } returns mockk<ZashiAccount>(relaxed = true)
+            },
+        synchronizerProvider = mockk(relaxed = true),
+        migrationLiveDriver = migrationLiveDriver,
+    )
 
     @Test
     fun invokeArmsTheMigrationWorkerChain() =
@@ -54,6 +57,34 @@ class FinalizeMigrationScheduleUseCaseTest {
             useCase(scheduler)(schedule(), MigrationMode.AUTOMATIC)
 
             verify(exactly = 1) { scheduler.schedule(any(), any()) }
+        }
+
+    @Test
+    fun startLiveDriverImmediatelyDefaultsToTrueAndStartsTheDriver() =
+        runTest {
+            val driver = mockk<MigrationLiveDriver>(relaxed = true)
+
+            useCase(migrationLiveDriver = driver)(schedule(), MigrationMode.AUTOMATIC)
+
+            verify(exactly = 1) { driver.startIfNotRunning(any()) }
+        }
+
+    @Test
+    fun startLiveDriverImmediatelyFalseSkipsStartingTheDriver() =
+        runTest {
+            // MOB-1669: the post-Keystone-scan path opts out — a large batch's whole prove-ready
+            // set would otherwise run through one blocking finalizeReadyTransfers call in the live
+            // driver's very first iteration. The already-armed scheduler job still drives the plan
+            // forward (see invokeArmsTheMigrationWorkerChain), just not synchronously forced here.
+            val driver = mockk<MigrationLiveDriver>(relaxed = true)
+
+            useCase(migrationLiveDriver = driver)(
+                schedule(),
+                MigrationMode.AUTOMATIC,
+                startLiveDriverImmediately = false,
+            )
+
+            verify(exactly = 0) { driver.startIfNotRunning(any()) }
         }
 
     @Test

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVMTest.kt
@@ -173,15 +173,23 @@ class MigrationProgressVMTest {
     fun transferRowDisplay_future_not_last_row_has_no_in_prefix() {
         // A span comfortably above either network's privacy floor (10 min testnet / 1 hour
         // mainnet) so this test isn't coupled to formatMigrationDuration's own floor behavior —
-        // that's covered separately in MigrationDurationFormatTest.
+        // that's covered separately in MigrationDurationFormatTest. fineGrained pinned explicitly
+        // (MOB-1669 test-flakiness follow-up, 2026-08-09) — this "~X h" (not "~X hours") shape is
+        // testnet-specific and must not depend on which Gradle flavor variant compiled this test.
         val t = transfer(scheduledAt = now + 2.hours)
-        assertEquals("~2 h", transferRowDisplay(t, now, isLastRowOverall = false).label.asString())
+        assertEquals(
+            "~2 h",
+            transferRowDisplay(t, now, isLastRowOverall = false, fineGrained = true).label.asString()
+        )
     }
 
     @Test
     fun transferRowDisplay_future_last_row_overall_gets_in_prefix() {
         val t = transfer(scheduledAt = now + 2.hours)
-        assertEquals("in ~2 h", transferRowDisplay(t, now, isLastRowOverall = true).label.asString())
+        assertEquals(
+            "in ~2 h",
+            transferRowDisplay(t, now, isLastRowOverall = true, fineGrained = true).label.asString()
+        )
     }
 
     // ── preparationRowDisplay: same priority shape, "Done" not "Sent"/"Confirmed" ─────────────
@@ -214,13 +222,28 @@ class MigrationProgressVMTest {
 
     @Test
     fun preparationRowDisplay_future_last_row_overall_gets_in_prefix() {
-        val display = preparationRowDisplay(prep(scheduledAt = now + 10.minutes), now, isLastRowOverall = true)
+        // fineGrained pinned explicitly (MOB-1669 test-flakiness follow-up, 2026-08-09) — the
+        // 10-minute testnet privacy floor is below the 1-hour mainnet floor, so this "~10 min"
+        // expectation must not depend on which Gradle flavor variant compiled this test.
+        val display =
+            preparationRowDisplay(
+                prep(scheduledAt = now + 10.minutes),
+                now,
+                isLastRowOverall = true,
+                fineGrained = true,
+            )
         assertEquals("in ~10 min", display.label.asString())
     }
 
     @Test
     fun preparationRowDisplay_future_not_last_row_has_no_in_prefix() {
-        val display = preparationRowDisplay(prep(scheduledAt = now + 10.minutes), now, isLastRowOverall = false)
+        val display =
+            preparationRowDisplay(
+                prep(scheduledAt = now + 10.minutes),
+                now,
+                isLastRowOverall = false,
+                fineGrained = true,
+            )
         assertEquals("~10 min", display.label.asString())
     }
 
@@ -317,7 +340,10 @@ class MigrationProgressVMTest {
                 transfer(index = 1, id = 2).copy(scheduledAt = now + 10.minutes),
             )
         val snapshot = LiveMigrationSnapshot(transfers = transfers, preparations = emptyList(), tipHeight = 1_000L)
-        val subtitle = migrationProgressSubtitle(snapshot, now)
+        // fineGrained pinned explicitly (MOB-1669 test-flakiness follow-up, 2026-08-09) — the
+        // 10-minute span here sits below the 1-hour mainnet floor, so this must not depend on
+        // which Gradle flavor variant compiled this test.
+        val subtitle = migrationProgressSubtitle(snapshot, now, fineGrained = true)
         assertTrue(subtitle.contains("over ~10 min"), subtitle)
         assertTrue(subtitle.contains("2 remaining transfers"), subtitle)
     }
@@ -332,7 +358,9 @@ class MigrationProgressVMTest {
                 transfer(index = 1, id = 2).copy(scheduledAt = now + 25.minutes),
             )
         val snapshot = LiveMigrationSnapshot(transfers = transfers, preparations = emptyList(), tipHeight = 1_000L)
-        val subtitle = migrationProgressSubtitle(snapshot, now)
+        // fineGrained pinned explicitly (MOB-1669 test-flakiness follow-up, 2026-08-09) — see the
+        // "not started" test above for why.
+        val subtitle = migrationProgressSubtitle(snapshot, now, fineGrained = true)
         assertTrue(subtitle.contains("~25 min remaining"), subtitle)
         assertFalse(subtitle.contains("over ~"), subtitle)
     }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledVMTest.kt
@@ -152,7 +152,9 @@ class MigrationScheduledVMTest {
 
             assertFalse(vm.isFinalizing.value)
             coVerify(exactly = 1) { sdk.storeSignedSchedulePczts(any()) }
-            coVerify(exactly = 1) { finalize(any(), any()) }
+            // MOB-1669: the post-Keystone-scan path opts out of eagerly starting the live driver
+            // here — see FinalizeMigrationScheduleUseCase's doc for why.
+            coVerify(exactly = 1) { finalize(any(), any(), startLiveDriverImmediately = false) }
             assertNull(pendingSchedule.get(testAccountKeyId))
             assertNull(pendingPczts.get(testAccountKeyId))
         }

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -1099,9 +1099,9 @@
     <string name="migrationTorFailure_riskBody">Sin Tor, tu dirección IP queda expuesta al servidor y podría vincularse con los montos de la migración.</string>
 
     <string name="migrationSetup_title">Mover a Ironwood</string>
-    <string name="migrationSetup_bodyPrefix">La última actualización de la red Zcash requiere mover tu </string>
-    <string name="migrationSetup_bodyFiatSuffix"> (%1$s)</string>
-    <string name="migrationSetup_bodySuffix"> del pool de Orchard al nuevo pool de Ironwood. Tus fondos están seguros.</string>
+    <string name="migrationSetup_bodyPrefix">"La última actualización de la red Zcash requiere mover tu "</string>
+    <string name="migrationSetup_bodyFiatSuffix">" (%1$s)"</string>
+    <string name="migrationSetup_bodySuffix">" del pool de Orchard al nuevo pool de Ironwood. Tus fondos están seguros."</string>
     <string name="migrationSetup_findOutMore">Más información</string>
     <string name="migrationSetup_immediateWarning">Todos los fondos transferidos en esta transacción se revelarán en la cadena de bloques.</string>
     <string name="migrationSetup_automaticWarning">El monto de cada transferencia individual entre pools se revela en la cadena de bloques.</string>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -1380,9 +1380,9 @@ Your vote can no longer be submitted.</string>
     <string name="migrationTorFailure_riskBody">Without Tor, your IP address is exposed to the server and could be linked to the migration amounts.</string>
 
     <string name="migrationSetup_title">Move to Ironwood</string>
-    <string name="migrationSetup_bodyPrefix">Latest Zcash network upgrade requires moving your </string>
-    <string name="migrationSetup_bodyFiatSuffix"> (%1$s)</string>
-    <string name="migrationSetup_bodySuffix"> from the Orchard pool to the new Ironwood pool. Your funds are safe.</string>
+    <string name="migrationSetup_bodyPrefix">"Latest Zcash network upgrade requires moving your "</string>
+    <string name="migrationSetup_bodyFiatSuffix">" (%1$s)"</string>
+    <string name="migrationSetup_bodySuffix">" from the Orchard pool to the new Ironwood pool. Your funds are safe."</string>
     <string name="migrationSetup_findOutMore">Find out more</string>
     <string name="migrationSetup_immediateWarning">All funds transferred in this transaction will be revealed on-chain.</string>
     <string name="migrationSetup_automaticWarning">The amount of an individual transfer across pools is revealed on-chain.</string>

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/signkeystonetransaction/SignKeystoneTransactionView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/signkeystonetransaction/SignKeystoneTransactionView.kt
@@ -2,6 +2,7 @@ package co.electriccoin.zcash.ui.screen.signkeystonetransaction
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,9 +14,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,6 +37,7 @@ import co.electriccoin.zcash.ui.design.component.ZashiBadgeDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiButton
 import co.electriccoin.zcash.ui.design.component.ZashiButtonDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiQr
+import co.electriccoin.zcash.ui.design.component.ZashiQrDefaults
 import co.electriccoin.zcash.ui.design.component.ZashiSmallTopAppBar
 import co.electriccoin.zcash.ui.design.component.ZashiTopAppBarBackNavigation
 import co.electriccoin.zcash.ui.design.component.listitem.BaseListItem
@@ -155,7 +159,7 @@ private fun ZashiAccountInfoListItem(
 
 @Composable
 private fun ColumnScope.QrContent(ksState: SignKeystoneTransactionState) {
-    ksState.qrData?.let {
+    if (ksState.qrData != null) {
         ZashiQr(
             state = ksState.toQrState(),
             modifier = Modifier.align(CenterHorizontally),
@@ -165,6 +169,18 @@ private fun ColumnScope.QrContent(ksState: SignKeystoneTransactionState) {
                     foreground = Color.Black
                 )
         )
+    } else {
+        // Encoding the transaction/batch into its first animated-QR part (createKeystoneProposalPCZTEncoder,
+        // called from init{}) can take a while for a large proposal, with no progress feedback across
+        // that boundary — previously this left the screen looking broken (title/buttons rendered,
+        // QR area silently blank) until it suddenly appeared. Same size as the QR itself so nothing
+        // shifts once qrData arrives.
+        Box(
+            modifier = Modifier.align(CenterHorizontally).size(ZashiQrDefaults.width),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(color = ZashiColors.Text.textPrimary)
+        }
     }
     LaunchedEffect(ksState.qrData) {
         if (ksState.qrData != null) {


### PR DESCRIPTION
## Summary
- Skip eagerly starting `MigrationLiveDriver` synchronously right after `finalizeMigrationSchedule` commits a plan — matches iOS, which never eagerly proves/drives after storing a signed batch (verified live: this was blocking a `finalizeReadyTransfers` call for 36.6s on a physical device). The already-armed `MigrationScheduler` job still drives the plan forward; proving is deferred, not skipped.
- Fix 7 `feature-migration` unit tests that were silently coupled to which Gradle flavor variant compiled them (`isTestnetBuildFlavor()`'s ambient `BuildConfig.FLAVOR` default resolved differently under `testZcashmainnetStoreDebugUnitTest` vs `testZcashtestnetStoreDebugUnitTest`) — pinned `fineGrained` explicitly at the affected call sites instead of relying on the ambient default.
- Fix a Compose layout bug in the "Prepare Your Balance" detail sheet where a long dependency list ("Waits on steps 1, 2, ..., 14") had no width bound, squeezing the weighted title column down to one character per line.
- Add a loading spinner to the Keystone Sign Transaction screen's QR area — it previously rendered nothing at all while the first animated-QR part was being built, making the screen look broken during any non-instant QR generation.
- Fix an Android string-resource whitespace bug: `migrationSetup_bodyPrefix`/`_bodyFiatSuffix`/`_bodySuffix` each needed a leading/trailing space to join correctly, but Android's string-resource compiler silently trims un-quoted `<string>` whitespace — quoted all three (en + es) to preserve it. Live symptom: `"your0.22786965 ZEC($119.72)from the Orchard pool..."`.
- Minor: add a spacer between the migration-setup body text and the "Find out more" link.

## Scope note
This is app-only. The *original* MOB-1669 root cause — "Android took 3.5 minutes to generate 3 batched QRs" during Keystone signing — turned out to live in the SDK's Rust migration engine (a spendable-note DB query re-run on every call instead of cached once per JNI invocation), not in this app-side path. That fix is a separate, unpushed SDK commit (`bugfix/MOB-1669` on `zcash-android-wallet-sdk`) and will need its own SDK release before the app can pick up the underlying speedup. The eager-live-driver-start fix in this PR is a real, independently-confirmed bug (not the one Harry originally reported), kept because it's a genuine improvement matching iOS's architecture.

## Test plan
- [x] `./gradlew :feature-migration:testZcashmainnetStoreDebugUnitTest :feature-migration:testZcashtestnetStoreDebugUnitTest :ui-lib:testZcashmainnetStoreDebugUnitTest` — all green
- [x] `detektAll`, `ktlint` — clean
- [x] Live-verified on a physical Pixel (mainnet internal debug): eager-driver-start stall eliminated, QR spinner renders correctly, prep-details sheet layout fixed, setup-screen text spacing fixed