### PR TITLE
Bump SDK to 3.0.2-SNAPSHOT and shim the changed voting JNI signatures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -185,7 +185,7 @@ KTOR_VERSION=3.4.0
 # WARNING: Ensure a non-snapshot version is used before releasing to production
 ZCASH_BIP39_VERSION=1.0.9
 # WARNING: Ensure a non-snapshot version is used before releasing to production
-ZCASH_SDK_VERSION=3.0.1-SNAPSHOT
+ZCASH_SDK_VERSION=3.0.2-SNAPSHOT
 # Toolchain is the Java version used to build the application, which is separate from the
 # Java version used to run the application.
 JVM_TOOLCHAIN=17

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
@@ -773,7 +773,7 @@ class VotingCryptoClientImpl : VotingCryptoClient {
     ): VotingDelegationPirPrecomputeResult =
         withContext(Dispatchers.IO) {
             db(dbHandle)
-                .precomputeDelegationPir(roundId, bundleIndex, pirServerUrl, notesJson.toJniNoteInfos())
+                .precomputeDelegationPir(roundId, bundleIndex, pirServerUrl, 0, 0, 0, notesJson.toJniNoteInfos())
                 .toAppModel()
         }
 
@@ -796,6 +796,9 @@ class VotingCryptoClientImpl : VotingCryptoClient {
                     roundId,
                     bundleIndex,
                     pirServerUrl,
+                    0,
+                    0,
+                    0,
                     notesJson.toJniNoteInfos(),
                     fvkBytes,
                     hotkeySeed,


### PR DESCRIPTION
## Summary

Moves `maint/v3.9.x` to SDK **3.0.2-SNAPSHOT**, delivering:

- **MOB-1667** — spendable balance no longer pinned at zero after an Orchard→Ironwood migration (the v3.9.0 sync regression; SDK PR zcash/zcash-android-wallet-sdk#2169)
- **MOB-1584** — sent transactions visible in the Activity list within ~2s under degraded networks
- **MOB-1669** — Keystone migration batch-signing stall fix

SDK release: zcash/zcash-android-wallet-sdk#2172, tag `v3.0.2`, refreshed `3.0.2-SNAPSHOT` (all four modules republished consistently, `lastUpdated=20260813132838`).

SDK 3.0.2 also carries changed voting JNI signatures (SDK PR zcash/zcash-android-wallet-sdk#2157): `precomputeDelegationPir` and the seed-variant `buildAndProveDelegation` gained required `pirDepth`/`pirTier0Layers`/`pirTier1Layers` parameters. This PR shims the two SDK-facing call sites in `VotingCryptoClient.kt` with `0, 0, 0` — the `zcash_voting::config::PirLayout::UNKNOWN` sentinel. CHP voting is dead code on this line (`VOTING_ENABLED = false`), so no behavioral backport is included; the full MOB-1678 voting rework (#2406) stays main-only.

Refs: [MOB-1667](https://linear.app/zodl/issue/MOB-1667), [MOB-1620](https://linear.app/zodl/issue/MOB-1620)

## Test plan

- [x] `:app:assembleZcashmainnetStoreDebug` against the published 3.0.2-SNAPSHOT (Maven resolution verified, no included build) — BUILD SUCCESSFUL
- [x] `ktlint` / `detektAll` — clean
- [x] Locked-module `check` suites (`configuration-api-lib`, `crash-lib`, `preference-api-lib`, `spackle-lib`, `ui-design-lib`) — green, zero lockfile drift
- [x] `:ui-lib:testZcashmainnetStoreDebugUnitTest` — green, incl. `VotingProofPrecomputeRepositoryTest` (4/4) and `SubmitVotesUseCaseProgressTest` (8/8) against the shimmed signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._