### PR TITLE
Fix API 27 launch crash: guard isBackgroundRestricted read behind SDK check

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/IsBackgroundExecutionAvailableProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/IsBackgroundExecutionAvailableProvider.kt
@@ -55,7 +55,9 @@ class IsBackgroundExecutionAvailableProvider(
         val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
         return backgroundExecutionState(
             isIgnoringBatteryOptimizations = powerManager?.isIgnoringBatteryOptimizations(context.packageName) == true,
-            isBackgroundRestricted = activityManager?.isBackgroundRestricted == true,
+            isBackgroundRestricted =
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
+                    activityManager?.isBackgroundRestricted == true,
             sdkInt = Build.VERSION.SDK_INT,
         )
     }


### PR DESCRIPTION
## Summary
- Fixes a launch crash on every API 27 device (the app's minSdk) since the 3.9.0 cut.
- Guards the `ActivityManager.isBackgroundRestricted` read at the call site in `IsBackgroundExecutionAvailableProvider.state()` behind the same `Build.VERSION.SDK_INT >= Build.VERSION_CODES.P` check already documented (and enforced) inside the pure helper functions below it.

## Root cause
`ActivityManager.isBackgroundRestricted()` exists only from API 28 (P) onward. In `ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/IsBackgroundExecutionAvailableProvider.kt`, `state()` eagerly evaluated `activityManager?.isBackgroundRestricted == true` as an argument to `backgroundExecutionState(...)`. The pure helpers (`backgroundExecutionState`, `isBackgroundExecutionAvailable`) ARE correctly SDK-gated internally and their KDoc documents that intent, but argument evaluation at the call site happens *before* any gate runs — so on API 27 the property read itself throws `NoSuchMethodError`, regardless of what the callee does with the value.

The fix moves the SDK gate to the call site, short-circuiting the property read entirely below API 28:

```kotlin
isBackgroundRestricted =
    Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
        activityManager?.isBackgroundRestricted == true,
```

The pure helper functions are left untouched — their internal gate is now redundant-but-harmless defense in depth.

## Evidence
FTL logcat captured via the temporary diagnostic PR #2418:

```
java.lang.NoSuchMethodError: No virtual method isBackgroundRestricted()Z in class Landroid/app/ActivityManager; or its super classes
	at co.electriccoin.zcash.ui.common.provider.IsBackgroundExecutionAvailableProvider.state(Unknown Source:49)
	at co.electriccoin.zcash.ui.common.usecase.MigrationHomeMessageSourceImpl$observe$1$1.invokeSuspend(Unknown Source:407)
```

CI evidence: `test_robo_release` red on 22/22 runs since 2026-08-08, `Pixel2.arm-27` axis only — consistent with this being a first-home-render crash hitting every API 27 device.

## Test plan
- [x] `./gradlew ktlintFormat -PSDK_INCLUDED_BUILD_PATH=` — passes
- [x] `./gradlew detektAll -PSDK_INCLUDED_BUILD_PATH=` — passes
- [x] `./gradlew :ui-lib:testZcashmainnetStoreDebugUnitTest -PSDK_INCLUDED_BUILD_PATH=` — passes (existing `IsBackgroundExecutionAvailableProviderTest` suite green; no `lint-baseline*.xml` entries existed for this file/method, and Robolectric is not wired up in `ui-lib` unit tests, so no new test class was added per the plan — the call-site guard plus the existing pure-function coverage stand in for it)
- [ ] This PR's own CI run — the `test_robo_release` job's `Pixel2.arm-27` axis is the end-to-end verification; it should go green here after being red since 2026-08-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)