### PR TITLE
Fix ScreenshotTest flake: budget Receive/Home waits for cold CI emulators

### DIFF
--- a/ui-screenshot-test/src/main/java/co/electroniccoin/zcash/ui/screenshot/ScreenshotTest.kt
+++ b/ui-screenshot-test/src/main/java/co/electroniccoin/zcash/ui/screenshot/ScreenshotTest.kt
@@ -383,21 +383,22 @@ class ScreenshotTest : UiTestPrerequisites() {
         // To ensure that the bottom tab is available, or wait until it is
         composeTestRule.waitUntilAtLeastOneExists(
             hasTestTag(HomeTags.SEND),
-            15.seconds.inWholeMilliseconds
+            DEFAULT_TIMEOUT_MILLISECONDS_LONG
         )
         accountScreenshots(tag, composeTestRule)
 
         composeTestRule.waitUntilAtLeastOneExists(
             hasTestTag(HomeTags.SEND),
-            15.seconds.inWholeMilliseconds
+            DEFAULT_TIMEOUT_MILLISECONDS_LONG
         )
         composeTestRule.onNode(hasTestTag(HomeTags.SEND)).performClick()
         sendZecScreenshots(resContext, tag, composeTestRule)
 
         composeTestRule.onNode(hasTestTag(ZashiTopAppBarTags.BACK)).performClick()
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntilAtLeastOneExists(
             hasTestTag(HomeTags.RECEIVE),
-            15.seconds.inWholeMilliseconds
+            DEFAULT_TIMEOUT_MILLISECONDS_LONG
         )
         composeTestRule.onNode(hasTestTag(HomeTags.RECEIVE)).performClick()
         receiveZecScreenshots(resContext, tag, composeTestRule)
@@ -498,7 +499,7 @@ private fun receiveZecScreenshots(
             text = resContext.getString(R.string.receive_title, CURRENCY_TICKER),
             ignoreCase = true
         ),
-        15.seconds.inWholeMilliseconds
+        DEFAULT_TIMEOUT_MILLISECONDS_LONG
     )
 
     composeTestRule
@@ -526,7 +527,7 @@ private fun sendZecScreenshots(
 
     composeTestRule.waitUntilAtLeastOneExists(
         hasText(resContext.getString(co.electriccoin.zcash.ui.design.R.string.send_review), ignoreCase = true),
-        15.seconds.inWholeMilliseconds
+        DEFAULT_TIMEOUT_MILLISECONDS_LONG
     )
 
     composeTestRule


### PR DESCRIPTION
## Background

Job `test_android_modules_emulator (app)` has been ~86% red since 2026-08-03, worsening when CI moved from emulator.wtf to GitHub-hosted software-GPU emulators. The failure is always one or two of the six `takeScreenshotsForNewWalletAndRestOfApp*` variants (the locale is incidental) with:

```
ComposeTimeoutException: ... contains 'Receive ZEC' ... still not satisfied after 15000 ms
```

## Root cause

The Home RECEIVE button click does not navigate directly. `HomeVM.onReceiveButtonClick` → `NavigateToReceiveUseCase` first blocks on `accountDataSource.requestNextShieldedAddress()` — a Rust address rotation served over an unbuffered request `SharedFlow` with an untimed `Channel.receive()` (`ui-lib/.../common/datasource/AccountDataSource.kt:196-215`) — which can far exceed 15s on a cold CI emulator.

The test file already uses a 100s constant (`DEFAULT_TIMEOUT_MILLISECONDS_LONG`) for exactly this class of synchronizer-dependent wait; this change extends that budget to the remaining under-budgeted 15s waits gating on the same kind of dependency. Precedent for this class of fix: commit 6d96db340 "Fix receiveZecScreenshots test".

## Change

In `ui-screenshot-test/src/main/java/co/electroniccoin/zcash/ui/screenshot/ScreenshotTest.kt`:

- Replaced `15.seconds.inWholeMilliseconds` with `DEFAULT_TIMEOUT_MILLISECONDS_LONG` (100_000L) at:
  - the two `HomeTags.SEND` waits
  - the `HomeTags.RECEIVE` wait
  - the Receive-title wait in `receiveZecScreenshots`
  - the `send_review` wait in `sendZecScreenshots`
- Added a `composeTestRule.waitForIdle()` after the back-click between the send and receive sections.

This is test-side hardening only. The underlying unbuffered request-flow design in `AccountDataSourceImpl.requestNextShieldedAddress` is a latent production hang (tap Receive before the address collector subscribes and navigation never fires) that deserves its own app-side fix.

## Follow-up

Open a ticket to fix the underlying latent hang on `main`: `AccountDataSourceImpl.requestNextShieldedAddress`'s unbuffered request `SharedFlow` + untimed `Channel.receive()` can leave a real Receive-button tap hanging indefinitely if the address collector hasn't subscribed yet, independent of this test-side timeout budget increase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
