### PR TITLE
ci: repoint SDK_COMMIT_PIN to SDK main HEAD

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -123,7 +123,7 @@ SDK_INCLUDED_BUILD_PATH=
 # you, defeating the point of a pin — and must be reachable from something more durable than
 # the SDK's own PR branch (which stops being fetchable once that branch is deleted): repoint
 # to the merged sha on origin/main once the companion SDK PR lands.
-SDK_COMMIT_PIN=e177a8811837baf0e9d276a79afd75009e53b4c9
+SDK_COMMIT_PIN=ab41542ad3dbd0d43181f430a0dcd373a4f3dc84
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=


### PR DESCRIPTION
## Summary

`gradle.properties`'s `SDK_COMMIT_PIN` on `main` was pointing at
`e177a8811837baf0e9d276a79afd75009e53b4c9` — the tip of a co-developed
`zcash-android-wallet-sdk` PR branch for MOB-1678. That SDK PR has since
merged, so per the property's own doc comment ("repoint to the merged sha
on origin/main once the companion SDK PR lands"), this repoints the pin to
`zcash-android-wallet-sdk`'s current `main` HEAD instead, since the old
branch tip stops being fetchable once that branch is deleted.

Verified the target sha immediately before this PR via:

```
git ls-remote https://github.com/zcash/zcash-android-wallet-sdk.git refs/heads/main
ab41542ad3dbd0d43181f430a0dcd373a4f3dc84
```

New value: `SDK_COMMIT_PIN=ab41542ad3dbd0d43181f430a0dcd373a4f3dc84`

Single-line change in `gradle.properties`, comment block left as-is.

## ⚠️ Safety note — releases stay blocked from `main`

This repoint does **not** clear the pin. While `SDK_COMMIT_PIN` is
non-blank on `main`, `.github/workflows/{deploy.yml,release.yaml,create-release.yml}`
all have a "Refuse to deploy with a live `SDK_COMMIT_PIN`" gate that
hard-fails any release/deploy attempt from `main`. After this merges,
`main` builds are still pinned to a specific (now newer, but still
unreleased) SDK commit — release/deploy from `main` remains blocked
until someone clears `SDK_COMMIT_PIN=` back to blank.

## Open question for reviewer

Now that the companion SDK PR (MOB-1678) has landed on
`zcash-android-wallet-sdk`'s `main`, should `SDK_COMMIT_PIN` instead be
**cleared to blank** in this PR, rather than repointed to a new commit?
Clearing it would restore the normal published-Maven-SDK build path and
lift the release-gate block on `main`. Repointing (as done here) keeps
CI building against unreleased SDK `main` for anyone who still needs
that. Not deciding this myself — flagging it here for the reviewer to
weigh in on.

## Test plan

- [ ] CI PR checks pass building against the live companion-SDK-build
      path (this PR targets `main` with a non-blank pin, so it will
      actually check out the SDK at the pinned commit, install Rust/NDK,
      and build against it — expect a longer run than a normal PR check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)