### PR TITLE
ci: [diagnostic] capture FTL robo logcat for API-27 crash — DO NOT MERGE

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -550,3 +550,10 @@ jobs:
         run: |
           unzip ${BINARIES_ZIP_PATH}
           ./gradlew :app:runFlankSanityConfigRelease
+      - name: Upload robo test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: Robo release test results
+          path: |
+            app/build/fladle/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -385,6 +385,15 @@ fladle {
             )
 
             flankVersion.set(libs.versions.flank.get())
+
+            filesToDownload.set(
+                listOf(
+                    ".*/logcat$",
+                    ".*/logcat\\.txt$",
+                    ".*\\.xml$",
+                    ".*/bugreport.*"
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
## Why

\`test_robo_release\` has been red on every run since 2026-08-08 (first red: run [31229024068](https://github.com/zodl-inc/zodl-android/actions/runs/31229024068) on \`review/v3.9.0\`).

The failure is isolated to the **Pixel2.arm API-27** axis only — "0 test cases failed" combined with an outcome of failure indicates the app crashes during the Robo crawl itself; the API 33 axis passes cleanly.

The job currently uploads no artifacts, so the crash stack captured by Firebase Test Lab is unreachable (the FTL project is CI-credential-only).

## What this PR does

This PR only adds:
- a Flank \`filesToDownload\` override on the release sanity config to pull logcat/XML/bugreport files from GCS
- an always-run \`actions/upload-artifact\` step on \`test_robo_release\` so the downloaded logs become an Actions artifact

No app or test logic changes.

## Disposition

This is a temporary diagnostic branch. It will be closed once the crash stack has been captured and the root cause diagnosed — **not merged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)