### PR TITLE
Fix Receive navigation hang: buffer address requests and bound the wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 ### Fixed:
 
 - Closing the error sheet during Keystone migration signing no longer discards already-signed rounds.
+- Tapping Receive no longer hangs indefinitely when a transient address-derivation error occurs; the request is retried and the wait is bounded with a fallback to the current address.
 
 ## [3.9.1 (2361)] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 ### Fixed:
 
 - Closing the error sheet during Keystone migration signing no longer discards already-signed rounds.
-- Tapping Receive no longer hangs indefinitely when a transient address-derivation error occurs; the request is retried and the wait is bounded with a fallback to the current address.
+- Tapping Receive no longer hangs indefinitely when a transient address-derivation error occurs; the app falls back to the account's current address instead.
 
 ## [3.9.1 (2361)] - 2026-08-08
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration.Companion.seconds
 
 interface AccountDataSource {
@@ -91,7 +92,7 @@ class AccountDataSourceImpl(
     private val log = loggableNot("AccountDataSource")
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    private val requestNextShieldedAddressChannel = MutableSharedFlow<AddressRequest>()
+    private val requestNextShieldedAddressChannel = MutableSharedFlow<AddressRequest>(replay = 1)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override val allAccounts: StateFlow<List<WalletAccount>?> =
@@ -204,8 +205,13 @@ class AccountDataSourceImpl(
                 val responseChannel = Channel<WalletAddress.Unified>(1)
                 requestNextShieldedAddressChannel.emit(AddressRequest(accountUuid, responseChannel))
                 try {
-                    result = responseChannel.receive()
-                    log("received address ${result.address} for $accountUuid")
+                    val address = withTimeoutOrNull(ADDRESS_REQUEST_TIMEOUT) { responseChannel.receive() }
+                    if (address == null) {
+                        log("timed out waiting for address for $accountUuid")
+                    } else {
+                        log("received address ${address.address} for $accountUuid")
+                    }
+                    result = address
                 } catch (e: Exception) {
                     log("failed to receive address for $accountUuid", e)
                 }
@@ -362,6 +368,15 @@ private data class AddressRequest(
 )
 
 private const val RETRY_DELAY = 3L
+
+/**
+ * Upper bound on how long [AccountDataSourceImpl.requestNextShieldedAddress] waits for
+ * [AccountDataSourceImpl.observeUnified]'s collector to deliver a rotated address. The collector
+ * can be unsubscribed during a [kotlinx.coroutines.flow.retryWhen] backoff, so an unbounded wait
+ * can hang indefinitely; on timeout the caller falls back to the account's current address.
+ */
+private val ADDRESS_REQUEST_TIMEOUT = 15.seconds
+
 private const val KEYSTONE_KEYSOURCE = "keystone"
 
 class AccountDeletionException(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -25,6 +25,7 @@ import co.electriccoin.zcash.ui.common.provider.SelectedAccountUUIDProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.design.util.combineToFlow
 import co.electriccoin.zcash.ui.util.loggableNot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -92,7 +93,7 @@ class AccountDataSourceImpl(
     private val log = loggableNot("AccountDataSource")
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    private val requestNextShieldedAddressChannel = MutableSharedFlow<AddressRequest>(replay = 1)
+    private val requestNextShieldedAddressChannel = MutableSharedFlow<AddressRequest>()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override val allAccounts: StateFlow<List<WalletAccount>?> =
@@ -250,6 +251,7 @@ class AccountDataSourceImpl(
                 }
             }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun observeUnified(synchronizer: Synchronizer, sdkAccount: Account): Flow<UnifiedInfo> {
         suspend fun rotateAddress(): WalletAddress.Unified {
             log("deriving unified address for ${sdkAccount.accountUuid}")
@@ -279,7 +281,15 @@ class AccountDataSourceImpl(
                     requestNextShieldedAddressChannel
                         .filter { it.accountUuid == sdkAccount.accountUuid }
                         .collect {
-                            val address = rotateAddress()
+                            val address =
+                                try {
+                                    rotateAddress()
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    it.responseChannel.close(e)
+                                    throw e
+                                }
                             send(address)
                             try {
                                 it.responseChannel.send(address)


### PR DESCRIPTION
## Summary

- Tapping the Home RECEIVE button runs `NavigateToReceiveUseCase`, which blocks on `AccountDataSourceImpl.requestNextShieldedAddress()` before navigating. Under a specific race, this call could hang forever, so Receive never opens.
- This PR makes a failed rotation fail fast into the existing current-address fallback and bounds the wait, so the call always completes and the app always navigates.

## Root cause

`AccountDataSource.kt` has two compounding issues:

1. The only collector of `requestNextShieldedAddressChannel` lives inside `observeUnified`'s `channelFlow`, wrapped in `retryWhen { ...; delay(...); true }`. When a rotation triggered by a received request throws (transient Rust/DB error — CI logcat shows `database is locked` during early sync), the exception kills the whole `channelFlow`, and the in-flight request's `responseChannel` dies with the old collector — consumed but never answered, even though the retried flow recovers a second later. Separately, a request emitted *during* a retry backoff window has no subscriber and is silently dropped.
2. `requestNextShieldedAddress()` waited on `responseChannel.receive()` with no timeout, inside `scope.launch { ... }.join()`. An orphaned or dropped request meant the wait never completes. A fallback already existed (`result ?: getSelectedAccount().unified.address`), but it was unreachable because nothing ever timed out.

## Evidence

CI job `test_android_modules_emulator (app)`, run [31677543163](https://github.com/zodl-inc/zodl-android/actions/runs/31677543163) on branch `fix/screenshot-test-receive-timeouts`: 3 of 12 `ScreenshotTest` runs hung on the Receive screen even with 100-second waits. Logcat from run [31675419175](https://github.com/zodl-inc/zodl-android/actions/runs/31675419175) shows the full sequence: request received → rotation throws `database is locked` → `retryWhen` restarts → rotation succeeds ~1 s later → the original request is never answered → 100 s timeout.

This is also a live user-facing bug, not just a test artifact: tap Receive during a transient address-derivation retry and the app never navigates.

## Fix

1. In `observeUnified`'s request collector, a rotation failure now closes the request's `responseChannel` with the cause before rethrowing. The requester unblocks immediately into the existing current-address fallback, while the rethrow preserves the `retryWhen` restart semantics for the address flow itself.
2. `requestNextShieldedAddress()` wraps `responseChannel.receive()` in `withTimeoutOrNull(ADDRESS_REQUEST_TIMEOUT)`, a new private `15.seconds` constant, as a backstop for the remaining narrow window (a request emitted while the collector is between retries is dropped with no subscriber). On timeout, `result` stays `null` and the fallback returns the account's current unified address — the user gets the Receive screen with the current (unrotated) address instead of an infinite hang. If a rotation completes later, `observeUnified`'s `addressFlow` still emits the rotated address into account state.

An earlier revision of this PR used `MutableSharedFlow(replay = 1)` to re-deliver orphaned requests. That was dropped: the replay cache is sticky, so every later `retryWhen` restart of an account's address flow would re-deliver the stale request and trigger a spurious address rotation (burning a diversifier index and spontaneously changing the displayed address). The fail-fast design has no re-delivery semantics at all.

This complements [PR #2419](https://github.com/zodl-inc/zodl-android/pull/2419) ("Fix ScreenshotTest flake: budget Receive/Home waits for cold CI emulators") by fixing the underlying production hang those tests were exposing, rather than just widening the test timeout.

## Test plan

- No dedicated `AccountDataSourceImpl` unit test file exists yet (only unrelated tests reference the interface as a mock). Per scope, no new test scaffolding was added from scratch.
- `./gradlew ktlintFormat` — passes
- `./gradlew detektAll` — passes
- `./gradlew :ui-lib:compileZcashmainnetStoreDebugKotlin` — passes
- The emulator job (`test_android_modules_emulator`) on this PR's own CI run is the end-to-end check: the previously hanging Receive `ScreenshotTest` runs should now complete without hitting their wait budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
