### PR TITLE
MOB-1620: Migration UI nits + Migration Complete threshold/duration fixes

### DIFF
--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
@@ -13,7 +13,7 @@ import co.electriccoin.zcash.ui.common.model.LceState
 import co.electriccoin.zcash.ui.common.model.SubmitResult
 import co.electriccoin.zcash.ui.common.model.groupLce
 import co.electriccoin.zcash.ui.common.model.guardLoading
-import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_DUST_THRESHOLD_ZATOSHI
+import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_RESIDUAL_MIN_ZATOSHI
 import co.electriccoin.zcash.ui.common.model.migration.MigrationTransferFailureState
 import co.electriccoin.zcash.ui.common.model.migration.formatMigrationDuration
 import co.electriccoin.zcash.ui.common.model.mutableLce
@@ -200,24 +200,28 @@ class MigrationCompleteVM(
         viewModelScope.launch {
             try {
                 // Keystone-only auto-continuation (hot-wallet multi-run is deferred): if residual
-                // Orchard balance is still above the real dust threshold (not just non-zero — a
-                // multi-round campaign's per-round MigrationState.Complete doesn't distinguish
-                // "genuinely done" from "this round's transfers are mined, more residual needs
-                // another round"), clear the plan instead of marking "seen" — GetHomeMessageUseCase's
-                // migrationMessageFor() then naturally re-evaluates to REQUIRED (plan == null) even
-                // though the SDK's own MigrationState is still Complete (it only advances once the
-                // next round is actually committed).
+                // Orchard balance is still at or above the engine's real migratable minimum (not
+                // just non-zero — a multi-round campaign's per-round MigrationState.Complete doesn't
+                // distinguish "genuinely done" from "this round's transfers are mined, more residual
+                // needs another round"), clear the plan instead of marking "seen" —
+                // GetHomeMessageUseCase's migrationMessageFor() then naturally re-evaluates to
+                // REQUIRED (plan == null) even though the SDK's own MigrationState is still Complete
+                // (it only advances once the next round is actually committed).
+                // MIGRATION_RESIDUAL_MIN_ZATOSHI (not the smaller MIGRATION_DUST_THRESHOLD_ZATOSHI)
+                // is the correct gate here: it's the same constant migrationMessageFor() uses to
+                // decide "Migrate now" vs. the residue/lock flow. A residual between the two
+                // thresholds is un-migratable (proposeMigrationTransfers returns NothingToMigrate),
+                // so gating on the smaller dust threshold used to make this flag true for a residual
+                // the engine could never actually turn into another round — leaving the completion
+                // screen unmarked "seen" while the home banner had already moved on to the residue
+                // flow for the same balance.
                 // Guarded (2026-08-07 Fable review): this sat in a try/finally with no catch — the
-                // finally block (navigate back) would still run on a "database is locked" throw,
-                // but the exception then propagated past it uncaught, crashing the app right after
-                // navigating. Falls back to the same MIGRATION_DUST_THRESHOLD_ZATOSHI constant
-                // migrationMessageFor itself defaults to.
-                val dustThreshold =
-                    runCatching { getOrchardMigrationSdk().migrationDustThresholdZatoshi() }
-                        .getOrDefault(MIGRATION_DUST_THRESHOLD_ZATOSHI)
+                // finally block (navigate back) would still run on an exception partway through this
+                // block, but the exception then propagated past it uncaught, crashing the app right
+                // after navigating.
                 val moreRoundsNeeded =
                     getSelectedWalletAccount() is KeystoneAccount &&
-                        getOrchardBalance().value > dustThreshold
+                        getOrchardBalance().value >= MIGRATION_RESIDUAL_MIN_ZATOSHI
                 // The background chain and any leftover notification are already cancelled in
                 // init{} (as soon as this screen was shown, not deferred until now) — a subsequent
                 // Keystone round re-arms a fresh chain at its own commit either way.

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
@@ -160,7 +160,14 @@ class MigrationCompleteVM(
                     summary.totalCount,
                     summary.totalCount
                 ),
-            duration = stringRes(formatMigrationDuration(summary.lastAt - summary.firstAt)),
+            // The full campaign span between its first and last MINED transfer -- both timestamps
+            // are already on-chain-public, so the pre-broadcast correlation risk the privacy floor
+            // guards against (see formatMigrationDuration's kdoc) doesn't apply here; flooring it
+            // would only inflate an already-short real duration up to a full hour on mainnet.
+            duration =
+                stringRes(
+                    formatMigrationDuration(summary.lastAt - summary.firstAt, applyPrivacyFloor = false)
+                ),
             isMigrating = isMigrating,
             isLocking = isLocking,
             onDone = ::onDone,

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
@@ -18,6 +18,7 @@ import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_DUST_THRESHOLD_ZATOSHI
 import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_RESIDUAL_MIN_ZATOSHI
+import co.electriccoin.zcash.ui.common.model.migration.formatMigrationDuration
 import co.electriccoin.zcash.ui.common.provider.HasLockedOrchardDustStorageProvider
 import co.electriccoin.zcash.ui.common.provider.HasSeenMigrationCompleteStorageProvider
 import co.electriccoin.zcash.ui.common.provider.MigrationNotifier
@@ -28,16 +29,20 @@ import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
 import co.electriccoin.zcash.ui.common.usecase.migrationMessageFor
+import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.migration.success.MigrationSuccessArgs
 import co.electriccoin.zcash.ui.screen.signkeystonetransaction.SignKeystoneTransactionArgs
 import co.electriccoin.zcash.work.MigrationScheduler
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -339,6 +344,47 @@ class MigrationCompleteVMTest {
             coVerify(exactly = 1) { sdk.getMigrationSummary() }
         }
 
+    @Test
+    fun durationDoesNotApplyThePrivacyFloorSinceBothTimestampsAreAlreadyMined() =
+        runTest {
+            // The displayed duration spans the campaign's first to last MINED transfer -- both
+            // already public on-chain, so formatMigrationDuration's default pre-broadcast privacy
+            // floor must not apply here (applyPrivacyFloor = false), or a short real span would be
+            // inflated up to the floor (10 min testnet / 1 hour mainnet) instead of showing its
+            // actual duration.
+            val firstAt = 1_785_281_502L
+            val spanSeconds = 120L // well under either privacy floor
+            val summary =
+                MigrationSummary(
+                    totalMigratedZatoshi = 500_000L,
+                    transferCount = 2,
+                    firstMinedEpochSeconds = firstAt,
+                    lastMinedEpochSeconds = firstAt + spanSeconds,
+                )
+            val sdk =
+                mockk<OrchardMigrationSdk> {
+                    coEvery { getMigrationSummary() } returns summary
+                }
+            val vm =
+                vm(
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = 500_000L,
+                    router = FakeNavigationRouter(),
+                    getOrchardMigrationSdk = mockk { coEvery { this@mockk() } returns sdk },
+                )
+
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            val expected = stringRes(formatMigrationDuration(spanSeconds, applyPrivacyFloor = false))
+            assertEquals(
+                expected,
+                vm.state.value.content
+                    ?.duration
+            )
+            collectJob.cancel()
+        }
+
     private fun invokeOnDone(vm: MigrationCompleteVM) {
         val onDone = MigrationCompleteVM::class.java.getDeclaredMethod("onDone")
         onDone.isAccessible = true
@@ -373,7 +419,13 @@ class MigrationCompleteVMTest {
                 coEvery { this@mockk() } returns Zatoshi(orchardBalanceZatoshi)
             },
         hasSeenMigrationCompleteStorageProvider = seen,
-        hasLockedOrchardDustStorageProvider = mockk<HasLockedOrchardDustStorageProvider>(relaxed = true),
+        hasLockedOrchardDustStorageProvider =
+            mockk<HasLockedOrchardDustStorageProvider>(relaxed = true) {
+                // A relaxed mock's default Flow return is empty (never emits), which would starve
+                // state's combine() forever -- it only emits once every source has emitted at least
+                // once. Tests that read vm.state.value.content need this to actually fire.
+                every { observe() } returns flowOf(false)
+            },
         getSelectedWalletAccount =
             mockk<GetSelectedWalletAccountUseCase> {
                 coEvery { this@mockk() } returns account

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
@@ -1,6 +1,7 @@
 package co.electriccoin.zcash.ui.screen.migration.complete
 
 import androidx.navigation.NavBackStackEntry
+import cash.z.ecc.android.sdk.MigrationState
 import cash.z.ecc.android.sdk.MigrationSummary
 import cash.z.ecc.android.sdk.OrchardMigrationSdk
 import cash.z.ecc.android.sdk.model.Proposal
@@ -16,6 +17,7 @@ import co.electriccoin.zcash.ui.common.model.SubmitResult
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_DUST_THRESHOLD_ZATOSHI
+import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_RESIDUAL_MIN_ZATOSHI
 import co.electriccoin.zcash.ui.common.provider.HasLockedOrchardDustStorageProvider
 import co.electriccoin.zcash.ui.common.provider.HasSeenMigrationCompleteStorageProvider
 import co.electriccoin.zcash.ui.common.provider.MigrationNotifier
@@ -25,6 +27,7 @@ import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
+import co.electriccoin.zcash.ui.common.usecase.migrationMessageFor
 import co.electriccoin.zcash.ui.screen.migration.success.MigrationSuccessArgs
 import co.electriccoin.zcash.ui.screen.signkeystonetransaction.SignKeystoneTransactionArgs
 import co.electriccoin.zcash.work.MigrationScheduler
@@ -59,19 +62,44 @@ class MigrationCompleteVMTest {
     }
 
     @Test
-    fun keystoneAccountWithResidualBalanceClearsPlanInsteadOfMarkingSeen() =
+    fun keystoneAccountWithMigratableResidualBalanceClearsPlanInsteadOfMarkingSeen() =
         runTest {
+            // A residual at or above MIGRATION_RESIDUAL_MIN_ZATOSHI is genuinely migratable -- the
+            // engine can propose another round for it, so onDone() must clear the plan (not mark
+            // seen) and let the home banner re-offer that round.
             val seen = mockk<HasSeenMigrationCompleteStorageProvider>(relaxed = true)
             val router = FakeNavigationRouter()
             val vm =
                 vm(
                     seen = seen,
                     account = mockk<KeystoneAccount>(relaxed = true),
-                    orchardBalanceZatoshi = 500_000L,
+                    orchardBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI + 500_000L,
                     router = router,
                 )
 
             vm.state.value // force lazy init to run (StateFlow combine below reads loadLce)
+            advanceUntilIdle()
+            invokeOnDone(vm)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { seen.store(true) }
+            assertEquals(1, router.backToRootCount)
+        }
+
+    @Test
+    fun keystoneAccountWithResidualExactlyAtResidualMinClearsPlanInsteadOfMarkingSeen() =
+        runTest {
+            // Boundary check: exactly-at-residual-min is still migratable (comparison is `>=`).
+            val seen = mockk<HasSeenMigrationCompleteStorageProvider>(relaxed = true)
+            val router = FakeNavigationRouter()
+            val vm =
+                vm(
+                    seen = seen,
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI,
+                    router = router,
+                )
+
             advanceUntilIdle()
             invokeOnDone(vm)
             advanceUntilIdle()
@@ -168,6 +196,50 @@ class MigrationCompleteVMTest {
 
             coVerify(exactly = 1) { seen.store(true) }
             assertEquals(1, router.backToRootCount)
+        }
+
+    @Test
+    fun onDoneAgreesWithHomeBannerForResidualInTheDustToResidualMinGap() =
+        runTest {
+            // Regression guard for the threshold discrepancy this test used to reproduce: onDone()'s
+            // `moreRoundsNeeded` check used to compare the residual only against
+            // MIGRATION_DUST_THRESHOLD_ZATOSHI (0.001 ZEC) instead of MIGRATION_RESIDUAL_MIN_ZATOSHI
+            // (0.01 ZEC) -- the actual engine minimum below which proposeMigrationTransfers() returns
+            // NothingToMigrate. For a balance in the gap between the two (e.g. the live-observed
+            // 0.005 ZEC / 500_000L zatoshi used by GetHomeMessageUseCaseMigrationTest's own
+            // residue-band tests), that made onDone() and the home banner disagree for identical
+            // input: onDone() left "seen complete" unset (expecting another round), while the home
+            // banner correctly routed to the residue/lock flow for a balance the engine can never
+            // actually turn into another round. Both decisions must now agree: this balance marks
+            // the completion seen AND the home banner reports it complete.
+            val residualInGapZatoshi = 500_000L
+            check(residualInGapZatoshi > MIGRATION_DUST_THRESHOLD_ZATOSHI)
+            check(residualInGapZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI)
+
+            val seen = mockk<HasSeenMigrationCompleteStorageProvider>(relaxed = true)
+            val router = FakeNavigationRouter()
+            val vm =
+                vm(
+                    seen = seen,
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = residualInGapZatoshi,
+                    router = router,
+                )
+
+            advanceUntilIdle()
+            invokeOnDone(vm)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { seen.store(true) }
+
+            val homeMessage =
+                migrationMessageFor(
+                    sdkState = MigrationState.Complete,
+                    snapshot = null,
+                    hasSeenComplete = false,
+                    orchardBalanceZatoshi = residualInGapZatoshi,
+                )
+            assertEquals(true, homeMessage?.isComplete)
         }
 
     @Test
@@ -285,15 +357,9 @@ class MigrationCompleteVMTest {
         account: WalletAccount,
         orchardBalanceZatoshi: Long,
         router: FakeNavigationRouter,
-        // migrationDustThresholdZatoshi() explicitly pinned to the real threshold constant — a
-        // relaxed mock's default would answer 0L instead, breaking the boundary tests below that
-        // set orchardBalanceZatoshi relative to MIGRATION_DUST_THRESHOLD_ZATOSHI.
         getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase =
             mockk {
-                coEvery { this@mockk() } returns
-                    mockk(relaxed = true) {
-                        coEvery { migrationDustThresholdZatoshi() } returns MIGRATION_DUST_THRESHOLD_ZATOSHI
-                    }
+                coEvery { this@mockk() } returns mockk(relaxed = true)
             },
         zashiSpendingKeyDataSource: ZashiSpendingKeyDataSource = mockk(relaxed = true),
         biometricRepository: BiometricRepository = mockk(relaxed = true),

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationDustThreshold.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationDustThreshold.kt
@@ -5,6 +5,10 @@ package co.electriccoin.zcash.ui.common.model.migration
 // `migrationMessageFor`'s defaulted parameter), so those call sites still have *a* real gate
 // instead of a bare `> 0L`/`== MigrationState.Complete` check. Matches the Rust-layer
 // `MIGRATION_DUST_THRESHOLD_ZATOSHI` in `migration.rs` as of this writing.
+//
+// Lives in ui-lib (not feature-migration) so ui-lib-level callers -- e.g.
+// WalletViewModel.shouldShowIronwoodAnnouncement -- can share the same gate feature-migration
+// uses, instead of each module inventing its own threshold.
 const val MIGRATION_DUST_THRESHOLD_ZATOSHI = 100_000L
 
 // The smallest Orchard balance the migration engine will actually migrate. Mirrors librustzcash's

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.SeedPhrase
 import cash.z.ecc.android.sdk.model.ZcashNetwork
+import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_DUST_THRESHOLD_ZATOSHI
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.repository.WalletRepository
 import co.electriccoin.zcash.ui.screen.ironwood.IronwoodActivation
@@ -31,9 +32,16 @@ class WalletViewModel(
 
     /**
      * Emits `true` once — on the first launch that satisfies all Ironwood-announcement conditions:
-     * the wallet has synced past the Ironwood activation height, holds a non-zero spendable Orchard
-     * balance, and the one-time announcement has not been shown yet. Stays `false` while syncing or
-     * while the balance is unknown.
+     * the wallet has synced past the Ironwood activation height, holds a spendable Orchard balance
+     * above the dust threshold, and the one-time announcement has not been shown yet. Stays `false`
+     * while syncing or while the balance is unknown.
+     *
+     * Gated on [MIGRATION_DUST_THRESHOLD_ZATOSHI] rather than a bare `> 0L`, matching the same
+     * dust floor `migrationMessageFor`'s home banner uses (MOB-1620): `isIronwoodAnnouncementShown`
+     * is a local flag that resets on wallet re-import even though on-chain state didn't change, so
+     * a wallet with only dust-level residual Orchard balance (e.g. a previously locked residue)
+     * used to re-trigger this full-screen announcement on every re-import — a bare `> 0L` check
+     * doesn't distinguish that from a genuinely unmigrated balance worth announcing.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     val shouldShowIronwoodAnnouncement: StateFlow<Boolean> =
@@ -53,7 +61,7 @@ class WalletViewModel(
                             scannedHeight != null &&
                             scannedHeight >= activationHeight &&
                             balances != null &&
-                            balances.values.any { it.orchard.available.value > 0L }
+                            balances.values.any { it.orchard.available.value > MIGRATION_DUST_THRESHOLD_ZATOSHI }
                     }
                 }
             }.stateIn(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/WalletHeaderIcons.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/WalletHeaderIcons.kt
@@ -75,7 +75,9 @@ fun WalletHeaderIcons(
             modifier =
                 Modifier
                     .size(48.dp)
-                    .offset(x = 36.dp)
+                    // Figma's "All Icons" row (node 3925:16402) uses gap: -3px between the two
+                    // 48dp circles -- a 3dp overlap, not the 12dp this offset used to produce.
+                    .offset(x = 45.dp)
                     .clip(CircleShape)
                     .background(background)
                     .border(2.dp, ZashiColors.Surfaces.bgPrimary, CircleShape)

--- a/ui-lib/src/main/res/ui/ironwood/values-es/strings.xml
+++ b/ui-lib/src/main/res/ui/ironwood/values-es/strings.xml
@@ -2,9 +2,9 @@
 <resources>
     <string name="ironwood_announcement_title">Zcash Se Actualizó a Ironwood</string>
     <string name="ironwood_announcement_body_1">Ironwood es un nuevo pool protegido: el mismo protocolo que Orchard, ahora verificado formalmente y auditado de forma independiente. Tus fondos están seguros y tus direcciones siguen funcionando.</string>
-    <string name="ironwood_announcement_body_2">Tus fondos en Orchard permanecen ahí hasta que los muevas. Puedes seguir gastándolos, pero el valor que sale de Orchard es público: al gastar se publica un monto en la cadena de bloques, y puede ser mayor que el que envías.</string>
-    <string name="ironwood_announcement_body_3">Una migración más privada llegará en una actualización posterior. Mueve tus fondos en partes de tamaño estándar que no te identifican, por eso recomendamos esperar.</string>
-    <string name="ironwood_announcement_body_guide">Si prefieres no esperar, nuestra guía explica cómo mover los fondos manualmente.</string>
-    <string name="ironwood_announcement_body_guide_link">nuestra guía</string>
+    <string name="ironwood_announcement_body_2">Tus fondos de Orchard siguen siendo tuyos hasta que los muevas. Puedes seguir gastándolos, pero el valor que sale de Orchard es público, así que al gastar se publica un importe en la cadena, y puede ser mayor que el que envías.</string>
+    <string name="ironwood_announcement_body_3">Puedes moverlos ahora. Recomendamos la opción privada: divide tu saldo en transferencias más pequeñas que se envían automáticamente en segundo plano a lo largo del tiempo, para que sea más difícil vincularlas contigo. O muévelo todo de una vez en una sola transferencia.</string>
+    <string name="ironwood_announcement_body_guide">¿No sabes cuál elegir? Nuestra guía explica ambas opciones.</string>
+    <string name="ironwood_announcement_body_guide_link">Nuestra guía</string>
     <string name="ironwood_announcement_primary_button">Ir a Zodl</string>
 </resources>

--- a/ui-lib/src/main/res/ui/ironwood/values/strings.xml
+++ b/ui-lib/src/main/res/ui/ironwood/values/strings.xml
@@ -2,9 +2,9 @@
 <resources>
     <string name="ironwood_announcement_title">Zcash Upgraded to Ironwood</string>
     <string name="ironwood_announcement_body_1">Ironwood is a new shielded pool: the same protocol as Orchard, now formally verified and independently audited. Your funds are safe and your addresses still work.</string>
-    <string name="ironwood_announcement_body_2">Your Orchard funds stay until you move them. You can still spend them, but value leaving Orchard is public, so spending publishes an amount on-chain, and it can be larger than you send.</string>
-    <string name="ironwood_announcement_body_3">A more private migration is coming in a later update. It moves your funds in standard-sized pieces that don\'t identify you, so we recommend waiting.</string>
-    <string name="ironwood_announcement_body_guide">If you\'d rather not wait, our guide explains how to move funds manually.</string>
-    <string name="ironwood_announcement_body_guide_link">our guide</string>
+    <string name="ironwood_announcement_body_2">Your Orchard funds stay yours until you move them. You can still spend them, but value leaving Orchard is public, so spending publishes an amount on-chain, and it can be larger than you send.</string>
+    <string name="ironwood_announcement_body_3">You can move them now. We recommend the private option: it splits your balance into smaller transfers that send automatically in the background over time, so they\'re harder to link to you. Or move everything at once in a single transfer.</string>
+    <string name="ironwood_announcement_body_guide">Not sure which to choose? Our guide explains both options.</string>
+    <string name="ironwood_announcement_body_guide_link">Our guide</string>
     <string name="ironwood_announcement_primary_button">Go to Zodl</string>
 </resources>

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModelTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModelTest.kt
@@ -1,0 +1,99 @@
+package co.electriccoin.zcash.ui.common.viewmodel
+
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.BlockHeight
+import cash.z.ecc.android.sdk.model.WalletBalance
+import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.ZcashNetwork
+import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_DUST_THRESHOLD_ZATOSHI
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.repository.WalletRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WalletViewModelTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val accountUuid = AccountUuid.new(ByteArray(16) { it.toByte() })
+
+    private fun zeroBalance() = WalletBalance(Zatoshi(0), Zatoshi(0), Zatoshi(0), Zatoshi(0))
+
+    private fun balancesWithOrchard(orchardZatoshi: Long): Map<AccountUuid, AccountBalance> =
+        mapOf(
+            accountUuid to
+                AccountBalance(
+                    sapling = zeroBalance(),
+                    orchard = zeroBalance().copy(available = Zatoshi(orchardZatoshi)),
+                    ironwood = zeroBalance(),
+                    unshielded = Zatoshi(0),
+                )
+        )
+
+    // MOB-1620: gated on MIGRATION_DUST_THRESHOLD_ZATOSHI rather than a bare `> 0L`, so a
+    // dust-only residual (e.g. left over after a re-import resets the locally-tracked
+    // isIronwoodAnnouncementShown flag) never re-triggers the full-screen announcement.
+    private fun vm(orchardZatoshi: Long): WalletViewModel {
+        val synchronizer =
+            mockk<Synchronizer> {
+                every { network } returns ZcashNetwork.Mainnet
+                every { fullyScannedHeight } returns MutableStateFlow(BlockHeight.new(3_500_000L))
+            }
+        val synchronizerProvider =
+            mockk<SynchronizerProvider> {
+                every { this@mockk.synchronizer } returns MutableStateFlow(synchronizer)
+                every { walletBalances } returns flowOf(balancesWithOrchard(orchardZatoshi))
+            }
+        val walletRepository =
+            mockk<WalletRepository>(relaxed = true) {
+                every { isIronwoodAnnouncementShown } returns MutableStateFlow(null)
+            }
+        return WalletViewModel(synchronizerProvider, walletRepository)
+    }
+
+    @Test
+    fun dustOnlyOrchardBalanceDoesNotShowAnnouncement() =
+        runTest {
+            val vm = vm(orchardZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI)
+            val collectJob = launch { vm.shouldShowIronwoodAnnouncement.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(false, vm.shouldShowIronwoodAnnouncement.value)
+            collectJob.cancel()
+        }
+
+    @Test
+    fun aboveDustOrchardBalanceShowsAnnouncement() =
+        runTest {
+            val vm = vm(orchardZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L)
+            val collectJob = launch { vm.shouldShowIronwoodAnnouncement.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(true, vm.shouldShowIronwoodAnnouncement.value)
+            collectJob.cancel()
+        }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/ironwood/IronwoodAnnouncementStringsTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/ironwood/IronwoodAnnouncementStringsTest.kt
@@ -1,0 +1,76 @@
+package co.electriccoin.zcash.ui.screen.ironwood
+
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * [IronwoodAnnouncementView] builds the clickable guide link by a case-sensitive
+ * [String.indexOf] lookup of `ironwood_announcement_body_guide_link` inside
+ * `ironwood_announcement_body_guide`. If the two strings drift out of sync in any
+ * locale, the lookup silently fails and the link disappears with no visible error.
+ * This test guards that invariant for every locale's `strings.xml` under the
+ * `ironwood` resource directory that defines both strings.
+ */
+class IronwoodAnnouncementStringsTest {
+    @Test
+    fun guideLinkIsSubstringOfGuideBodyInEveryLocale() {
+        val ironwoodResDir = findIronwoodResDir()
+
+        val localeDirs =
+            ironwoodResDir
+                .listFiles { file -> file.isDirectory && file.name.startsWith("values") }
+                .orEmpty()
+
+        assertTrue(localeDirs.isNotEmpty(), "No values*/ directories found under $ironwoodResDir")
+
+        localeDirs.forEach { localeDir ->
+            val stringsFile = File(localeDir, "strings.xml")
+            if (!stringsFile.exists()) {
+                return@forEach
+            }
+
+            val strings = parseStrings(stringsFile)
+            val guideBody = strings["ironwood_announcement_body_guide"]
+            val guideLink = strings["ironwood_announcement_body_guide_link"]
+
+            if (guideBody != null && guideLink != null) {
+                assertTrue(
+                    guideBody.contains(guideLink),
+                    "In ${localeDir.name}, ironwood_announcement_body_guide_link (\"$guideLink\") is not a " +
+                        "substring of ironwood_announcement_body_guide (\"$guideBody\")"
+                )
+            }
+        }
+    }
+
+    private fun findIronwoodResDir(): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, "src/main/res/ui/ironwood")
+            if (candidate.isDirectory) {
+                return candidate
+            }
+            dir = dir.parentFile
+        }
+        error("Could not locate ui-lib's src/main/res/ui/ironwood directory starting from ${File(".").absoluteFile}")
+    }
+
+    private fun parseStrings(file: File): Map<String, String> {
+        val document =
+            DocumentBuilderFactory
+                .newInstance()
+                .newDocumentBuilder()
+                .parse(file)
+
+        val nodes = document.getElementsByTagName("string")
+        val result = mutableMapOf<String, String>()
+        for (i in 0 until nodes.length) {
+            val element = nodes.item(i) as Element
+            result[element.getAttribute("name")] = element.textContent
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `MigrationCompleteVM.onDone()` to gate auto-continuation on `MIGRATION_RESIDUAL_MIN_ZATOSHI` (the engine's real migratable minimum) instead of the smaller dust threshold, so it no longer disagrees with the home banner's residue/lock decision for the same balance.
- Fix Migration Complete's `duration` display to skip the pre-broadcast privacy floor (both timestamps are already-mined/public), matching the existing exception used for "sent X ago" labels.
- Fix `WalletHeaderIcons`' badge overlap (36dp → 45dp offset) to match Figma's `-3px` gap spec, corrected on all 5 screens that share the component.
- Update Ironwood announcement copy to match the current Figma design (old copy predated the migration feature's launch).
- Fix `WalletViewModel.shouldShowIronwoodAnnouncement` to gate on the dust threshold instead of a bare `> 0L`, so a dust-only residual (e.g. after wallet re-import resets local dismissal flags) no longer re-triggers the full-screen announcement ahead of the home banner's correct residue flow.

## Test plan
- [x] New/updated unit tests pass: `MigrationCompleteVMTest` (11), `GetHomeMessageUseCaseMigrationTest` (20), `WalletViewModelTest` (2, new)
- [x] `ktlint` / `detektAll` clean
- [x] Verified against Maven Central SDK build (local SDK checkout has unrelated in-progress voting work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)