### PR TITLE
Drop the removed WalletCoordinator.isSlipstreamEnabled argument

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -123,7 +123,7 @@ SDK_INCLUDED_BUILD_PATH=
 # you, defeating the point of a pin — and must be reachable from something more durable than
 # the SDK's own PR branch (which stops being fetchable once that branch is deleted): repoint
 # to the merged sha on origin/main once the companion SDK PR lands.
-SDK_COMMIT_PIN=e177a8811837baf0e9d276a79afd75009e53b4c9
+SDK_COMMIT_PIN=d6c1e8ef432781bd748aa916730cf3cc3a6bfe44
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/ui-lib/src/main/java/co/electriccoin/zcash/global/WalletCoordinatorFactory.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/global/WalletCoordinatorFactory.kt
@@ -25,7 +25,6 @@ internal operator fun WalletCoordinator.Companion.invoke(
         isTorEnabled = isTorEnabledStorageProvider.observe(),
         isExchangeRateEnabled = isExchangeRateEnabledStorageProvider.observe(),
         isSyncBlocked = isSyncBlocked(context, persistableWalletProvider),
-        isSlipstreamEnabled = true,
     )
 
 /**


### PR DESCRIPTION
Companion to SDK PR [zcash/zcash-android-wallet-sdk#2168 — Extract Slipstream into its own gated module, :slipstream-lib](https://github.com/zcash/zcash-android-wallet-sdk/pull/2168), merged into SDK `main` as commit [`d6c1e8ef`](https://github.com/zcash/zcash-android-wallet-sdk/commit/d6c1e8ef432781bd748aa916730cf3cc3a6bfe44).

The SDK removes `WalletCoordinator.isSlipstreamEnabled` — engine selection is now decided at SDK build time (module presence), not by a runtime boolean. This PR deletes the one argument the app passed. Nothing else changes: Koin's `singleOf(WalletCoordinator::invoke)` is signature-agnostic, and the app gets the slipstream classes transitively.

## SDK_COMMIT_PIN repoint

This PR also repoints `SDK_COMMIT_PIN` in `gradle.properties` from `e177a881` to `d6c1e8ef` (the merged sha above). CI builds the SDK from source at that exact commit, so the pin bump is what makes the argument drop mandatory rather than optional — a wrong sha or a leftover argument fails the build loudly, not silently. There is no snapshot-based landing order to worry about here: this is a from-source build against the pinned commit, not a Maven snapshot.

**Voting caveat (resolved):** the old draft of this PR carried a heads-up about `VotingCryptoClient` needing an update for the `precomputeDelegationPir` PIR-tier reshape. That's already fixed on `main` by MOB-1678 ([#2406](https://github.com/zodl-inc/zodl-android/pull/2406)), so no further action is needed here.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
