### PR TITLE
[MOB-1677] Failure-sheet dismiss no longer discards signed Keystone rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed:
+
+- Closing the error sheet during Keystone migration signing no longer discards already-signed rounds.
+
 ## [3.9.1 (2361)] - 2026-08-08
 
 ### Fixed:

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
@@ -183,10 +183,7 @@ class MigrationKeystoneSignVM(
                             failureSheet.value = null
                             buildBatch()
                         },
-                        onDismiss = {
-                            failureSheet.value = null
-                            onReject()
-                        },
+                        onDismiss = { failureSheet.value = null },
                     )
                 }
             }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVMTest.kt
@@ -321,33 +321,46 @@ class MigrationKeystoneSignVMTest {
         }
 
     @Test
-    fun failureSheetDismissNavigatesBack() =
+    fun failureSheetDismissOnlyHidesSheet() =
         runTest {
+            val existingPczts =
+                PendingKeystoneMigrationPczts(
+                    requestId = byteArrayOf(0x01),
+                    splitUnsignedPczt = null,
+                    transferUnsignedPczts = listOf(1L to byteArrayOf(0x02)),
+                    roundIndex = 0,
+                    accumulatedSplitSigned = null,
+                    accumulatedPrepSigned = emptyList(),
+                    accumulatedTransferSigned = listOf(1L to byteArrayOf(0x03)),
+                )
             val sdk =
                 mockk<OrchardMigrationSdk>(relaxed = true) {
                     coEvery { keystoneSigningRoundBudget() } returns
                         cash.z.ecc.android.sdk
                             .KeystoneSigningRoundBudget(96, 16, 3)
-                    coEvery { isNoteSplitNeeded() } returns false
-                    coEvery { createUnsignedTransferPczts(any()) } throws RuntimeException("SDK error")
+                    coEvery { buildKeystoneSignBatchQrParts(any(), any(), any(), any()) } throws
+                        RuntimeException("SDK error")
                 }
             val pendingSchedule =
                 PendingMigrationScheduleRepositoryImpl()
                     .apply { set(testAccountKeyId, schedule()) }
-            val pendingPczts = PendingKeystoneMigrationPcztsRepositoryImpl()
+            val pendingPczts =
+                PendingKeystoneMigrationPcztsRepositoryImpl()
+                    .apply { set(testAccountKeyId, existingPczts) }
             val router = FakeNavigationRouter()
             val vm = vm(sdk, pendingSchedule, pendingPczts, router)
 
             advanceUntilIdle()
 
             assertNotNull(vm.failureSheet.value)
-            // onDismiss must call onReject → back() + clear repos.
             vm.failureSheet.value!!
                 .onDismiss
                 .invoke()
 
-            assertEquals(1, router.backCount)
             assertNull(vm.failureSheet.value)
+            assertEquals(0, router.backCount)
+            assertNotNull(pendingSchedule.peek(testAccountKeyId))
+            assertNotNull(pendingPczts.get(testAccountKeyId))
         }
 
     @Test


### PR DESCRIPTION
Closes [MOB-1677](https://linear.app/zodl/issue/MOB-1677/dismissing-the-failure-sheet-aborts-the-whole-signing-batch) (parent: [MOB-1676](https://linear.app/zodl/issue/MOB-1676/keystone-multi-round-signing-signed-rounds-are-easily-lost-and-not)).

On the Keystone migration Sign screen, the failure bottom sheet's `onDismiss` was wired to `onReject()`, and `ZashiModalBottomSheet` routes every close gesture (scrim tap, swipe-down, back-with-sheet-open, Dismiss button) through `onDismissRequest`. Closing the error sheet therefore cleared `pendingSchedule` + `pendingKeystonePczts` — destroying every accumulated signature from all completed signing rounds (held in memory only) — and navigated away. A user mid-way through a multi-round session who tapped outside a transient error sheet lost everything and restarted from round 0.

## Fix
- `MigrationKeystoneSignVM`: the failure sheet's `onDismiss` now only hides the sheet. `onRetry` and `onReject()` are unchanged — Reject / screen back remains the intentional abort path.
- `MigrationKeystoneSignVMTest`: the characterization test `failureSheetDismissNavigatesBack` is rewritten as `failureSheetDismissOnlyHidesSheet` — dismiss hides the sheet, performs no navigation, and leaves both pending repositories intact (seeded with a prior round's accumulated signatures to prove survival).
- Changelog entry added.

The shared `MigrationFailureBottomSheet` component is untouched (Progress/Sending/NoteSplit rely on it).

## Testing
- `MigrationKeystoneSignVMTest`: 17/17 green.
- Full `:feature-migration:testZcashmainnetStoreDebugUnitTest`: the only failures (`MigrationPreparationDetailsTest`, `MigrationProgressVMTest` — duration-estimate formatting) are pre-existing on pristine `maint/v3.9.x` (verified by stashing this change and rerunning) and unrelated.

Base is `maint/v3.9.x` (newly cut from `release/v3.9.1`); forward-port to the dev line follows after merge per the maintenance-branch model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)