### PR TITLE
[MOB-1447] Remove biometric prompt for new app users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 - Closing the error sheet during Keystone migration signing no longer discards already-signed rounds.
 - Tapping Receive no longer hangs indefinitely when a transient address-derivation error occurs; the app falls back to the account's current address instead.
+- The device authentication prompt no longer appears on app launch before a wallet has been created or restored.
 
 ## [3.9.1 (2361)] - 2026-08-08
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
@@ -112,11 +112,19 @@ class AuthenticationViewModel(
                 }
 
                 (state == AuthenticationUIState.Initial) -> {
-                    if (secretState == SecretState.NONE) {
-                        appAccessAuthentication.value = AuthenticationUIState.NotRequired
-                        AuthenticationUIState.NotRequired
-                    } else {
-                        AuthenticationUIState.Required
+                    when (secretState) {
+                        SecretState.LOADING -> {
+                            AuthenticationUIState.Initial
+                        }
+
+                        SecretState.NONE -> {
+                            appAccessAuthentication.value = AuthenticationUIState.NotRequired
+                            AuthenticationUIState.NotRequired
+                        }
+
+                        SecretState.READY -> {
+                            AuthenticationUIState.Required
+                        }
                     }
                 }
 

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModelTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModelTest.kt
@@ -1,0 +1,209 @@
+package co.electriccoin.zcash.ui.common.viewmodel
+
+import android.app.Application
+import androidx.biometric.BiometricManager
+import co.electriccoin.zcash.preference.StandardPreferenceProvider
+import co.electriccoin.zcash.preference.api.PreferenceProvider
+import co.electriccoin.zcash.preference.model.entry.PreferenceKey
+import co.electriccoin.zcash.spackle.AndroidApiVersion
+import co.electriccoin.zcash.ui.common.provider.GetVersionInfoProvider
+import co.electriccoin.zcash.ui.fixture.VersionInfoFixture
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression coverage for MOB-1447: opening the app before any wallet has been created or
+ * restored must never surface the app-access authentication prompt.
+ *
+ * [WalletViewModel.secretState] starts at [SecretState.LOADING] and only resolves to
+ * [SecretState.NONE] or [SecretState.READY] once preferences and configuration finish loading.
+ * [AuthenticationViewModel.appAccessAuthenticationResultState] must defer to
+ * [AuthenticationUIState.Initial] while that resolution is pending, instead of racing ahead to
+ * [AuthenticationUIState.Required] and triggering a biometric prompt that a moment later turns
+ * out to have been unnecessary.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthenticationViewModelTest {
+    private val application = mockk<Application>(relaxed = true)
+    private val biometricManager = mockk<BiometricManager>()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        mockkObject(AndroidApiVersion)
+        every { AndroidApiVersion.isExactlyO } returns false
+        every { AndroidApiVersion.isAtLeastR } returns true
+        every { AndroidApiVersion.isExactlyP } returns false
+        every { AndroidApiVersion.isExactlyQ } returns false
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun loadingSecretStateStaysInitial() =
+        runTest {
+            val (viewModel, _) = newViewModel(secretState = SecretState.LOADING)
+
+            val states = mutableListOf<AuthenticationUIState>()
+            backgroundScope.launch { viewModel.appAccessAuthenticationResultState.collect { states += it } }
+            advanceUntilIdle()
+
+            assertEquals(listOf<AuthenticationUIState>(AuthenticationUIState.Initial), states)
+        }
+
+    @Test
+    fun loadingThenNoneBecomesNotRequired() =
+        runTest {
+            val (viewModel, secretState) = newViewModel(secretState = SecretState.LOADING)
+
+            backgroundScope.launch { viewModel.appAccessAuthenticationResultState.collect { } }
+            advanceUntilIdle()
+
+            secretState.value = SecretState.NONE
+            advanceUntilIdle()
+
+            assertEquals(AuthenticationUIState.NotRequired, viewModel.appAccessAuthenticationResultState.value)
+        }
+
+    @Test
+    fun loadingThenReadyBecomesRequired() =
+        runTest {
+            val (viewModel, secretState) = newViewModel(secretState = SecretState.LOADING)
+
+            backgroundScope.launch { viewModel.appAccessAuthenticationResultState.collect { } }
+            advanceUntilIdle()
+
+            secretState.value = SecretState.READY
+            advanceUntilIdle()
+
+            assertEquals(AuthenticationUIState.Required, viewModel.appAccessAuthenticationResultState.value)
+        }
+
+    @Test
+    fun notRequiredSurvivesLaterWalletCreationInTheSameSession() =
+        runTest {
+            val (viewModel, secretState) = newViewModel(secretState = SecretState.NONE)
+
+            backgroundScope.launch { viewModel.appAccessAuthenticationResultState.collect { } }
+            advanceUntilIdle()
+            assertEquals(AuthenticationUIState.NotRequired, viewModel.appAccessAuthenticationResultState.value)
+
+            secretState.value = SecretState.READY
+            advanceUntilIdle()
+
+            assertEquals(AuthenticationUIState.NotRequired, viewModel.appAccessAuthenticationResultState.value)
+        }
+
+    @Test
+    fun disabledAuthenticationPreferenceSkipsPromptEvenWhenReady() =
+        runTest {
+            val (viewModel, _) =
+                newViewModel(secretState = SecretState.READY, isAppAccessAuthenticationPreference = "false")
+
+            backgroundScope.launch { viewModel.appAccessAuthenticationResultState.collect { } }
+            advanceUntilIdle()
+
+            assertEquals(AuthenticationUIState.NotRequired, viewModel.appAccessAuthenticationResultState.value)
+        }
+
+    @Test
+    fun runningUnderTestServiceSkipsPromptEvenWhenReady() =
+        runTest {
+            val (viewModel, _) =
+                newViewModel(secretState = SecretState.READY, isRunningUnderTestService = true)
+
+            backgroundScope.launch { viewModel.appAccessAuthenticationResultState.collect { } }
+            advanceUntilIdle()
+
+            assertEquals(AuthenticationUIState.NotRequired, viewModel.appAccessAuthenticationResultState.value)
+        }
+
+    private fun newViewModel(
+        secretState: SecretState,
+        isAppAccessAuthenticationPreference: String? = null,
+        isRunningUnderTestService: Boolean = false
+    ): Pair<AuthenticationViewModel, MutableStateFlow<SecretState>> {
+        val secretStateFlow = MutableStateFlow(secretState)
+        val walletViewModel = mockk<WalletViewModel>()
+        every { walletViewModel.secretState } returns secretStateFlow
+
+        val standardPreferenceProvider = mockk<StandardPreferenceProvider>()
+        coEvery { standardPreferenceProvider() } returns FakePreferenceProvider(isAppAccessAuthenticationPreference)
+
+        val getVersionInfo = mockk<GetVersionInfoProvider>()
+        every { getVersionInfo() } returns
+            VersionInfoFixture.new(isRunningUnderTestService = isRunningUnderTestService)
+
+        val viewModel =
+            AuthenticationViewModel(
+                application = application,
+                biometricManager = biometricManager,
+                getVersionInfo = getVersionInfo,
+                standardPreferenceProvider = standardPreferenceProvider,
+                walletViewModel = walletViewModel
+            )
+
+        return viewModel to secretStateFlow
+    }
+}
+
+/**
+ * A hand-written [PreferenceProvider] stand-in, not a MockK proxy: [PreferenceProvider]'s methods
+ * take the [PreferenceKey] value class, and MockK's reflection-based call recorder throws on that
+ * combination for suspend members (`getString`). [getString] returns [stringValue] for every key;
+ * [observe] never emits more than the one initial `null` needed to trigger the first read.
+ */
+private class FakePreferenceProvider(
+    private val stringValue: String?
+) : PreferenceProvider {
+    override suspend fun hasKey(key: PreferenceKey) = false
+
+    override suspend fun putString(
+        key: PreferenceKey,
+        value: String?
+    ) = Unit
+
+    override suspend fun putStringSet(
+        key: PreferenceKey,
+        value: Set<String>?
+    ) = Unit
+
+    override suspend fun putLong(
+        key: PreferenceKey,
+        value: Long?
+    ) = Unit
+
+    override suspend fun getLong(key: PreferenceKey): Long? = null
+
+    override suspend fun getString(key: PreferenceKey): String? = stringValue
+
+    override suspend fun getStringSet(key: PreferenceKey): Set<String>? = null
+
+    override fun observe(key: PreferenceKey): Flow<String?> = flowOf(null)
+
+    override suspend fun remove(key: PreferenceKey) = Unit
+
+    override suspend fun clearPreferences(): Boolean = true
+}


### PR DESCRIPTION
Fixes [MOB-1447](https://linear.app/zodl/issue/MOB-1447/remove-biometric-for-new-app-users): on a fresh install (no wallet created or restored yet), the app showed the app-access biometric/device-credential prompt at launch even though there is nothing to protect. iOS/macOS already skip it.

## Root cause

`AuthenticationViewModel.appAccessAuthenticationResultState` already skips authentication for `SecretState.NONE`, but `secretState` starts at `LOADING` on every launch and only resolves after configuration and preferences load. `LOADING` fell into the `else -> Required` branch, so the first emission fired the `BiometricPrompt` immediately — and by the time the state resolved to `NONE`, the system prompt was already on screen (nothing cancels it). The skip existed; it lost the race.

## Fix

The binary `if (secretState == SecretState.NONE)` is now an exhaustive `when`:
- `LOADING` → stays `Initial` (defers the decision; the splash screen covers this window, so wallet holders see no difference)
- `NONE` → `NotRequired` (unchanged; the persisted `NotRequired` write is kept deliberately — it prevents a lock-out right after creating/restoring a wallet in the same session)
- `READY` → `Required` (unchanged re-lock behavior, including the 15-minute background timeout)

Added `AuthenticationViewModelTest` (first unit coverage for this ViewModel) with six cases, including the regression case (`LOADING` never emits `Required`) and the in-session wallet-creation case.

Known debt left out of scope: the state write inside the `combine` transform (flow-conventions smell) and the fact that an already-shown prompt is never cancelled — moot now that it cannot fire prematurely.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)